### PR TITLE
docs: point cross-repo references at the current repository names

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@
 
 ## 项目结构
 
-- [MetasequoiaImeTsf](https://github.com/metasequoiaime/MetasequoiaImeTsf): 核心 TSF。
-- [MetasequoiaImeServer](https://github.com/metasequoiaime/MetasequoiaImeServer): Server 端，负责算法和窗口渲染。
-- [MetasequoiaImeUiHtml](https://github.com/metasequoiaime/MetasequoiaImeUiHtml): UI。
-- [MetasequoiaImeDict](https://github.com/metasequoiaime/MetasequoiaImeDict): 词库。
-- [MetasequoiaImeHelpCode](https://github.com/metasequoiaime/MetasequoiaImeHelpCode): 辅助码。
+- [MSIME-Windows](https://github.com/metasequoiaime/MSIME-Windows): 核心 TSF。
+- [MSIME-Server](https://github.com/metasequoiaime/MSIME-Server): Server 端，负责算法和窗口渲染。
+- [MSIME-UiHtml](https://github.com/metasequoiaime/MSIME-UiHtml): UI。
+- [MSIME-Dict](https://github.com/metasequoiaime/MSIME-Dict): 词库。
+- [MSIME-HelpCode](https://github.com/metasequoiaime/MSIME-HelpCode): 辅助码。
 - [MetasequoiaVoiceInput](https://github.com/metasequoiaime/MetasequoiaVoiceInput): 语音输入模块，也可单独使用。
 
 ## 功能简介


### PR DESCRIPTION
## What

Two stale references to repositories that have since been renamed.

### README project structure

| Old link | New link |
| --- | --- |
| `MetasequoiaImeTsf` | `MSIME-Windows` |
| `MetasequoiaImeServer` | `MSIME-Server` |
| `MetasequoiaImeUiHtml` | `MSIME-UiHtml` |
| `MetasequoiaImeDict` | `MSIME-Dict` |
| `MetasequoiaImeHelpCode` | `MSIME-HelpCode` |

`MetasequoiaVoiceInput` is left as is; that repository has not been renamed.

### release.yml

`actions/checkout` still asked for `metasequoiaime/MetasequoiaImeUiHtml`. Every other checkout in that workflow already uses the current name. This step has no `path:` of its own, so the change moves nothing on disk.

## What is deliberately **not** changed

`AGENTS.md` lists the sibling checkout directories as `../MetasequoiaImeServer/`, `../MetasequoiaImeDict/`, `../MetasequoiaImeHelpCode/` and so on. I started to update those and then reverted: `AGENTS.md` itself records that the historical directory names are intentional, so that `msime-installer`'s `Prepare-PackageFiles.ps1` runs unchanged, and `release.yml` backs that up by checking `metasequoiaime/MSIME-Server` out into `path: .../MetasequoiaImeServer`.

So the rule in this organization is: **repository names are current, checkout directory names stay historical.** This PR only touches the former.

## Not in this PR

The project structure section omits two repositories that are part of the structure today: `MSIME-Engine` (the shared C++ engine, reached through the Server) and `MSIME-UI` (the Direct2D GUI framework the Server links against). Adding them is a content change rather than a rename fix, so it is left out here.

## Verification

Documentation plus one `repository:` field. No build files, no source, no directory layout.
