### PR TITLE
fix(ci): take the release scripts from the default branch, not the built commit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,12 +18,12 @@ body:
       description: 问题主要出现在哪个部分？Which part is primarily affected?
       multiple: true
       options:
-        - TSF 前端 / MetasequoiaImeTsf
-        - Server / 引擎服务 / MetasequoiaImeServer
+        - TSF 前端 / MSIME-Windows
+        - Server / 引擎服务 / MSIME-Server
         - 设置界面 / Settings
         - 候选窗 UI / Candidate UI
-        - 词典 / MetasequoiaImeDict
-        - 辅助码 / MetasequoiaImeHelpCode
+        - 词典 / MSIME-Dict
+        - 辅助码 / MSIME-HelpCode
         - 安装器 / Installer
         - 文档 / 官网
         - 不确定 / Not sure

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://t.me/msimegroup
     about: 使用问题、讨论与日常交流。Questions and discussions.
   - name: QQ 群 / QQ Group
-    url: https://github.com/metasequoiaime/MetasequoiaImeTsf
-    about: QQ 群号 829919142（见仓库简介）。QQ Group: 829919142.
+    url: https://github.com/metasequoiaime/MSIME-Windows
+    about: "QQ 群号 829919142（见仓库简介）。QQ Group: 829919142."
   - name: 项目文档 / Documentation
-    url: https://github.com/metasequoiaime/MetasequoiaIME
+    url: https://github.com/metasequoiaime/MSIME-Docs
     about: 水杉输入法文档仓库。Docs for Metasequoia IME.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,12 +18,12 @@ body:
       description: 该功能主要涉及哪个部分？Which part does this mainly involve?
       multiple: true
       options:
-        - TSF 前端 / MetasequoiaImeTsf
-        - Server / 引擎服务 / MetasequoiaImeServer
+        - TSF 前端 / MSIME-Windows
+        - Server / 引擎服务 / MSIME-Server
         - 设置界面 / Settings
         - 候选窗 UI / Candidate UI
-        - 词典 / MetasequoiaImeDict
-        - 辅助码 / MetasequoiaImeHelpCode
+        - 词典 / MSIME-Dict
+        - 辅助码 / MSIME-HelpCode
         - 安装器 / Installer
         - 文档 / 官网
         - 不确定 / Not sure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       dictionary_tag: ${{ github.event_name == 'workflow_dispatch' && inputs.dictionary_tag || 'latest' }}
     steps:
       - name: Check out release automation
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -99,6 +99,14 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      - name: Check out release automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: automation
+          sparse-checkout: scripts/ci
+          persist-credentials: false
+
       - name: Stamp the version resource
         shell: pwsh
         run: |
@@ -125,7 +133,7 @@ jobs:
 
       - name: Check the DLL the installer expects
         shell: pwsh
-        run: ./scripts/ci/check-tsf-dll.ps1 -BuildDir '${{ matrix.build_dir }}'
+        run: ./automation/scripts/ci/check-tsf-dll.ps1 -BuildDir '${{ matrix.build_dir }}'
 
       - name: Upload the DLL
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -151,8 +159,9 @@ jobs:
       # After the checkout above, which cleans the workspace root: a checkout into a subdirectory
       # does not touch its parent, so the order matters.
       - name: Check out release automation
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           path: automation
           sparse-checkout: scripts/ci
           persist-credentials: false
@@ -249,10 +258,18 @@ jobs:
           path: ${{ env.TSF_ROOT }}
           persist-credentials: false
 
+      - name: Check out release automation
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          path: automation
+          sparse-checkout: scripts/ci
+          persist-credentials: false
+
       - name: Verify the release commit is on main
         shell: bash
         working-directory: ${{ env.TSF_ROOT }}
-        run: bash scripts/ci/verify-commit-on-main.sh
+        run: bash ../../automation/scripts/ci/verify-commit-on-main.sh
 
       - name: Check out the installer
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -304,7 +321,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DICTIONARY_TAG: ${{ needs.prepare.outputs.dictionary_tag }}
-        run: bash ${{ env.TSF_ROOT }}/scripts/ci/download-dictionaries.sh
+        run: bash automation/scripts/ci/download-dictionaries.sh
 
       - name: Decide the signing mode
         id: signing
@@ -312,7 +329,7 @@ jobs:
         env:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
-        run: ./${{ env.TSF_ROOT }}/scripts/ci/detect-release-signing.ps1
+        run: ./automation/scripts/ci/detect-release-signing.ps1
 
       - name: Collect the installer payload
         shell: pwsh
@@ -329,11 +346,11 @@ jobs:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
-        run: ../../${{ env.TSF_ROOT }}/scripts/ci/sign-binaries.ps1 -Path 'server_exe', 'tsf_dll' -Recurse
+        run: ../../automation/scripts/ci/sign-binaries.ps1 -Path 'server_exe', 'tsf_dll' -Recurse
 
       - name: Install the Chinese language file for Inno Setup
         shell: pwsh
