### PR TITLE
fix(ci): supply the Inno Setup language file, and move release shell into scripts/ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,6 +409,34 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
           Remove-Item $pfx -Force
 
+      # msime_setup.iss declares a chinesesimplified language pointing at
+      # compiler:Languages\ChineseSimplified.isl, and the runner's Inno Setup does not ship that
+      # file, so ISCC aborts on the [Languages] section. Pinned by commit and checksum rather
+      # than tracking a branch, so the installer text cannot change under a rebuild.
+      - name: Install the Chinese language file for Inno Setup
+        shell: pwsh
+        env:
+          ISL_URL: https://raw.githubusercontent.com/jrsoftware/issrc/1ae7bf81dc0d2013235dfe4bb0b6f4e4a0b6b25c/Files/Languages/ChineseSimplified.isl
+          ISL_SHA256: e0b0b350e2245f3c5e65586dfe43d574f6e7f06f2261149aba284954b3fc9a8d
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $iscc = Get-Command 'ISCC.exe' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+          $root = if ($iscc) { Split-Path $iscc.Source -Parent } else { 'C:\Program Files (x86)\Inno Setup 6' }
+          $languages = Join-Path $root 'Languages'
+          $target = Join-Path $languages 'ChineseSimplified.isl'
+          if (Test-Path $target) {
+            Write-Host "Already present: $target"
+            exit 0
+          }
+          New-Item -ItemType Directory -Path $languages -Force | Out-Null
+          Invoke-WebRequest -Uri $env:ISL_URL -OutFile $target -MaximumRetryCount 3 -RetryIntervalSec 5
+          $actual = (Get-FileHash $target -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:ISL_SHA256) {
+            Remove-Item $target -Force
+            throw "ChineseSimplified.isl checksum mismatch: expected $env:ISL_SHA256, got $actual"
+          }
+          Write-Host "Installed $target ($((Get-Item $target).Length) bytes)"
+
       - name: Compile the installer
         shell: pwsh
         working-directory: ${{ env.STAGING_ROOT }}/msime-installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ env:
   # The installer scripts address sibling checkouts by their historical directory names.
   # Staging under these names is what lets msime-installer run unmodified in CI.
   STAGING_ROOT: src
+  # Where the packaging job finds this repository's scripts, since it checks out several.
+  TSF_ROOT: src/MetasequoiaImeTsf
 
 jobs:
   prepare:
@@ -42,6 +44,11 @@ jobs:
       target_sha: ${{ github.event_name == 'workflow_dispatch' && steps.requested_release.outputs.target_sha || steps.release.outputs.sha }}
       dictionary_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.dictionary_tag || 'latest' }}
     steps:
+      - name: Check out release automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
       - name: Prepare release
         if: ${{ github.event_name == 'push' }}
         id: release
@@ -49,22 +56,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Merging is what carries the release forward: the resulting push runs this workflow again,
-      # release-please turns the release commit into the draft release, and the build jobs take
-      # over. Left open the pull request would stall there, because CI cannot run on it either:
-      # GITHUB_TOKEN is not allowed to start workflows, so anything it triggers waits for a human.
-      # The pull request only rewrites version.txt, CHANGELOG.md and the manifest.
       - name: Merge the release pull request
         if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RELEASE_PR: ${{ steps.release.outputs.pr }}
-        run: |
-          set -euo pipefail
-          number=$(jq -er .number <<< "$RELEASE_PR")
-          echo "Merging release pull request #$number"
-          gh pr merge "$number" --repo "$GH_REPO" --merge
+        run: bash scripts/ci/merge-release-pr.sh
 
       - name: Validate requested draft release
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -73,29 +71,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag must use the vMAJOR.MINOR.PATCH format, got '$TAG_NAME'." >&2
-            exit 1
-          fi
-          release_json=$(gh release view "$TAG_NAME" --json isDraft,targetCommitish)
-          if [[ "$(jq -er .isDraft <<< "$release_json")" != true ]]; then
-            echo "Release $TAG_NAME is not an unpublished draft." >&2
-            exit 1
-          fi
-          target_sha=$(jq -er .targetCommitish <<< "$release_json")
-          if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Draft release target must be an immutable full commit SHA, got '$target_sha'." >&2
-            exit 1
-          fi
-          version=$(gh api "repos/$GH_REPO/contents/version.txt?ref=$target_sha" --jq .content | base64 --decode | tr -d '[:space:]')
-          if [[ "$TAG_NAME" != "v$version" ]]; then
-            echo "Release $TAG_NAME does not match version.txt ($version)." >&2
-            exit 1
-          fi
-          printf 'target_sha=%s\n' "$target_sha" >> "$GITHUB_OUTPUT"
-          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+        run: bash scripts/ci/validate-draft-release.sh
 
   tsf:
     name: Build TSF ${{ matrix.name }}
@@ -123,10 +99,6 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      # Verifying the built DLL instead would not work: the VERSIONINFO block in
-      # src/IME/MetasequoiaIME.rc is named IDR_VERSION2, which is not defined anywhere, rather
-      # than the VS_VERSION_INFO the Windows version API looks for. GetFileVersionInfo therefore
-      # finds nothing and the DLL reports an empty FileVersion, which has always been the case.
       - name: Stamp the version resource
         shell: pwsh
         run: |
