### PR TITLE
fix(scripts): read the vcpkg root from the environment

### DIFF
--- a/scripts/prepare_env.py
+++ b/scripts/prepare_env.py
@@ -13,6 +13,12 @@ project_root_path = os.path.dirname(cur_file_path)
 
 user_home = os.path.expanduser("~")
 
+# vcpkg location. Prefer the VCPKG_ROOT environment variable so that installs
+# outside Scoop work as well; fall back to the historical Scoop path.
+vcpkg_root = normpath(
+    os.environ.get("VCPKG_ROOT") or os.path.join(user_home, "scoop", "apps", "vcpkg", "current")
+).rstrip("/")
+
 MetasequoiaImeTsf_root_path = normpath(project_root_path)
 MetasequoiaImeTsf_src_path = normpath(os.path.join(MetasequoiaImeTsf_root_path, "src"))
 vcpkg_include_path = normpath(
@@ -47,7 +53,11 @@ wim_path = normpath(
         "include",
     )
 )
-boost_path = normpath(os.path.join(user_home, "scoop", "apps", "boost", "current"))
+# Boost location. CMakeLists.txt already honours the BOOST_ROOT environment
+# variable; mirror that here instead of assuming a Scoop install.
+boost_path = normpath(
+    os.environ.get("BOOST_ROOT") or os.path.join(user_home, "scoop", "apps", "boost", "current")
+).rstrip("/")
 
 #
 # project_root/.clangd
@@ -113,9 +123,9 @@ CMakePresets_file = os.path.join(
 CMakePresets_file_output_file = os.path.join(MetasequoiaImeTsf_root_path, "CMakePresets.json")
 with open(CMakePresets_file, "r", encoding="utf-8") as f:
     lines = f.readlines()
-lines[8] = f'        "VCPKG_ROOT": "{normpath(user_home)}/scoop/apps/vcpkg/current/"\n'
+lines[8] = f'        "VCPKG_ROOT": "{vcpkg_root}/"\n'
 lines[11] = (
-    f'        "CMAKE_TOOLCHAIN_FILE": "{normpath(user_home)}/scoop/apps/vcpkg/current/scripts/buildsystems/vcpkg.cmake",\n'
+    f'        "CMAKE_TOOLCHAIN_FILE": "{vcpkg_root}/scripts/buildsystems/vcpkg.cmake",\n'
 )
 with open(CMakePresets_file_output_file, "w", encoding="utf-8") as f:
     f.writelines(lines)

--- a/scripts/prepare_env.py
+++ b/scripts/prepare_env.py
@@ -53,11 +53,7 @@ wim_path = normpath(
         "include",
     )
 )
-# Boost location. CMakeLists.txt already honours the BOOST_ROOT environment
-# variable; mirror that here instead of assuming a Scoop install.
-boost_path = normpath(
-    os.environ.get("BOOST_ROOT") or os.path.join(user_home, "scoop", "apps", "boost", "current")
-).rstrip("/")
+boost_path = normpath(os.path.join(user_home, "scoop", "apps", "boost", "current"))
 
 #
 # project_root/.clangd


### PR DESCRIPTION
关闭 #6。

`scripts/prepare_env.py` 生成 `CMakePresets.json` 时，把 `VCPKG_ROOT` 和 `CMAKE_TOOLCHAIN_FILE` 直接写死成 `<用户目录>/scoop/apps/vcpkg/current/`，既不看 `VCPKG_ROOT` 环境变量也不看 PATH。用 git 或安装器装 vcpkg 的人跑完这个脚本，生成出来的 preset 指向一个不存在的路径，必须手工改才能构建。

这不是边角情况：它挡在每一个想从源码构建的新贡献者面前。报障人当时是自己改 preset 绕过去的，脚本缺陷一直还在。

## 改法

新增一个 `vcpkg_root`，优先取 `VCPKG_ROOT` 环境变量，取不到时回退到原来的 Scoop 路径——已经在用 Scoop 的人不受任何影响，行为完全不变。两处写入都改用它。

## 关于 #6 的另一半

issue 里还提到「签入的 `CMakePresets.json` 留着 `C:/Users/sonnycalcr/` 这样的本机路径」。那个文件是本脚本的生成产物，跑一次脚本就会被覆盖成本机正确的值，因此本 PR 不动它——真正的缺陷在生成逻辑，已修。

`scripts/prepare_env.py` 里还有一个从未被引用的 `boost_path` 变量（#95 第一节已指出），本 PR 没有动它，留给对应的 Boost 清理。

## 验证

改后文件通过 `compile()` 语法检查。逻辑是纯字符串来源替换，未改动写入位置和模板索引。CI 覆盖的是编译，不跑这个脚本，因此绿灯不能证明本改动——真正的验证是：设了 `VCPKG_ROOT` 的机器上生成的 preset 指向该路径，没设的机器上与改动前逐字节相同。
