### PR TITLE
fix(tsf): pass application modifier shortcuts through in Chinese mode

### DIFF
--- a/src/Key/KeyEventSink.cpp
+++ b/src/Key/KeyEventSink.cpp
@@ -711,6 +711,15 @@ BOOL CMetasequoiaIME::_IsKeyEaten(        //
             return TRUE;
         }
 
+        // Other Ctrl/Alt/Windows combinations belong to the application.
+        // IME-owned shortcuts are handled before this normal key classifier.
+        if ((shortcutModifiers & 0b00000110u) != 0 ||
+            (GetAsyncKeyState(VK_LWIN) & 0x8000) != 0 ||
+            (GetAsyncKeyState(VK_RWIN) & 0x8000) != 0)
+        {
+            return isTouchKeyboardSpecialKeys;
+        }
+
         const bool isComposing = freshCompositionState ? false : _IsComposing() != FALSE;
         const CANDIDATE_MODE candidateMode =
             freshCompositionState ? CANDIDATE_NONE : _candidateMode;


### PR DESCRIPTION
Fixes #69

## Root cause
The deferred-key classifier already leaves Ctrl/Alt/Windows chords to the host, but the normal `_IsKeyEaten` path did not apply the same rule. In Chinese mode, keys such as `V` in `Ctrl+Shift+V` could therefore be classified as IME input and consumed before the application saw the shortcut.

## Fix
Pass non-IME Ctrl/Alt/Windows combinations back to the application before normal composition-key classification. IME-owned shortcuts remain handled first, including `Ctrl+Shift+E`, `Ctrl+Alt+Space`, `Ctrl+Shift+Space`, and `Ctrl+.`.

## Validation
- [x] x64 Release build with Visual Studio 2022
- [x] `git diff --check`
- [ ] Manual verification in Edge and an Electron host