### PR TITLE
ci: build the TSF DLL on Windows for every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Windows ${{ matrix.name }}
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x64
+            architecture: x64
+            triplet: x64-windows-static
+          - name: Win32
+            architecture: Win32
+            triplet: x86-windows-static
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        shell: pwsh
+        run: vcpkg install --triplet ${{ matrix.triplet }}
+      - name: Configure
+        shell: pwsh
+        run: >
+          cmake -S . -B build -A ${{ matrix.architecture }}
+          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+          -DVCPKG_TARGET_TRIPLET=${{ matrix.triplet }}
+      - name: Build
+        shell: pwsh
+        run: cmake --build build --config Release --parallel


### PR DESCRIPTION
主仓目前没有任何 CI。1200+ star、55 个 fork、25 个 open PR 的情况下，一个 PR 能不能编译只能靠人工在本机验证；而本机验证本身又依赖 `CMakePresets.json` 里写死的个人 vcpkg 路径（见 #6），外部贡献者连复现构建都要先绕一道。

本 PR 加一个最小编译门禁。

## 为什么不用现有 preset

`CMakePresets.json` / `CMakeUserPresets.json` 里的 `for64` / `for64-release` 等 preset 指定了 `Visual Studio 18 2026` 生成器，并把 `VCPKG_ROOT` 和 `CMAKE_TOOLCHAIN_FILE` 写死成 `C:/Users/sonnycalcr/scoop/apps/vcpkg/current/`。这两项在 GitHub runner 上都不成立，所以 workflow 直接指定 toolchain 和 triplet，不经过 preset。

这也意味着本 PR **没有**顺手去修 #6（`prepare_env.py` 写死 vcpkg 路径）——那条已经标成 `good first issue`，留给新贡献者。

## 构建矩阵

按项目实际发布的两个架构各构建一次，均为 Release，`fail-fast: false` 以便一次看到两边的结果：

| 架构 | triplet |
| --- | --- |
| x64 | `x64-windows-static` |
| Win32 | `x86-windows-static` |

triplet 取自 `CMakeUserPresets.json` 中对应 preset 的 `VCPKG_TARGET_TRIPLET`，不是我另选的。依赖只有 `fmt` 和 `utfcpp`，用 runner 预装的 vcpkg 安装。

## 与既有约定的一致性

- `actions/checkout` 用与 `MSIME-Engine/.github/workflows/ci.yml` 相同的 pinned SHA，不用浮动 tag。
- 同样通过 `VCPKG_INSTALLATION_ROOT` 使用 runner 预装的 vcpkg，与 Engine 的 Windows job 一致。
- `push` 只在 `master` 触发，`pull_request` 全量触发，避免特性分支与 PR 重复跑（MSIME-Apple #211 处理过同一问题）。

## 验证

本 PR 自身的 CI 运行结果即为验证——这是 macOS 上无法本地复现的部分，只能由 runner 给出结论。若某个架构失败，我会在本 PR 内继续修到两个架构都通过再请求合并。

没有测试目标，因此暂不跑 `ctest`；后续如果补了测试，在此 workflow 追加一步即可。
