### PR TITLE
chore: follow the default branch rename to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
组织内 17 个仓库的默认分支已从 `master` 统一改名为 `main`，本 PR 跟进本仓库里因此失配的引用。

GitHub 在改名时会自动重定向网页链接并把在途 PR 指向新的默认分支，但不会更新仓库内容里的分支引用，这些需要手工跟进。

## 验证

改后仓库内已无 `branches: [master]` 或 `branch = master`。合并后 push 到 `main` 会正常触发流水线；submodule 的 `--remote` 更新也会指向存在的分支。
