### PR TITLE
ci: merge the release pull request automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
+    # A release-please pull request only rewrites these three files. Skipping it keeps every
+    # release from parking an unapprovable run in the checks list: runs whose triggering actor is
+    # github-actions[bot] land in action_required, because GITHUB_TOKEN is not allowed to start
+    # workflows on its own. Nothing here builds from these files anyway.
+    paths-ignore:
+      - version.txt
+      - CHANGELOG.md
+      - .release-please-manifest.json
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,23 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Merging is what carries the release forward: the resulting push runs this workflow again,
+      # release-please turns the release commit into the draft release, and the build jobs take
+      # over. Left open the pull request would stall there, because CI cannot run on it either:
+      # GITHUB_TOKEN is not allowed to start workflows, so anything it triggers waits for a human.
+      # The pull request only rewrites version.txt, CHANGELOG.md and the manifest.
+      - name: Merge the release pull request
+        if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
+        run: |
+          set -euo pipefail
+          number=$(jq -er .number <<< "$RELEASE_PR")
+          echo "Merging release pull request #$number"
+          gh pr merge "$number" --repo "$GH_REPO" --merge
+
       - name: Validate requested draft release
         if: ${{ github.event_name == 'workflow_dispatch' }}
         id: requested_release


### PR DESCRIPTION
Makes the release path hands-off. Follow-up to #113 and #116.

## Why the approval prompt appears

Comparing the three CI runs on the release-please branch:

```
33953787118  sha=8041511  triggering_actor=github-actions[bot]  action_required   <- PR #114
33953155207  sha=0d9de4d  triggering_actor=houko                success           <- PR #112
33952554730  sha=545deb2  triggering_actor=houko                success           <- PR #112
```

The green ones were triggered by a person pushing or merging. The gated one was triggered end to end by the bot. This is not the fork approval policy: the release pull request is not from a fork. It is GitHub's rule that `GITHUB_TOKEN` may not start workflows, which exists to stop a workflow from triggering itself forever. release-please uses `secrets.GITHUB_TOKEN`, so anything it opens waits for a human.

## Change

The prepare job merges the release pull request right after creating it. That push runs this workflow again, release-please turns the release commit into the draft release, and the build jobs take over. `MSIME-Apple` does the same thing through its `merge-release-pr.sh` step.

Merging without CI is safe here: the pull request only rewrites `version.txt`, `CHANGELOG.md` and `.release-please-manifest.json`. For the same reason the CI workflow now ignores those three paths on pull requests, so a release no longer parks an unapprovable run in the checks list.

`main` is unprotected, so `gh pr merge` with `GITHUB_TOKEN` is enough; no PAT or GitHub App to maintain.

## What this means day to day

Every conventional commit that lands on `main` now cuts and publishes a release with no manual step. That is how `MSIME-Apple` already behaves. If that turns out to be too eager, the knob is `release-please-config.json`, not this workflow.

## Alternative considered

Giving release-please a PAT would let its pull requests run CI normally, at the cost of a token to rotate and keep scoped. Not worth it for three generated files.
