### PR TITLE
ci: check out the UI resources and installer by their current repository names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,10 +204,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - name: Check out MetasequoiaImeUiHtml
+      - name: Check out MSIME-UiHtml
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: metasequoiaime/MetasequoiaImeUiHtml
+          repository: metasequoiaime/MSIME-UiHtml
           persist-credentials: false
 
       - name: Set up pnpm
@@ -274,7 +274,7 @@ jobs:
       - name: Check out the installer
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: metasequoiaime/msime-installer
+          repository: metasequoiaime/MSIME-Installer
           path: ${{ env.STAGING_ROOT }}/msime-installer
           persist-credentials: false
 


### PR DESCRIPTION
## What

Two `actions/checkout` steps in the release workflow still asked for repositories by their pre-rename names:

| Line | Old | New |
| --- | --- | --- |
| 210 | `metasequoiaime/MetasequoiaImeUiHtml` | `metasequoiaime/MSIME-UiHtml` |
| 277 | `metasequoiaime/msime-installer` | `metasequoiaime/MSIME-Installer` |

The step name `Check out MetasequoiaImeUiHtml` is updated to match. Both worked only through GitHub's rename redirect; every other `repository:` in this workflow already used the current name.

## What is deliberately not changed

Every `path:` and `working-directory:` stays exactly as it was:

```
path: ${{ env.STAGING_ROOT }}/msime-installer
path: ${{ env.STAGING_ROOT }}/MetasequoiaImeServer
path: ${{ env.STAGING_ROOT }}/MetasequoiaImeHelpCode
path: ${{ env.STAGING_ROOT }}/MetasequoiaImeUiHtml/webview2
```

Lines 28 and 122 of this file already explain why — staging under the historical names is what lets `Prepare-PackageFiles.ps1` run unmodified — and `msime-installer` is referenced as a `working-directory` in six further steps. The rule in this organization is: repository names are current, checkout directory names stay historical. This PR only touches the former.

## Verification

- All five `repository:` fields now match `gh repo list metasequoiaime`
- All `path:` and `working-directory:` values are byte-identical to before
- `yaml.safe_load` parses the file; jobs are still `prepare`, `tsf`, `server`, `ui`, `package`

The workflow triggers only on push to `main` and `workflow_dispatch`, so it does not run on this PR. The change is a two-token rename in checkout inputs.
