### PR TITLE
docs: give the README a download entry and correct the runtime requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,70 +2,44 @@
 
 一款开源的自由 Windows 输入法，面向 Windows 10 / Windows 11，采用纯 TSF 方案。
 
+## 下载与安装
+
+- **安装包**：[Releases](https://github.com/metasequoiaime/MSIME-Windows/releases)，或[官网下载页](https://msime.app/download/)
+- **安装步骤与常见问题**：[docs/installation.md](docs/installation.md)
+
+安装后用 `Win + 空格` 切换到水杉输入法。如果切换不过去、Server 反复退出或设置窗口一闪即关，多半是缺少 Visual C++ 2015–2022 Redistributable（**x64**），处理办法见安装文档的常见问题。
+
+其他平台：[macOS 与 iOS](https://github.com/metasequoiaime/MSIME-Apple) · [Linux](https://github.com/metasequoiaime/MSIME-Linux)
+
 ## 2026.09.02 给水杉输入法的新用户的说明
 
 最近两天，水杉输入法的新增用户远超预期，约有 5000 名新用户加入，内测服务的多项 API 配额也因此暂时耗尽。随着用户增长，我们收到了许多功能建议，也发现了一些内测阶段的问题。目前我正在逐一修复，同时重构 UI，并开发一套专门面向输入法场景的原生 GUI 框架。
 
 如果你在使用过程中遇到问题，还请耐心等待后续版本。也欢迎有能力的朋友提交 PR：无论是完善输入法本身，还是参与其背后的 GUI 框架，都非常欢迎。本项目接受纯 vibe 的 PR；唯一的请求是友善交流——不要骂主包。
 
-项目即将突破 1000 Stars。如果你是在校学生或正在求职，也欢迎通过贡献代码，或整理与学校、专业相关的词库来参与项目(刷个 PR)。输入法是一款能够直接面向大量用户的软件；如果你希望自己参与开发的软件、自己写的代码真正被人使用并获得反馈，这会是一个不错的实践机会。
+如果你是在校学生或正在求职，也欢迎通过贡献代码，或整理与学校、专业相关的词库来参与项目(刷个 PR)。输入法是一款能够直接面向大量用户的软件；如果你希望自己参与开发的软件、自己写的代码真正被人使用并获得反馈，这会是一个不错的实践机会。
 
 本项目现在及未来都会保持 100% 开源。开源的目的之一，是探索 AI 能否参与完善输入法这类容错空间较小、与操作系统耦合较深的软件；同时，也希望为由大型厂商主导的工具软件生态提供一个开放、可控的替代选择。
 
 ### 如何参与贡献
 
-不会写 TSF 或 C++ 也没关系，项目还有很多可以参与的方向：
+不会写 TSF 或 C++ 也没关系。项目可以参与的方向按类别整理在[招募开源开发者](https://github.com/metasequoiaime/.github/blob/main/RECRUITING.md)里，从整理词库、补文档、做本地化、测兼容性，到实现新的输入方案都有。
 
-- 完善安装、配置、升级和卸载文档；
-- 补充语音输入、云服务和本地模型的接入指南；
-- 编写 API 申请与配置教程；
-- 整理各厂商提供的免费额度或试用额度；
-- 编写常见问题、故障排查和使用技巧；
-- 改进全拼、双拼、五笔等现有输入方案；
-- 参与日语、注音、粤语等输入方案的设计与实现；
-- 整理学校、专业、行业、地区或兴趣领域的专用词库；
-- 修复程序问题或实现新的功能；
-- 参与原生 GUI 框架和界面功能的开发；
-- 改进界面设计、图标、动画和交互体验；
-- 参与英文、日文等语言的翻译和本地化；
-- 测试不同 Windows 版本、软件和硬件环境；
-- 提交包含复现步骤、日志和截图的问题报告；
-- 制作截图、演示视频和新手教程；
-- 提出功能建议或参与技术方案讨论。
+Issue 已经逐条核过并按可接手程度打了标签，可以直接筛：
 
-写代码、写文档、整理词库、测试 Bug、制作教程，都是非常有价值的开源贡献。可以纯手写，也可以借助 AI；但请认真检查和测试，并注意不要在 PR、Issue、截图或日志中泄露 API Key 等敏感信息。
+- [good first issue](https://github.com/metasequoiaime/MSIME-Windows/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)——改动小，根因和修法已经写明
+- [no-code](https://github.com/metasequoiaime/MSIME-Windows/issues?q=is%3Aissue+is%3Aopen+label%3Ano-code)——不需要写代码：图标资源、词库条目、文档、调研
+- [help wanted](https://github.com/metasequoiaime/MSIME-Windows/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)——根因明确、改动中等
+- [needs-design](https://github.com/metasequoiaime/MSIME-Windows/issues?q=is%3Aissue+is%3Aopen+label%3Aneeds-design)——方案未定，先在 Issue 里讨论再动手
 
-如果你会写代码，可以参与以下方向：
-
-- 修复 TSF 输入法核心中的 Bug；
-- 改进候选词、组词、联想和排序算法；
-- 优化输入响应速度、内存占用和启动性能；
-- 完善全拼、双拼、五笔等现有输入方案；
-- 实现日语、注音、粤语等新的输入方案；
-- 开发模糊音、辅助码、纠错和智能补全功能；
-- 改进中英文切换、标点转换和快捷键逻辑；
-- 完善用户词库、系统词库和词频学习功能；
-- 开发词库导入、导出、同步和转换工具；
-- 接入语音识别、翻译或其他第三方 API；
-- 为不同厂商的 API 编写统一的适配器；
-- 接入本地模型或其他离线能力；
-- 参与输入法原生 GUI 框架的开发；
-- 开发候选窗口、设置页面和状态栏组件；
-- 改进多显示器、高 DPI、缩放和深色模式支持；
-- 修复不同 Windows 版本及应用程序中的兼容性问题；
-- 改进崩溃恢复、异常处理、日志和诊断功能；
-- 编写单元测试、集成测试和自动化测试；
-- 完善编译脚本、开发环境和持续集成流程；
-- 检查线程安全、资源释放和内存安全问题；
-- 重构重复代码，改善模块边界和接口设计；
-- 补充代码注释、接口文档和开发者文档；
-- 对现有 PR 进行代码审查、测试和性能验证；
-- 制作能够稳定复现问题的最小示例。
+写代码、写文档、整理词库、测试 Bug、制作教程，都是非常有价值的开源贡献。可以纯手写，也可以借助 AI；但请认真检查和测试，并注意不要在 PR、Issue、截图或日志中泄露 API Key 等敏感信息。完整的贡献约定见[贡献指南](https://github.com/metasequoiaime/.github/blob/main/CONTRIBUTING.md)。
 
 ## 项目结构
 
 - [MSIME-Windows](https://github.com/metasequoiaime/MSIME-Windows): 核心 TSF。
-- [MSIME-Server](https://github.com/metasequoiaime/MSIME-Server): Server 端，负责算法和窗口渲染。
+- [MSIME-Server](https://github.com/metasequoiaime/MSIME-Server): Server 端，负责算法调度和窗口渲染。
+- [MSIME-Engine](https://github.com/metasequoiaime/MSIME-Engine): 跨平台输入引擎，各平台前端共用。
+- [MSIME-UI](https://github.com/metasequoiaime/MSIME-UI): 自研原生 GUI 框架，用于替换现有的 WebView2 界面。
 - [MSIME-UiHtml](https://github.com/metasequoiaime/MSIME-UiHtml): UI。
 - [MSIME-Dict](https://github.com/metasequoiaime/MSIME-Dict): 词库。
 - [MSIME-HelpCode](https://github.com/metasequoiaime/MSIME-HelpCode): 辅助码。

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # 安装水杉输入法
 
 > 适用版本：v0.0.9.2（2026 年 8 月 25 日发布，内测版）
-> 若你安装的是更新版本，请以 [Releases](https://github.com/metasequoiaime/MetasequoiaImeTsf/releases) 中的说明为准。
+> 若你安装的是更新版本，请以 [Releases](https://github.com/metasequoiaime/MSIME-Windows/releases) 中的说明为准。
 
 ## 目录
 
@@ -20,11 +20,11 @@
 | 磁盘空间 | 安装包约 61 MB，安装后占用约 250 MB［待确认：实测安装后目录大小］ |
 | 网络 | 云联想、AI 联想、语音输入、候选词翻译等在线功能需要联网；离线状态下本地输入不受影响 |
 | 其他 | 使用手写识别需先在 Windows 中安装「中文手写包」 |
-| Visual C++ 运行库 | 无需单独安装：TSF DLL 采用静态 CRT 构建（Release 为 `/MT`），不依赖宿主的 MSVCP140 / VCRUNTIME140 |
+| Visual C++ 运行库 | **需要 x64 版**。TSF DLL 采用静态 CRT 构建，被加载进宿主进程时不依赖 MSVCP140 / VCRUNTIME140；但 Server 与设置程序是动态 CRT 的 64 位程序，缺少运行库时会表现为服务反复退出、设置窗口一闪即关。详见下文[常见问题](#常见问题) |
 
 ## 下载
 
-1. 打开 [Releases 页面](https://github.com/metasequoiaime/MetasequoiaImeTsf/releases)。
+1. 打开 [Releases 页面](https://github.com/metasequoiaime/MSIME-Windows/releases)。
 2. 下载最新的安装包 `MetasequoiaIME_Setup_v<版本号>.exe`（例如 `MetasequoiaIME_Setup_v0.0.9.2.exe`）。
 
 > 注意：当前发布版本均标记为 **Pre-release（内测版）**，功能与稳定性可能变动，重要环境建议先在虚拟机或非主力机试用。
@@ -44,3 +44,26 @@
 
 ## 常见问题
 
+### 安装后无法切换到水杉，或设置窗口一闪即关
+
+绝大多数情况是缺少 **Visual C++ 2015–2022 Redistributable（x64）**。
+
+TSF DLL 被加载进宿主程序进程，采用静态 CRT 构建，不依赖运行库；但 Server 和设置程序是独立的 64 位程序，采用动态 CRT，缺少运行库时进程会在启动阶段直接退出。典型表现有三种：切换不到水杉输入法、Server 反复退出、设置窗口打开后立即消失。
+
+到[微软官方下载页](https://learn.microsoft.com/zh-cn/cpp/windows/latest-supported-vc-redist?view=msvc-170)下载 `vc_redist.x64.exe` 安装，然后重启 Windows。
+
+**注意 x86 与 x64 是两套独立的运行库。** 即使机器上已经装了较新的 x86 版本，也不能替代这里需要的 x64 版本。Windows 事件查看器里如果记录了 `MetasequoiaImeServer.exe` 或 `MetasequoiaImeSettings.exe` 因 `MSVCP140.dll` 或 `VCRUNTIME140.dll` 无法启动，就是这个原因。
+
+### 候选窗始终不出现
+
+先确认已安装 **Microsoft Edge WebView2 Runtime**（在「设置 → 应用 → 已安装的应用」里搜索 WebView2）。当前版本的候选窗由 WebView2 渲染，运行时缺失会导致窗口无法显示。
+
+### 手写识别没有候选结果
+
+需要先在 Windows 中安装「中文手写包」：设置 → 时间和语言 → 语言和区域 → 中文（简体，中国）→ 语言选项 → 手写。
+
+### 其他问题
+
+在 [Issues](https://github.com/metasequoiaime/MSIME-Windows/issues) 中反馈。为便于定位，请附上：输入法版本号、Windows 版本（`Win + R` 输入 `winver`）、出问题的宿主程序、以及最小复现步骤。
+
+与按键、候选窗相关的问题，可以在 `%LOCALAPPDATA%\metasequoiaime\config.toml` 的 `[general]` 段设 `tsf_diagnostic_log = true`，复现一次后附上日志。日志中可能包含你输入的内容，贴出前请先自行检查。


### PR DESCRIPTION
文档润色，三处，都是对着代码和实际状态核过的。

## 一、README 没有下载入口

这一条最要紧：README 从头到尾没有出现过 Releases、下载、安装、官网中的任何一个，`docs/installation.md` 也没有被任何地方链接。1200+ star 的面向用户产品，读者从 README 里找不到怎么装。

开头补一节「下载与安装」，指向 Releases、官网下载页和安装文档，顺带给出 macOS 与 Linux 前端仓库的入口。

## 二、安装文档里的运行库说明是错的

原文：

> Visual C++ 运行库：**无需单独安装**：TSF DLL 采用静态 CRT 构建（Release 为 `/MT`），不依赖宿主的 MSVCP140 / VCRUNTIME140

前半句对，结论错。核对了两个仓的构建配置：

- `MSIME-Windows`（TSF DLL）：`CMakeUserPresets.json` 用 `x64-windows-static` / `x86-windows-static`，确实是静态 CRT，被加载进宿主进程时不依赖运行库；
- `MSIME-Server`（Server 与设置程序）：`CMakePresets.json` 用 `x64-windows`，是动态三元组，`CMakeLists.txt` 里也没有任何 `MSVC_RUNTIME_LIBRARY` 或 `/MT` 设置。

也就是说 Server 和设置程序**需要** x64 运行库，缺了会在启动阶段直接退出——表现就是切换不到水杉、Server 反复退出、设置窗口一闪即关。官网下载页专门写了一整节讲这件事，两处说法此前是矛盾的。已改正为分别说明两个组件。

顺带把原本只有一个空标题的「常见问题」补上：运行库缺失的完整症状与处置、WebView2 Runtime 缺失导致候选窗不显示、手写包缺失、以及反馈问题时该附哪些信息（含 `tsf_diagnostic_log` 的开法，并提醒日志可能含输入内容、贴出前先自查）。

## 三、贡献方向清单与组织级文档重复

README 里两段共约 50 行的方向清单，与组织级的[招募开源开发者](https://github.com/metasequoiaime/.github/blob/main/RECRUITING.md)几乎逐条重复。两份清单必然各自漂移，读者也不知道该看哪份。

收敛为一小节：指向招募帖，并给出 Issue 标签的筛选链接（`good first issue` / `no-code` / `help wanted` / `needs-design`）——这比一长串方向更能让人真正找到能接的活。原文里关于「AI 辅助要自己检查」「不要泄露 API Key」的表述保留了。

同时把「项目即将突破 1000 Stars」这句去掉（现在是 1228），并给「项目结构」补上缺失的 `MSIME-Engine` 和 `MSIME-UI`——引擎和 GUI 框架是核心组件，原先没有列。

## 关于 diff

README 是 CRLF 行尾。我第一次编辑时无意把整个文件转成了 LF，产生 654 行的假 diff，已撤销重做，现在只有 20 增 46 删。行尾计数可以核对：340 − 46 + 20 = 314，与改后实际一致，没有夹带格式化改动。

## 验证

两个文件里所有链接逐个实测，均返回 200（其中微软运行库下载页原先是 301，已改为最终地址）。`docs/installation.md` 的相对链接和 `#常见问题` 锚点都已确认存在。