@@ -153,10 +125,7 @@ jobs:
 
       - name: Check the DLL the installer expects
         shell: pwsh
-        run: |
-          $dll = "${{ matrix.build_dir }}/Release/MetasequoiaImeTsf.dll"
-          if (-not (Test-Path $dll)) { throw "The build did not produce $dll" }
-          Write-Host "$dll is $((Get-Item $dll).Length) bytes"
+        run: ./scripts/ci/check-tsf-dll.ps1 -BuildDir '${{ matrix.build_dir }}'
 
       - name: Upload the DLL
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -179,22 +148,24 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      # Kept in step with metasequoiaime/MSIME-Server's own CI: Boost is linked statically but is
-      # not declared in vcpkg.json, and the triplet has to be static-md so Boost does not switch
-      # to the static CRT the rest of the project does not use.
+      # After the checkout above, which cleans the workspace root: a checkout into a subdirectory
+      # does not touch its parent, so the order matters.
+      - name: Check out release automation
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          path: automation
+          sparse-checkout: scripts/ci
+          persist-credentials: false
+
       - name: Install Boost
         shell: pwsh
-        run: |
-          Push-Location $env:VCPKG_INSTALLATION_ROOT
-          ./vcpkg install boost-locale:x64-windows-static-md boost-json:x64-windows-static-md
-          Pop-Location
-          "BOOST_ROOT=$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md" >> $env:GITHUB_ENV
+        run: ./automation/scripts/ci/install-boost.ps1
 
       # The binary directory has to be named build: MSIME-Server's CMakeLists.txt hardcodes
-      # ${CMAKE_SOURCE_DIR}/build/vcpkg_installed for the WebView2 loader and its include
-      # paths, so any other name fails to link MetasequoiaImeSettings. The packaging job
-      # downloads this artifact into build-release/bin/Release, which is where
-      # Prepare-PackageFiles.ps1 reads it from, so the name used here does not matter.
+      # ${CMAKE_SOURCE_DIR}/build/vcpkg_installed for the WebView2 loader and its include paths,
+      # so any other name fails to link MetasequoiaImeSettings. The packaging job downloads this
+      # artifact into build-release/bin/Release, which is where Prepare-PackageFiles.ps1 reads it
+      # from, so the name used here does not matter.
       - name: Configure
         shell: pwsh
         run: >
@@ -208,11 +179,7 @@ jobs:
 
       - name: Check the binaries the installer requires
         shell: pwsh
-        run: |
-          $required = @('MetasequoiaImeServer.exe', 'MetasequoiaImeSettings.exe', 'MetasequoiaImeWatchdog.exe', 'MetasequoiaImeDictionaryReplay.exe')
-          $missing = $required | Where-Object { -not (Test-Path "build/bin/Release/$_") }
-          if ($missing) { throw "Missing from the Server build: $($missing -join ', ')" }
-          Get-ChildItem build/bin/Release -File | Select-Object Name, Length | Format-Table
+        run: ./automation/scripts/ci/check-server-binaries.ps1
 
       - name: Upload the Server build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -270,23 +237,22 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: write
+    env:
+      # jrsoftware/issrc pinned by commit, with the checksum of the file at that commit.
+      ISL_URL: https://raw.githubusercontent.com/jrsoftware/issrc/1ae7bf81dc0d2013235dfe4bb0b6f4e4a0b6b25c/Files/Languages/ChineseSimplified.isl
+      ISL_SHA256: e0b0b350e2245f3c5e65586dfe43d574f6e7f06f2261149aba284954b3fc9a8d
     steps:
       - name: Check out MSIME-Windows at the release commit
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ needs.prepare.outputs.target_sha }}
-          path: ${{ env.STAGING_ROOT }}/MetasequoiaImeTsf
+          path: ${{ env.TSF_ROOT }}
           persist-credentials: false
 
       - name: Verify the release commit is on main
         shell: bash
-        working-directory: ${{ env.STAGING_ROOT }}/MetasequoiaImeTsf
-        run: |
-          git fetch --no-tags --depth 50 origin main
-          if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
-            echo "The release commit is not in main's history." >&2
-            exit 1
-          fi
+        working-directory: ${{ env.TSF_ROOT }}
+        run: bash scripts/ci/verify-commit-on-main.sh
 
       - name: Check out the installer
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -313,13 +279,13 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: tsf-x64
-          path: ${{ env.STAGING_ROOT }}/MetasequoiaImeTsf/build64-release/Release
+          path: ${{ env.TSF_ROOT }}/build64-release/Release
 
       - name: Download the 32-bit TSF DLL
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: tsf-Win32
-          path: ${{ env.STAGING_ROOT }}/MetasequoiaImeTsf/build32-release/Release
+          path: ${{ env.TSF_ROOT }}/build32-release/Release
 
       - name: Download the Server build
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -338,27 +304,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DICTIONARY_TAG: ${{ needs.prepare.outputs.dictionary_tag }}
-        run: |
-          set -euo pipefail
-          target="$STAGING_ROOT/MetasequoiaImeDict/out"
-          mkdir -p "$target"
-          if [[ "$DICTIONARY_TAG" == "latest" ]]; then
-            DICTIONARY_TAG=$(gh release list --repo metasequoiaime/MSIME-Dict --limit 30 --json tagName --jq '[.[] | select(.tagName | startswith("dict-"))] | first | .tagName // ""')
-          fi
-          if [[ -z "$DICTIONARY_TAG" ]]; then
-            echo "No dict-* release found in metasequoiaime/MSIME-Dict. Run its Build dictionaries workflow with publish enabled first." >&2
-            exit 1
-          fi
-          echo "Using dictionary release $DICTIONARY_TAG"
-          gh release download "$DICTIONARY_TAG" --repo metasequoiaime/MSIME-Dict --dir "$target" --clobber
-          (cd "$target" && sha256sum --check SHA256SUMS.txt)
-          # Prepare-PackageFiles.ps1 reads the Mozc notice from the path the local build leaves it
-          # at and copies it into the installer as MOZC_DICTIONARY_LICENSE.txt. The IPAdic / ICOT /
-          # Okinawa attribution has to ship with dict_japanese.dat, so put it where it is expected.
-          notice_dir="$STAGING_ROOT/MetasequoiaImeDict/source/mozc_dictionary_oss"
-          mkdir -p "$notice_dir"
-          cp "$target/mozc_dictionary_oss_README.txt" "$notice_dir/README.txt"
-          echo "DICTIONARY_TAG=$DICTIONARY_TAG" >> "$GITHUB_ENV"
+        run: bash ${{ env.TSF_ROOT }}/scripts/ci/download-dictionaries.sh
 
       - name: Decide the signing mode
         id: signing
