### PR TITLE
fix(ci): verify the version resource at the source, not on the built DLL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,15 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      # Verifying the built DLL instead would not work: the VERSIONINFO block in
+      # src/IME/MetasequoiaIME.rc is named IDR_VERSION2, which is not defined anywhere, rather
+      # than the VS_VERSION_INFO the Windows version API looks for. GetFileVersionInfo therefore
+      # finds nothing and the DLL reports an empty FileVersion, which has always been the case.
       - name: Stamp the version resource
         shell: pwsh
-        run: python scripts/apply_version.py
+        run: |
+          python scripts/apply_version.py
+          python scripts/apply_version.py --check
 
       - name: Install dependencies
         shell: pwsh
@@ -128,17 +134,12 @@ jobs:
         shell: pwsh
         run: cmake --build ${{ matrix.build_dir }} --config Release --parallel
 
-      - name: Verify the stamped version
+      - name: Check the DLL the installer expects
         shell: pwsh
-        env:
-          EXPECTED: ${{ needs.prepare.outputs.version }}
         run: |
           $dll = "${{ matrix.build_dir }}/Release/MetasequoiaImeTsf.dll"
-          $actual = (Get-Item $dll).VersionInfo.FileVersion
-          Write-Host "$dll reports $actual"
-          if ($actual -notlike "$env:EXPECTED*") {
-            throw "Expected the DLL to report $env:EXPECTED, got $actual"
-          }
+          if (-not (Test-Path $dll)) { throw "The build did not produce $dll" }
+          Write-Host "$dll is $((Get-Item $dll).Length) bytes"
 
       - name: Upload the DLL
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Fixes the failure in run 33952585441, where both TSF jobs died at `Verify the stamped version`.

## What happened

Stamping worked. The log has:

```
Stamped 0.0.10.0 into src\IME\MetasequoiaIME.rc (4 fields).
```

Reading it back from the built DLL did not:

```
build64-release/Release/MetasequoiaImeTsf.dll reports
Expected the DLL to report 0.0.10, got
```

## Why

The `VERSIONINFO` block in `src/IME/MetasequoiaIME.rc:37` is named `IDR_VERSION2`, and that identifier is not defined in `resource.h` or anywhere else in the tree. The Windows version API only reads the `VERSIONINFO` resource named `VS_VERSION_INFO`, so `GetFileVersionInfo` finds nothing and `FileVersion` comes back empty.

This is not new and the build is not broken: the DLL has never exposed a version Windows can read, and Explorer's Details tab shows nothing for it either. The check I added asserted something the binary could never satisfy.

## Fix

Stamping now runs `apply_version.py` and then `apply_version.py --check`, which verifies the resource really matches `version.txt`. That is the part worth asserting and it does not depend on how the resource is named. The step on the built artifact is reduced to confirming that the DLL the installer collects exists.

Verified locally: `--check` alone exits 1 against the committed resource, because the release PR bumped `version.txt` to `0.0.10` while the resource still says `0.0.9`. Stamp followed by check exits 0, which is the order the workflow uses.

## Left alone

Making the version readable means renaming the resource to `VS_VERSION_INFO`. That changes what the shipped DLL exposes to Windows and to anything that inspects it, so it does not belong in a CI fix. Worth deciding separately: right now the released TSF DLL reports no version at all.
