### PR TITLE
chore(deps): move the vcpkg baseline forward from March 2025

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
+    "baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
The pinned baseline was `b02e341c`, committed **2025-03-19**, 5642 commits behind vcpkg master. Nothing was watching it: the dependabot template used across this org declares only `github-actions` and `gitsubmodule`, so vcpkg, npm and pip all go unnoticed everywhere.

This repository resolves only two ports, so the blast radius is small and precise:

| Port | Before | After |
| --- | --- | --- |
| fmt | 11.0.2#1 | 12.2.0#1 |
| utfcpp | 4.0.6 | 4.1.1 |

The fmt major is the part worth watching. **CI is what decides this**: it builds x64 and Win32 on every pull request, and I cannot build Windows locally, so I am not going to claim it is safe ahead of the checks. If fmt 12 breaks the build I would rather see it here than have it surface the next time someone runs `vcpkg install` against a newer baseline by accident.

## Noted, not changed

`vcpkg-configuration.json` also registers the `microsoft/vcpkg-ce-catalog` artifact registry. That repository is still up, not archived, last pushed 2025-02-06, and the URL resolves, but nothing in this project uses vcpkg artifacts. It is dead weight rather than a fault, so removing it belongs in its own change.

## For context

Baseline state across the org, from the same audit:

| Repository | Baseline | Age |
| --- | --- | --- |
| MSIME-Windows | `b02e341c` | 2025-03-19, 5642 commits behind |
| MSIME-Server | `66c0373d` | 2026-01-16, 2870 commits behind |
| MSIME-Engine | none | resolves against whatever vcpkg the runner ships |
| MSIME-UI | not applicable | does not use vcpkg at all: no manifest, no toolchain file in CI |

MSIME-Server has eight ports including curl, webview2 and spdlog, where the spdlog and fmt pairing is a classic breakage, and its CI builds without running tests. That one deserves its own pull request rather than riding along here. MSIME-Engine, the one that genuinely has no baseline, is a separate lower-risk fix: pinning it stabilises a build that is currently non-reproducible.
