### PR TITLE
fix(scripts): prepare_env.py 生成 preset 时读取 VCPKG_ROOT 环境变量

### DIFF
--- a/scripts/prepare_env.py
+++ b/scripts/prepare_env.py
@@ -47,7 +47,10 @@ wim_path = normpath(
         "include",
     )
 )
-boost_path = normpath(os.path.join(user_home, "scoop", "apps", "boost", "current"))
+vcpkg_root = normpath(
+    os.environ.get("VCPKG_ROOT")
+    or os.path.join(user_home, "scoop", "apps", "vcpkg", "current")
+).rstrip("/")
 
 #
 # project_root/.clangd
@@ -113,9 +116,9 @@ CMakePresets_file = os.path.join(
 CMakePresets_file_output_file = os.path.join(MetasequoiaImeTsf_root_path, "CMakePresets.json")
 with open(CMakePresets_file, "r", encoding="utf-8") as f:
     lines = f.readlines()
-lines[8] = f'        "VCPKG_ROOT": "{normpath(user_home)}/scoop/apps/vcpkg/current/"\n'
+lines[8] = f'        "VCPKG_ROOT": "{vcpkg_root}/"\n'
 lines[11] = (
-    f'        "CMAKE_TOOLCHAIN_FILE": "{normpath(user_home)}/scoop/apps/vcpkg/current/scripts/buildsystems/vcpkg.cmake",\n'
+    f'        "CMAKE_TOOLCHAIN_FILE": "{vcpkg_root}/scripts/buildsystems/vcpkg.cmake",\n'
 )
 with open(CMakePresets_file_output_file, "w", encoding="utf-8") as f:
     f.writelines(lines)


### PR DESCRIPTION
## Summary

- `scripts/prepare_env.py` 生成 `CMakePresets.json` 时，把 `VCPKG_ROOT` 和 `CMAKE_TOOLCHAIN_FILE` 无条件写成 `~/scoop/apps/vcpkg/current/...`。vcpkg 装在别处（scoop 非默认目录、或按官方文档 git clone + bootstrap）的人拿到的 preset 指向一个不存在的 toolchain 文件，`lcompile.ps1` 直接报 `Could not find toolchain file`。改成先读 `VCPKG_ROOT` 环境变量，读不到再退回原来的 scoop 默认路径；两处写入共用同一个变量。
- 顺带删掉 `boost_path`：它自定义后从未被引用，且 `vcpkg.json` / `CMakeLists.txt` / `src/` 里已经没有任何 Boost 依赖（`grep -rin boost` 在 `scripts/`、`src/`、`vcpkg.json`、`CMakeLists.txt` 下无命中）。
- 选了环境变量而不是探测 PATH 上的 `vcpkg.exe`：`VCPKG_ROOT` 是 vcpkg 自己文档里的标准约定，而 PATH 上的 `vcpkg.exe` 未必在 vcpkg root 里（scoop shim 就不在），从 exe 反推根目录不可靠。

另外提一件事，本 PR **没有**动它，留给你定：仓库里签入的 `CMakePresets.json` 现在还写着 `C:/Users/sonnycalcr/scoop/apps/vcpkg/current/...`。按 `AGENTS.md`「生成文件与配置真源」，这个文件是 `prepare_env.py` 的生成物，但 `.gitignore` 没有忽略它（`.clangd`、`CMakeLists.txt` 同理）。而且签入的这份有 `vcpkg` / `vcpkg-release` 两个 preset，模板 `scripts/config_files/CMakePresets.json` 只有一个 `vcpkg`，跑一次 `prepare_env.py` 就会把 `vcpkg-release` 冲掉；`lcompile.ps1` 用的 `for64` / `for32` 两者都没有。要不要把这三个生成物移出版本控制、或者反过来让模板与签入内容对齐，我不清楚你的意图，所以只在这里指出来。

## Verification

在 macOS 上跑 `python3 scripts/prepare_env.py`（Python 3.9.6），对比改动前后 × `VCPKG_ROOT` 设置与否，取生成的 `CMakePresets.json` 第 9、12 行。为了输出干净把 `HOME` 固定成 `/home/dev`：

```
[master / VCPKG_ROOT 未设置]
        "VCPKG_ROOT": "/home/dev/scoop/apps/vcpkg/current/"
        "CMAKE_TOOLCHAIN_FILE": "/home/dev/scoop/apps/vcpkg/current/scripts/buildsystems/vcpkg.cmake",
[master / VCPKG_ROOT=D:/dev/vcpkg]
        "VCPKG_ROOT": "/home/dev/scoop/apps/vcpkg/current/"
        "CMAKE_TOOLCHAIN_FILE": "/home/dev/scoop/apps/vcpkg/current/scripts/buildsystems/vcpkg.cmake"
[本分支 / VCPKG_ROOT 未设置]
        "VCPKG_ROOT": "/home/dev/scoop/apps/vcpkg/current/"
        "CMAKE_TOOLCHAIN_FILE": "/home/dev/scoop/apps/vcpkg/current/scripts/buildsystems/vcpkg.cmake",
[本分支 / VCPKG_ROOT=D:/dev/vcpkg]
        "VCPKG_ROOT": "D:/dev/vcpkg/"
        "CMAKE_TOOLCHAIN_FILE": "D:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake",
```

反斜杠加尾分隔符的 Windows 写法也过了（`VCPKG_ROOT=D:\dev\vcpkg\`，`normpath` + `rstrip("/")`）：

```
        "VCPKG_ROOT": "D:/dev/vcpkg/"
        "CMAKE_TOOLCHAIN_FILE": "D:/dev/vcpkg/scripts/buildsystems/vcpkg.cmake",
```

没测的：未在 Windows 上跑过 `prepare_env.py`，也没有用生成的 preset 跑 `cmake --preset` / `lcompile.ps1` 实际配置或构建过（我在 macOS 上，无 VS/vcpkg 环境）。你那边值得回归的是：设好 `VCPKG_ROOT` 指向一个非 scoop 的 vcpkg（例如 `D:\vcpkg`），跑 `python .\scripts\prepare_env.py`，确认根目录 `CMakePresets.json` 里两行都指向该目录，然后 `.\scripts\lcompile.ps1 64` 能配置通过。

## Refs

Refs #6 #2