@@ -366,18 +312,7 @@ jobs:
         env:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
-        run: |
-          if ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD) {
-            "signing_enabled=true" >> $env:GITHUB_OUTPUT
-            "asset_suffix=" >> $env:GITHUB_OUTPUT
-            Write-Host 'Signing certificate present: the installer and its binaries will be signed.'
-          } else {
-            "signing_enabled=false" >> $env:GITHUB_OUTPUT
-            "asset_suffix=-unsigned" >> $env:GITHUB_OUTPUT
-            # AGENTS.md: uiAccess="true" only takes effect for a correctly signed binary installed
-            # in a location Windows trusts, so an unsigned build cannot float over elevated hosts.
-            Write-Host '::warning::No signing certificate configured. Publishing an unsigned installer; uiAccess will not take effect.'
-          }
+        run: ./${{ env.TSF_ROOT }}/scripts/ci/detect-release-signing.ps1
 
       - name: Collect the installer payload
         shell: pwsh
@@ -394,48 +329,11 @@ jobs:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          # Sign-PackageBinaries-Local.ps1 mints a self-signed certificate for local testing and
-          # must not run here; this uses the real certificate from the repository secrets instead.
-          $pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
-          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
-          $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe' |
-            Sort-Object FullName -Descending | Select-Object -First 1
-          if (-not $signtool) { throw 'signtool.exe not found in the Windows SDK.' }
-          $targets = Get-ChildItem -Recurse -File -Include '*.exe', '*.dll' -Path 'server_exe', 'tsf_dll'
-          if (-not $targets) { throw 'Nothing to sign under server_exe/ or tsf_dll/.' }
-          & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
-          if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
-          Remove-Item $pfx -Force
+        run: ../../${{ env.TSF_ROOT }}/scripts/ci/sign-binaries.ps1 -Path 'server_exe', 'tsf_dll' -Recurse
 
-      # msime_setup.iss declares a chinesesimplified language pointing at
-      # compiler:Languages\ChineseSimplified.isl, and the runner's Inno Setup does not ship that
-      # file, so ISCC aborts on the [Languages] section. Pinned by commit and checksum rather
-      # than tracking a branch, so the installer text cannot change under a rebuild.
       - name: Install the Chinese language file for Inno Setup
         shell: pwsh
-        env:
-          ISL_URL: https://raw.githubusercontent.com/jrsoftware/issrc/1ae7bf81dc0d2013235dfe4bb0b6f4e4a0b6b25c/Files/Languages/ChineseSimplified.isl
-          ISL_SHA256: e0b0b350e2245f3c5e65586dfe43d574f6e7f06f2261149aba284954b3fc9a8d
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $iscc = Get-Command 'ISCC.exe' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-          $root = if ($iscc) { Split-Path $iscc.Source -Parent } else { 'C:\Program Files (x86)\Inno Setup 6' }
-          $languages = Join-Path $root 'Languages'
-          $target = Join-Path $languages 'ChineseSimplified.isl'
-          if (Test-Path $target) {
-            Write-Host "Already present: $target"
-            exit 0
-          }
-          New-Item -ItemType Directory -Path $languages -Force | Out-Null
-          Invoke-WebRequest -Uri $env:ISL_URL -OutFile $target -MaximumRetryCount 3 -RetryIntervalSec 5
-          $actual = (Get-FileHash $target -Algorithm SHA256).Hash.ToLower()
-          if ($actual -ne $env:ISL_SHA256) {
-            Remove-Item $target -Force
-            throw "ChineseSimplified.isl checksum mismatch: expected $env:ISL_SHA256, got $actual"
-          }
-          Write-Host "Installed $target ($((Get-Item $target).Length) bytes)"
+        run: ./${{ env.TSF_ROOT }}/scripts/ci/install-inno-language.ps1
 
       - name: Compile the installer
         shell: pwsh
@@ -451,16 +349,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
           TARGET_VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