-        run: ./${{ env.TSF_ROOT }}/scripts/ci/install-inno-language.ps1
+        run: ./automation/scripts/ci/install-inno-language.ps1
 
       - name: Compile the installer
         shell: pwsh
@@ -349,7 +366,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
           TARGET_VERSION: ${{ needs.prepare.outputs.version }}
-        run: ../../${{ env.TSF_ROOT }}/scripts/ci/sign-binaries.ps1 -Path "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
+        run: ../../automation/scripts/ci/sign-binaries.ps1 -Path "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"
 
       - name: Name the asset and record its checksum
         id: asset
@@ -358,7 +375,7 @@ jobs:
         env:
           TARGET_VERSION: ${{ needs.prepare.outputs.version }}
           ASSET_SUFFIX: ${{ steps.signing.outputs.asset_suffix }}
-        run: ../../${{ env.TSF_ROOT }}/scripts/ci/name-installer-asset.ps1
+        run: ../../automation/scripts/ci/name-installer-asset.ps1
 
       - name: Upload the installer as a workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -374,7 +391,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           TARGET_SHA: ${{ needs.prepare.outputs.target_sha }}
-        run: bash ${{ env.TSF_ROOT }}/scripts/ci/revalidate-draft-release.sh
+        run: bash automation/scripts/ci/revalidate-draft-release.sh
 
       - name: Upload and publish the release
         shell: bash
@@ -386,4 +403,4 @@ jobs:
           ASSET_NAME: ${{ steps.asset.outputs.asset_name }}
           ASSET_SHA256: ${{ steps.asset.outputs.asset_sha256 }}
           SIGNING_ENABLED: ${{ steps.signing.outputs.signing_enabled }}
-        run: bash ${{ env.TSF_ROOT }}/scripts/ci/publish-release.sh
+        run: bash automation/scripts/ci/publish-release.sh


### PR DESCRIPTION
Fixes the TSF failure in run 33955405130, plus the `.github` staleness an org-wide dependency and docs audit turned up.

## The scripts were coming from the wrong commit

```
The term './scripts/ci/check-tsf-dll.ps1' is not recognized as a name of a cmdlet,
function, script file, or executable program.
```

The TSF and packaging jobs check the product out at the draft release's **target commit**, then ran `scripts/ci` from that checkout. `scripts/ci` arrived in #122, later than the commit `v0.0.12` points at, so the directory was not there. Everything before it passed, including `apply_version.py`, which has been in the tree since #111.

This was going to keep biting: a workflow change can always outrun the scripts present at the tag being built. It is also a trust problem, since the commit being released could substitute its own release automation.

Each job that runs a script now checks the automation out separately from `github.event.repository.default_branch`, which is what MSIME-Apple's release workflow does with its "Check out trusted release automation" step. I dismissed that step as Apple-specific complexity when writing #111 and have now been wrong about it twice, the first time being the release-please permission in #118.

The product still comes from the release commit; only the automation is pinned to the branch the workflow itself came from. All twelve invocations were resolved against their `working-directory` and checked to land on `automation/scripts/ci/`.

## Repository names

The UiHtml checkout named `metasequoiaime/MetasequoiaImeUiHtml`, which now resolves only through the rename redirect to `MSIME-UiHtml`. A release pipeline should not lean on that: if anyone creates a repository at the old name, the redirect stops working and the release silently pulls the wrong tree.

The other `MetasequoiaIme*` strings in the workflow are **staging directory names**, not repositories. `Prepare-PackageFiles.ps1` addresses its sibling checkouts by those pre-rename names, and staging under them is exactly what lets msime-installer run unmodified. A comment now says so, so they do not get "corrected" later.

## Issue templates

- Component dropdowns offered `MetasequoiaImeTsf` / `MetasequoiaImeServer` / `MetasequoiaImeDict` / `MetasequoiaImeHelpCode`; renamed to the current names.
- The QQ group contact link pointed at the old repository URL, and the documentation link at `MetasequoiaIME`, which redirects to `MSIME-Docs`.
- `config.yml` **was not valid YAML**, and predates this change:

  ```yaml
  about: QQ 群号 829919142（见仓库简介）。QQ Group: 829919142.
  ```

  A colon followed by a space cannot appear in a plain scalar. Confirmed against `HEAD` before touching it, so GitHub has been either lenient or quietly ignoring the file. Quoting the value fixes it; all six YAML files under `.github` now parse.

## Pins

Two `actions/checkout` pins were still on v6 because the steps did not exist on main when dependabot ran. Brought up to the v7.0.1 the rest of the file uses; every pin in the file is now consistent.
