### PR TITLE
fix(ci): build the Server in build/, the only directory name it links in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,30 +173,35 @@ jobs:
           Pop-Location
           "BOOST_ROOT=$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md" >> $env:GITHUB_ENV
 
+      # The binary directory has to be named build: MSIME-Server's CMakeLists.txt hardcodes
+      # ${CMAKE_SOURCE_DIR}/build/vcpkg_installed for the WebView2 loader and its include
+      # paths, so any other name fails to link MetasequoiaImeSettings. The packaging job
+      # downloads this artifact into build-release/bin/Release, which is where
+      # Prepare-PackageFiles.ps1 reads it from, so the name used here does not matter.
       - name: Configure
         shell: pwsh
         run: >
-          cmake -S . -B build-release -A x64
+          cmake -S . -B build -A x64
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
           -DVCPKG_TARGET_TRIPLET=x64-windows
 
       - name: Build
         shell: pwsh
-        run: cmake --build build-release --config Release --parallel
+        run: cmake --build build --config Release --parallel
 
       - name: Check the binaries the installer requires
         shell: pwsh
         run: |
           $required = @('MetasequoiaImeServer.exe', 'MetasequoiaImeSettings.exe', 'MetasequoiaImeWatchdog.exe', 'MetasequoiaImeDictionaryReplay.exe')
-          $missing = $required | Where-Object { -not (Test-Path "build-release/bin/Release/$_") }
+          $missing = $required | Where-Object { -not (Test-Path "build/bin/Release/$_") }
           if ($missing) { throw "Missing from the Server build: $($missing -join ', ')" }
-          Get-ChildItem build-release/bin/Release -File | Select-Object Name, Length | Format-Table
+          Get-ChildItem build/bin/Release -File | Select-Object Name, Length | Format-Table
 
       - name: Upload the Server build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: server
-          path: build-release/bin/Release
+          path: build/bin/Release
           if-no-files-found: error
 
   ui:


### PR DESCRIPTION
Fixes the Server job in run 33953180360. Everything else in that run passed: both TSF builds and the settings page are green now that #113 landed.

## What happened

```
LINK : fatal error LNK1181: cannot open input file
'D:\a\MSIME-Windows\MSIME-Windows\build\vcpkg_installed\x64-windows\lib\WebView2Loader.dll.lib'
```

Note the path says `build/` while the job configured into `build-release/`.

## Why

`MSIME-Server`'s `CMakeLists.txt` hardcodes `${CMAKE_SOURCE_DIR}/build/vcpkg_installed` in three places:

- `:257` an include path
- `:369` `WEBVIEW2_VCPKG_ROOT`, which feeds the loader import library and the runtime DLL copy
- `:412` another include path

so the binary directory has to be literally named `build`. Line 322 does use `${CMAKE_BINARY_DIR}` for sqlite3, which is what the others should have done. `MSIME-Server`'s own CI passes `-B build` and never hits it.

## Fix

Build in `build/`, matching that green CI exactly. The directory name never needed to match the installer layout: the packaging job downloads the artifact into `MetasequoiaImeServer/build-release/bin/Release`, which is where `Prepare-PackageFiles.ps1` reads it from, so nothing about the staged layout changes.

## Worth fixing upstream, separately

`MSIME-Server` should use `${CMAKE_BINARY_DIR}` in those three places like it already does on line 322. Right now any binary directory other than `build` fails to link, which also breaks the repo's own `CMakePresets.json`, whose `vcpkg-release` preset sets `binaryDir` to `build-release`.
