### PR TITLE
chore(scripts): drop the unused boost_path variable

### DIFF
--- a/scripts/prepare_env.py
+++ b/scripts/prepare_env.py
@@ -53,7 +53,6 @@ wim_path = normpath(
         "include",
     )
 )
-boost_path = normpath(os.path.join(user_home, "scoop", "apps", "boost", "current"))
 
 #
 # project_root/.clangd


### PR DESCRIPTION
`scripts/prepare_env.py` 里的 `boost_path` 定义后从未被引用（全文件仅 1 处出现），Bug 汇总 #95 第一节也写明「顺手删掉即可」。

## 来源说明

**这一处改动来自 @PathGao 的 #97。** 那个 PR 做了两件事：让 `prepare_env.py` 读取 `VCPKG_ROOT`，以及删掉这个死变量。前一半与后来合入的 #117 重复了——而重复的责任在我们这边：#97 是 09-04 提交的，#117 是 09-05，我们在做 issue 分类和挑选工作时没有先核对已有的 open PR。

把 #97 合并进来会顺带撤掉 #117 里的说明注释、并把定义挪位置，属于无意义的改动churn，所以这里只取其中尚未被覆盖的那一行删除，并在此说明出处。#97 将以此为由关闭。

## 验证

删除后文件通过 `ast.parse` 语法检查，全文件已无 `boost` 相关引用。该变量此前无任何读取处，删除不改变脚本行为。