-          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
-          $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe' |
-            Sort-Object FullName -Descending | Select-Object -First 1
-          $setup = "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
-          & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v $setup
-          if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
-          Remove-Item $pfx -Force
+        run: ../../${{ env.TSF_ROOT }}/scripts/ci/sign-binaries.ps1 -Path "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
 
       - name: Name the asset and record its checksum
         id: asset
@@ -469,18 +358,7 @@ jobs:
         env:
           TARGET_VERSION: ${{ needs.prepare.outputs.version }}
           ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $built = "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
-          if (-not (Test-Path $built)) { throw "Inno Setup did not produce $built" }
-          $final = "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION$env:ASSET_SUFFIX.exe"
-          if ($built -ne $final) { Move-Item $built $final -Force }
-          $hash = (Get-FileHash $final -Algorithm SHA256).Hash.ToLower()
-          $size = [math]::Round((Get-Item $final).Length / 1MB, 1)
-          "asset_path=$((Resolve-Path $final).Path)" >> $env:GITHUB_OUTPUT
-          "asset_name=$(Split-Path $final -Leaf)" >> $env:GITHUB_OUTPUT
-          "asset_sha256=$hash" >> $env:GITHUB_OUTPUT
-          "### Installer`n`n| Field | Value |`n| --- | --- |`n| File | $(Split-Path $final -Leaf) |`n| Size | $size MB |`n| SHA256 | ``$hash`` |`n| Dictionaries | $env:DICTIONARY_TAG |" >> $env:GITHUB_STEP_SUMMARY
+        run: ../../${{ env.TSF_ROOT }}/scripts/ci/name-installer-asset.ps1
 
       - name: Upload the installer as a workflow artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -496,11 +374,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           TARGET_SHA: ${{ needs.prepare.outputs.target_sha }}
-        run: |
-          set -euo pipefail
-          release_json=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json isDraft,targetCommitish)
-          test "$(jq -er .isDraft <<< "$release_json")" = true
-          test "$(jq -er .targetCommitish <<< "$release_json")" = "$TARGET_SHA"
+        run: bash ${{ env.TSF_ROOT }}/scripts/ci/revalidate-draft-release.sh
 
       - name: Upload and publish the release
         shell: bash
@@ -512,18 +386,4 @@ jobs:
           ASSET_NAME: ${{ steps.asset.outputs.asset_name }}
           ASSET_SHA256: ${{ steps.asset.outputs.asset_sha256 }}
           SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
