### PR TITLE
chore: track dependency updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
本仓库此前没有 dependabot 配置，GitHub Actions 的 action 版本和子模块都不会收到更新提醒。组织内目前只有 MSIME-Apple 和 MSIME-Linux 配了。

配置沿用 MSIME-Apple 已有的写法：monthly、`chore(deps)` 前缀、actions 分组、单仓最多 5 个 PR，保持组织内一致。

vcpkg 不在 dependabot 支持的生态里，`vcpkg.json` 的依赖仍需手工跟进。