-        run: |
-          set -euo pipefail
-          gh release upload "$TAG_NAME" "$ASSET_PATH" --repo "$GH_REPO" --clobber
-          gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq .body > notes.md
-          {
-            printf '\n---\n\n'
-            printf '| Field | Value |\n| --- | --- |\n'
-            printf '| Installer | `%s` |\n' "$ASSET_NAME"
-            printf '| SHA256 | `%s` |\n' "$ASSET_SHA256"
-            printf '| Dictionaries | `%s` |\n' "$DICTIONARY_TAG"
-            if [[ "$SIGNING_ENABLED" != true ]]; then
-              printf '\nThis build is **unsigned**. Windows warns on launch, and `uiAccess` does not take effect, so the candidate window cannot float over elevated applications.\n'
-            fi
-          } >> notes.md
-          gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false --prerelease --notes-file notes.md
+        run: bash ${{ env.TSF_ROOT }}/scripts/ci/publish-release.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,6 +304,24 @@ python .\scripts\apply_version.py           # 从 version.txt 写入版本资源
 python .\scripts\apply_version.py --check   # 只检查是否与 version.txt 一致
 ```
 
+release workflow 里的每一段 shell 都抽在 `scripts/ci/` 下，workflow 本身只负责编排和传参：
+
+| 脚本 | 用途 |
+|---|---|
+| `validate-draft-release.sh` | 手动触发时校验 tag 是未发布 draft、指向不可变 commit、且与 `version.txt` 一致 |
+| `merge-release-pr.sh` | 合并 release-please 刚开的 PR |
+| `verify-commit-on-main.sh` | 拒绝构建不在 main 历史里的 commit |
+| `install-boost.ps1` | 装 Server 链接但未声明的 Boost，triplet 必须是 static-md |
+| `check-server-binaries.ps1` | 提前拦住 Server 产物缺文件 |
+| `check-tsf-dll.ps1` | 确认 TSF DLL 产出 |
+| `download-dictionaries.sh` | 从 MSIME-Dict 的 `dict-*` release 拉词库并校验 SHA256 |
+| `detect-release-signing.ps1` | 判定签名模式，决定产物后缀 |
+| `sign-binaries.ps1` | 用仓库 secret 里的真证书签名，包内二进制和安装包共用 |
+| `install-inno-language.ps1` | 补 runner 上缺失的 `ChineseSimplified.isl`，按 commit + SHA256 固定 |
+| `name-installer-asset.ps1` | 定最终产物名、算校验和、写 step summary |
+| `revalidate-draft-release.sh` | 发布前复查 draft 仍指向被构建的那个 commit |
+| `publish-release.sh` | 上传产物、追加说明、发布 |
+
 CI 里的目录布局刻意用了各仓的历史名（`MetasequoiaImeTsf`、`MetasequoiaImeServer`、`MetasequoiaImeUiHtml`、`MetasequoiaImeHelpCode`、`MetasequoiaImeDict`），这样 `msime-installer` 的 `Prepare-PackageFiles.ps1` 不用改一行就能在 CI 跑。改动那些脚本里的产物路径时，要连同本仓的 release workflow 一起核对。
 
 词库不在 CI 里现建，从 `metasequoiaime/MSIME-Dict` 的 `dict-*` release 下载并校验 SHA256。词库改了要先在那边跑 `Build dictionaries` workflow 并勾选 publish，再发 Windows 版本；也可以在手动触发时用 `dictionary_tag` 指定某个具体的词库版本。

--- a/scripts/ci/check-server-binaries.ps1
+++ b/scripts/ci/check-server-binaries.ps1
@@ -1,0 +1,19 @@
+# Fail early when the Server build is missing something the installer collects, rather than
+# letting Prepare-PackageFiles.ps1 report it several jobs later.
+param([string]$BuildDir = 'build/bin/Release')
+
+$ErrorActionPreference = 'Stop'
+
+$required = @(
+    'MetasequoiaImeServer.exe',
+    'MetasequoiaImeSettings.exe',
+    'MetasequoiaImeWatchdog.exe',
+    'MetasequoiaImeDictionaryReplay.exe'
+)
+
+$missing = $required | Where-Object { -not (Test-Path (Join-Path $BuildDir $_)) }
+if ($missing) {
+    throw "Missing from the Server build: $($missing -join ', ')"
+}
+
+Get-ChildItem $BuildDir -File | Select-Object Name, Length | Format-Table

--- a/scripts/ci/check-tsf-dll.ps1
+++ b/scripts/ci/check-tsf-dll.ps1
@@ -1,0 +1,13 @@
+# Confirm the build produced the DLL the installer collects.
+#
+# Reading a version back off the DLL would not work: the VERSIONINFO block in
+# src/IME/MetasequoiaIME.rc is named IDR_VERSION2, which is not defined anywhere, rather than the
+# VS_VERSION_INFO the Windows version API looks for, so GetFileVersionInfo finds nothing and the
+# DLL reports an empty FileVersion. apply_version.py --check covers the version instead.
+param([Parameter(Mandatory)][string]$BuildDir)
+
+$ErrorActionPreference = 'Stop'
+
+$dll = Join-Path $BuildDir 'Release/MetasequoiaImeTsf.dll'
+if (-not (Test-Path $dll)) { throw "The build did not produce $dll" }
+Write-Host "$dll is $((Get-Item $dll).Length) bytes"

--- a/scripts/ci/detect-release-signing.ps1
+++ b/scripts/ci/detect-release-signing.ps1
@@ -1,0 +1,20 @@
+# Decide whether this release can be signed, and say so in the log either way.
+#
+# Signing is optional so the pipeline stays runnable without a certificate, but an unsigned build
+# is degraded in a way users will notice: per AGENTS.md, uiAccess="true" only takes effect for a
+# correctly signed binary installed somewhere Windows trusts, so the candidate window cannot float
+# over elevated hosts. Unsigned artifacts therefore carry a suffix and the release notes say so.
+#
+# Writes signing_enabled and asset_suffix to GITHUB_OUTPUT.
+$ErrorActionPreference = 'Stop'
+
+if ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD) {
+    "signing_enabled=true" >> $env:GITHUB_OUTPUT
+    "asset_suffix=" >> $env:GITHUB_OUTPUT
+    Write-Host 'Signing certificate present: the installer and its binaries will be signed.'
+}
+else {
+    "signing_enabled=false" >> $env:GITHUB_OUTPUT
+    "asset_suffix=-unsigned" >> $env:GITHUB_OUTPUT
+    Write-Host '::warning::No signing certificate configured. Publishing an unsigned installer; uiAccess will not take effect.'
+}

--- a/scripts/ci/download-dictionaries.sh
+++ b/scripts/ci/download-dictionaries.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Fetch the shipping dictionaries from a metasequoiaime/MSIME-Dict release and stage them where
+# msime-installer's Prepare-PackageFiles.ps1 reads them from. They are not rebuilt here: MSIME-Dict
+# builds and publishes them, and this verifies the checksums it published alongside.
+#
+# Requires GH_TOKEN, DICTIONARY_TAG (a dict-* tag or "latest"), STAGING_ROOT.
+# Appends the resolved tag to GITHUB_ENV.
+set -euo pipefail
+
+target="$STAGING_ROOT/MetasequoiaImeDict/out"
+mkdir -p "$target"
+
+if [[ "$DICTIONARY_TAG" == "latest" ]]; then
+    DICTIONARY_TAG=$(gh release list --repo metasequoiaime/MSIME-Dict --limit 30 --json tagName \
+        --jq '[.[] | select(.tagName | startswith("dict-"))] | first | .tagName // ""')
+fi
+
+if [[ -z "$DICTIONARY_TAG" ]]; then
+    echo "No dict-* release found in metasequoiaime/MSIME-Dict. Run its Build dictionaries workflow with publish enabled first." >&2
+    exit 1
+fi
+
+echo "Using dictionary release $DICTIONARY_TAG"
+gh release download "$DICTIONARY_TAG" --repo metasequoiaime/MSIME-Dict --dir "$target" --clobber
+(cd "$target" && sha256sum --check SHA256SUMS.txt)
+
+# Prepare-PackageFiles.ps1 reads the Mozc notice from the path the local build leaves it at and
+# copies it into the installer as MOZC_DICTIONARY_LICENSE.txt. The IPAdic / ICOT / Okinawa
+# attribution has to ship with dict_japanese.dat, so put it where it is expected.
+notice_dir="$STAGING_ROOT/MetasequoiaImeDict/source/mozc_dictionary_oss"
+mkdir -p "$notice_dir"
+cp "$target/mozc_dictionary_oss_README.txt" "$notice_dir/README.txt"
+
+echo "DICTIONARY_TAG=$DICTIONARY_TAG" >> "$GITHUB_ENV"

--- a/scripts/ci/install-boost.ps1
+++ b/scripts/ci/install-boost.ps1
@@ -1,0 +1,21 @@
+# Install the Boost packages MSIME-Server links but does not declare.
+#
+# Kept in step with metasequoiaime/MSIME-Server's own CI. Boost is linked statically but is not in
+# its vcpkg.json, so it cannot come from the manifest. The triplet has to be static-md, not static:
+# Boost_USE_STATIC_LIBS ON asks for static Boost libraries while the rest of the project builds
+# against the dynamic CRT, and plain x64-windows-static would switch Boost to the static CRT and
+# fail to link with LNK2038 RuntimeLibrary mismatches.
+#
+# Appends BOOST_ROOT to GITHUB_ENV, which is the override MSIME-Server's CMakeLists.txt supports.
+$ErrorActionPreference = 'Stop'
+
+Push-Location $env:VCPKG_INSTALLATION_ROOT
+try {
+    ./vcpkg install boost-locale:x64-windows-static-md boost-json:x64-windows-static-md
+    if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed with exit code $LASTEXITCODE" }
+}
+finally {
+    Pop-Location
+}
+
+"BOOST_ROOT=$env:VCPKG_INSTALLATION_ROOT/installed/x64-windows-static-md" >> $env:GITHUB_ENV

--- a/scripts/ci/install-inno-language.ps1
+++ b/scripts/ci/install-inno-language.ps1
@@ -1,0 +1,30 @@
+# Put the Chinese language file next to the Inno Setup compiler.
+#
+# msime_setup.iss declares a chinesesimplified language pointing at
+# compiler:Languages\ChineseSimplified.isl, and the Inno Setup on the runner does not ship that
+# file, so ISCC aborts on the [Languages] section. Pinned by commit and checksum rather than
+# tracking a branch, so the installer's Chinese text cannot change under a rebuild.
+#
+# Requires ISL_URL and ISL_SHA256.
+$ErrorActionPreference = 'Stop'
+
+$iscc = Get-Command 'ISCC.exe' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+$root = if ($iscc) { Split-Path $iscc.Source -Parent } else { 'C:\Program Files (x86)\Inno Setup 6' }
+$languages = Join-Path $root 'Languages'
+$target = Join-Path $languages 'ChineseSimplified.isl'
+
+if (Test-Path $target) {
+    Write-Host "Already present: $target"
+    exit 0
+}
+
+New-Item -ItemType Directory -Path $languages -Force | Out-Null
+Invoke-WebRequest -Uri $env:ISL_URL -OutFile $target -MaximumRetryCount 3 -RetryIntervalSec 5
+
+$actual = (Get-FileHash $target -Algorithm SHA256).Hash.ToLower()
+if ($actual -ne $env:ISL_SHA256) {
+    Remove-Item $target -Force
+    throw "ChineseSimplified.isl checksum mismatch: expected $env:ISL_SHA256, got $actual"
+}
+
+Write-Host "Installed $target ($((Get-Item $target).Length) bytes)"

--- a/scripts/ci/merge-release-pr.sh
+++ b/scripts/ci/merge-release-pr.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Merge the pull request release-please just opened.
+#
+# Merging is what carries the release forward: the resulting push runs the release workflow
+# again, release-please turns the release commit into the draft release, and the build jobs take
+# over. Left open the pull request stalls, because CI cannot run on it either -- GITHUB_TOKEN is
+# not allowed to start workflows, so anything it triggers waits for a human. The pull request
+# only rewrites version.txt, CHANGELOG.md and .release-please-manifest.json.
+#
+# Requires GH_TOKEN, GH_REPO, RELEASE_PR (the JSON release-please emits).
+set -euo pipefail
+
+number=$(jq -er .number <<< "$RELEASE_PR")
+echo "Merging release pull request #$number"
+gh pr merge "$number" --repo "$GH_REPO" --merge

--- a/scripts/ci/name-installer-asset.ps1
+++ b/scripts/ci/name-installer-asset.ps1
@@ -1,0 +1,35 @@
+# Give the compiled installer its final name, record its checksum and summarise the build.
+#
+# Inno Setup names the output from MyAppVersion alone; unsigned builds get a suffix here so the
+# published asset says what it is.
+#
+# Requires TARGET_VERSION, ASSET_SUFFIX, DICTIONARY_TAG. Run from the installer directory.
+# Writes asset_path, asset_name and asset_sha256 to GITHUB_OUTPUT.
+$ErrorActionPreference = 'Stop'
+
+$built = "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
+if (-not (Test-Path $built)) { throw "Inno Setup did not produce $built" }
+
+$final = "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION$env:ASSET_SUFFIX.exe"
+if ($built -ne $final) { Move-Item $built $final -Force }
+
+$hash = (Get-FileHash $final -Algorithm SHA256).Hash.ToLower()
+$size = [math]::Round((Get-Item $final).Length / 1MB, 1)
+$name = Split-Path $final -Leaf
+
+"asset_path=$((Resolve-Path $final).Path)" >> $env:GITHUB_OUTPUT
+"asset_name=$name" >> $env:GITHUB_OUTPUT
+"asset_sha256=$hash" >> $env:GITHUB_OUTPUT
+
+@(
+    '### Installer'
+    ''
+    '| Field | Value |'
+    '| --- | --- |'
+    "| File | $name |"
+    "| Size | $size MB |"
+    "| SHA256 | ``$hash`` |"
+    "| Dictionaries | $env:DICTIONARY_TAG |"
+) | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+
+Write-Host "$name ($size MB, sha256 $hash)"

--- a/scripts/ci/publish-release.sh
+++ b/scripts/ci/publish-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Attach the installer to the draft release, append the artifact details to its notes and publish.
+#
+# Requires GH_TOKEN, GH_REPO, TAG_NAME, ASSET_PATH, ASSET_NAME, ASSET_SHA256, SIGNING_ENABLED,
+# DICTIONARY_TAG.
+set -euo pipefail
+
+gh release upload "$TAG_NAME" "$ASSET_PATH" --repo "$GH_REPO" --clobber
+
+gh release view "$TAG_NAME" --repo "$GH_REPO" --json body --jq .body > notes.md
+{
+    printf '\n---\n\n'
+    printf '| Field | Value |\n| --- | --- |\n'
+    printf '| Installer | `%s` |\n' "$ASSET_NAME"
+    printf '| SHA256 | `%s` |\n' "$ASSET_SHA256"
+    printf '| Dictionaries | `%s` |\n' "$DICTIONARY_TAG"
+    if [[ "$SIGNING_ENABLED" != true ]]; then
+        printf '\nThis build is **unsigned**. Windows warns on launch, and `uiAccess` does not take effect, so the candidate window cannot float over elevated applications.\n'
+    fi
+} >> notes.md
+
+gh release edit "$TAG_NAME" --repo "$GH_REPO" --draft=false --prerelease --notes-file notes.md
+echo "Published $TAG_NAME with $ASSET_NAME"

--- a/scripts/ci/revalidate-draft-release.sh
+++ b/scripts/ci/revalidate-draft-release.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Re-check right before publishing that the draft is still a draft and still points at the commit
+# that was actually built, so a release edited mid-build is never published with these artifacts.
+#
+# Requires GH_TOKEN, GH_REPO, TAG_NAME, TARGET_SHA.
+set -euo pipefail
+
+release_json=$(gh release view "$TAG_NAME" --repo "$GH_REPO" --json isDraft,targetCommitish)
+test "$(jq -er .isDraft <<< "$release_json")" = true
+test "$(jq -er .targetCommitish <<< "$release_json")" = "$TARGET_SHA"
+echo "Draft $TAG_NAME still targets $TARGET_SHA."

--- a/scripts/ci/sign-binaries.ps1
+++ b/scripts/ci/sign-binaries.ps1
@@ -1,0 +1,41 @@
+# Sign the given files with the release certificate from the repository secrets.
+#
+# msime-installer's Sign-PackageBinaries-Local.ps1 mints a self-signed certificate for local
+# testing and must never run in CI, so this is a separate path using the real certificate. Used
+# for both the packaged binaries and the finished installer.
+#
+# Requires CERTIFICATE_BASE64, CERTIFICATE_PASSWORD, TIMESTAMP_URL.
+param(
+    [Parameter(Mandatory)][string[]]$Path,
+    [switch]$Recurse
+)
+
+$ErrorActionPreference = 'Stop'
+
+$targets = if ($Recurse) {
+    Get-ChildItem -Recurse -File -Include '*.exe', '*.dll' -Path $Path
+}
+else {
+    Get-Item -Path $Path
+}
+
+if (-not $targets) {
+    throw "Nothing to sign under: $($Path -join ', ')"
+}
+
+$signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin\*\x64\signtool.exe' |
+    Sort-Object FullName -Descending | Select-Object -First 1
+if (-not $signtool) { throw 'signtool.exe not found in the Windows SDK.' }
+
+$pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
+[IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
+try {
+    & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 `
+        /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
+    if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
+}
+finally {
+    Remove-Item $pfx -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Signed $($targets.Count) file(s)."

--- a/scripts/ci/validate-draft-release.sh
+++ b/scripts/ci/validate-draft-release.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that a manually requested tag names an unpublished draft release pinned to an immutable
+# commit whose version.txt agrees with the tag, then report the commit and version for the build
+# jobs to use. Nothing is built until this passes.
+#
+# Requires GH_TOKEN, GH_REPO, TAG_NAME. Writes target_sha and version to GITHUB_OUTPUT.
+set -euo pipefail
+
+if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Tag must use the vMAJOR.MINOR.PATCH format, got '$TAG_NAME'." >&2
+    exit 1
+fi
+
+release_json=$(gh release view "$TAG_NAME" --json isDraft,targetCommitish)
+
+if [[ "$(jq -er .isDraft <<< "$release_json")" != true ]]; then
+    echo "Release $TAG_NAME is not an unpublished draft." >&2
+    exit 1
+fi
+
+target_sha=$(jq -er .targetCommitish <<< "$release_json")
+if [[ ! "$target_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Draft release target must be an immutable full commit SHA, got '$target_sha'." >&2
+    exit 1
+fi
+
+version=$(gh api "repos/$GH_REPO/contents/version.txt?ref=$target_sha" --jq .content | base64 --decode | tr -d '[:space:]')
+if [[ "$TAG_NAME" != "v$version" ]]; then
+    echo "Release $TAG_NAME does not match version.txt ($version)." >&2
+    exit 1
+fi
+
+printf 'target_sha=%s\n' "$target_sha" >> "$GITHUB_OUTPUT"
+printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+echo "Draft $TAG_NAME is valid: version $version at $target_sha"

--- a/scripts/ci/verify-commit-on-main.sh
+++ b/scripts/ci/verify-commit-on-main.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Refuse to build anything that is not in main's history. Run from inside the checkout being
+# validated.
+set -euo pipefail
+
+git fetch --no-tags --depth 50 origin main
+if ! git merge-base --is-ancestor HEAD FETCH_HEAD; then
+    echo "The release commit is not in main's history." >&2
+    exit 1
+fi
+echo "HEAD is in main's history."


### PR DESCRIPTION
Two things: the last blocker on the packaging job, and pulling every inline shell step out of the workflow.

## The packaging failure

Run 33953797415 got all the way through and then aborted at compile:

```
Error on line 61 in msime_setup.iss: Couldn't open include file
"c:\program files (x86)\inno setup 6\Languages\ChineseSimplified.isl"
```

`msime_setup.iss` declares a `chinesesimplified` language pointing at `compiler:Languages\ChineseSimplified.isl`, and the Inno Setup on the runner does not ship that file. A developer machine has it because it was installed by hand at some point.

The packaging job now fetches it into the `Languages` directory next to the resolved `ISCC.exe`, skipping the download when it is already there. Pinned to a `jrsoftware/issrc` commit and checked against its SHA-256, so the installer's Chinese text cannot change under a rebuild. Verified the pinned file is the 6.5.0+ message set, 21516 bytes, which matches the 6.7.1 on `windows-2025`.

## Everything before that step passed

Worth recording, because it is the part that had never run:

```
Check out MSIME-Windows at the release commit  success
Verify the release commit is on main           success
Check out the installer                        success
Check out MSIME-Server sources                 success
Check out MSIME-HelpCode                       success
Download the TSF DLLs                          success
Download the 32-bit TSF DLL                    success
Download the Server build                      success
Download the web assets                        success
Download the dictionaries                      success
Decide the signing mode                        success
Collect the installer payload                  success   <- Prepare-PackageFiles.ps1
Compile the installer                          failure
```

`Prepare-PackageFiles.ps1` ran unmodified against the staged layout and collected the payload, which confirms all eighteen paths it asserts on are satisfied. Signing was skipped, as designed, because no certificate is configured.

## Moving the shell out of the workflow

`release.yml` had grown thirteen inline shell and PowerShell blocks, some twenty lines. They are now files under `scripts/ci/` and the workflow only wires them up:

| Script | Purpose |
| --- | --- |
| `validate-draft-release.sh` | Check a dispatched tag is an unpublished draft on an immutable commit matching `version.txt` |
| `merge-release-pr.sh` | Merge the pull request release-please just opened |
| `verify-commit-on-main.sh` | Refuse to build a commit outside `main`'s history |
| `install-boost.ps1` | Install the Boost the Server links but does not declare |
| `check-server-binaries.ps1` | Fail early when the Server build is missing an installer input |
| `check-tsf-dll.ps1` | Confirm the TSF DLL exists |
| `download-dictionaries.sh` | Pull a `dict-*` release and verify its checksums |
| `detect-release-signing.ps1` | Decide the signing mode and asset suffix |
| `sign-binaries.ps1` | Sign with the real certificate from secrets |
| `install-inno-language.ps1` | Supply the language file above |
| `name-installer-asset.ps1` | Final asset name, checksum, step summary |
| `revalidate-draft-release.sh` | Re-check the draft target before publishing |
| `publish-release.sh` | Upload, append notes, publish |

Two things fall out of the move rather than being separate changes. The two signing steps were near-duplicates and are now one script taking a path list. The pinned language file URL and checksum moved to the packaging job's `env`, where they read as configuration.

The Server job now checks this repository out into `automation/` for its two scripts, **after** the MSIME-Server checkout: checkout cleans its destination, so doing it the other way round would delete `automation/`.

## Verification

- `shellcheck -S warning` is clean on all six shell scripts.
- Every script referenced by the workflow exists, and every script on disk is referenced; checked programmatically, not by eye.
- The relative paths used from `working-directory: src/msime-installer` were resolved and compared against the expected absolute paths.
- YAML parses; the only inline `run` blocks left are two two-line ones that are plain tool invocations.
- The PowerShell is **not** syntax-checked here, no `pwsh` on this machine. Four of the seven are verbatim from steps that already ran green in run 33953797415; the three that have not run are `install-inno-language.ps1`, `name-installer-asset.ps1` and `sign-binaries.ps1`, and the last cannot execute at all until a certificate is configured.

Stacked on #118, which is still open.
