### PR TITLE
ci: build the release pull request before merging it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,17 @@ on:
   push:
     branches: [main]
   pull_request:
-    # A release-please pull request only rewrites these three files. Skipping it keeps every
-    # release from parking an unapprovable run in the checks list: runs whose triggering actor is
-    # github-actions[bot] land in action_required, because GITHUB_TOKEN is not allowed to start
-    # workflows on its own. Nothing here builds from these files anyway.
+    # A release-please pull request only rewrites these three files, and its pull_request run would
+    # be created in action_required and never execute: GITHUB_TOKEN may not start workflows, so
+    # anything it triggers waits for a human. Skipping it here keeps an unapprovable run out of the
+    # checks list. The release workflow dispatches this workflow on the release branch instead,
+    # which is the one trigger GITHUB_TOKEN is allowed to fire, so the version bump still gets a
+    # full build and the checks land on the same commit.
     paths-ignore:
       - version.txt
       - CHANGELOG.md
       - .release-please-manifest.json
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
     name: Prepare release metadata
     runs-on: ubuntu-24.04
     permissions:
+      # actions: write lets merge-release-pr.sh dispatch ci.yml on the release branch, which is the
+      # only trigger GITHUB_TOKEN is allowed to fire.
+      actions: write
       contents: write
       pull-requests: write
     outputs:

--- a/scripts/ci/merge-release-pr.sh
+++ b/scripts/ci/merge-release-pr.sh
@@ -1,15 +1,72 @@
 #!/usr/bin/env bash
-# Merge the pull request release-please just opened.
+# Build the pull request release-please just opened, then merge it.
 #
-# Merging is what carries the release forward: the resulting push runs the release workflow
-# again, release-please turns the release commit into the draft release, and the build jobs take
-# over. Left open the pull request stalls, because CI cannot run on it either -- GITHUB_TOKEN is
-# not allowed to start workflows, so anything it triggers waits for a human. The pull request
-# only rewrites version.txt, CHANGELOG.md and .release-please-manifest.json.
+# Merging is what carries the release forward: the resulting push runs the release workflow again,
+# release-please turns the release commit into the draft release, and the build jobs take over.
+#
+# Getting a check onto that pull request is the awkward part. GITHUB_TOKEN may not start workflows,
+# so the pull_request run is created in action_required and never executes; a push to the branch
+# does not produce a run at all. workflow_dispatch is the exception GitHub allows, so dispatch CI on
+# the release branch and wait for it. The checks land on the pull request's head commit, which is
+# what lets required_status_checks be turned on for this repository (see MSIME-Windows#121). This
+# mirrors what MSIME-Apple's release automation already does.
 #
 # Requires GH_TOKEN, GH_REPO, RELEASE_PR (the JSON release-please emits).
 set -euo pipefail
 
 number=$(jq -er .number <<< "$RELEASE_PR")
+
+pr_json=$(gh pr view "$number" --repo "$GH_REPO" \
+    --json state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid)
+state=$(jq -er .state <<< "$pr_json")
+is_draft=$(jq -r .isDraft <<< "$pr_json")
+head_branch=$(jq -er .headRefName <<< "$pr_json")
+head_sha=$(jq -er .headRefOid <<< "$pr_json")
+base_branch=$(jq -er .baseRefName <<< "$pr_json")
+base_sha=$(jq -er .baseRefOid <<< "$pr_json")
+
+if [[ "$state" != OPEN || "$is_draft" != false || "$base_branch" != main ]]; then
+    echo "Release pull request #$number is not an open, non-draft pull request against main." >&2
+    exit 1
+fi
+if [[ "$head_branch" != release-please--* ]]; then
+    echo "Release pull request #$number has an unexpected head branch: $head_branch" >&2
+    exit 1
+fi
+
+echo "Dispatching CI for release pull request #$number at $head_sha"
+gh workflow run ci.yml --repo "$GH_REPO" --ref "$head_branch"
+
+# The run does not appear immediately, and gh has no way to ask for the run a dispatch created, so
+# poll for one on this branch at this exact commit.
+run_id=""
+for _ in $(seq 1 150); do
+    run_id=$(gh run list --repo "$GH_REPO" --workflow ci.yml --branch "$head_branch" \
+        --event workflow_dispatch --limit 20 --json databaseId,headSha \
+        --jq "map(select(.headSha == \"$head_sha\")) | first | .databaseId // empty")
+    [[ -n "$run_id" ]] && break
+    sleep 2
+done
+if [[ -z "$run_id" ]]; then
+    echo "Timed out waiting for CI to start for release pull request #$number at $head_sha." >&2
+    exit 1
+fi
+
+gh run watch "$run_id" --repo "$GH_REPO" --exit-status --interval 15
+
+# main can move while the build runs. Merging then would rebase the release commit onto something
+# that was never tested, so leave the pull request for the next release run instead.
+current_base_sha=$(gh api "repos/$GH_REPO/git/ref/heads/$base_branch" --jq .object.sha)
+if [[ "$current_base_sha" != "$base_sha" ]]; then
+    echo "main advanced while release pull request #$number was being tested; leaving it open."
+    exit 0
+fi
+
+current_head_sha=$(gh pr view "$number" --repo "$GH_REPO" --json headRefOid --jq .headRefOid)
+if [[ "$current_head_sha" != "$head_sha" ]]; then
+    echo "Release pull request #$number changed after CI completed; refusing to merge it." >&2
+    exit 1
+fi
+
 echo "Merging release pull request #$number"
 gh pr merge "$number" --repo "$GH_REPO" --merge


### PR DESCRIPTION
处理 #121 的 Windows 部分。**不需要 GitHub App 或 PAT。**

## 我之前在那个 issue 上说错了

我写过「方案一是唯一选择，必须建 GitHub App」。不对。`workflow_dispatch` 是 GitHub 允许 `GITHUB_TOKEN` 触发的例外，而 MSIME-Apple 的发布自动化一直在用这条路。

查了 Apple 的 release 分支，`workflow_dispatch` 的 run 确实存在而且成功：

```
33964544177 event=pull_request      22d00fc  success
33964544103 event=workflow_dispatch 22d00fc  success
33961255018 event=workflow_dispatch c45f8d9  success
```

## 另外两条看起来更省事的路，都不成立

**push 触发器不产生 run。** MSIME-Linux#31 已经合入，前提是「push run 不受门禁」。查了那条 release 分支上最近 6 个 run，**全部是 `pull_request` 事件，一个 `push` 都没有**——`GITHUB_TOKEN` 的 push 压根不创建 run，限制不只作用于 pull_request。那个 PR 解决不了它想解决的问题。

**审批策略不是原因。** 六个仓现在都已经是最松的 `first_time_contributors_new_to_github`，bot 触发的 run 照样被门禁。对比同一条分支上的 run，门禁完全跟着 `triggering_actor` 走：

| run | triggering_actor | 结果 |
| --- | --- | --- |
| 33965464400 | `github-actions[bot]` | `action_required` |
| 33964767082 | `houko` | `success` |
| 33962607074 | `github-actions[bot]` | `action_required` |
| 33964181639 | `houko` | `success` |

## 改动

`merge-release-pr.sh` 在合并前先 dispatch `ci.yml` 到 release 分支，按 head commit 精确轮询出那个 run，`--exit-status` 等它结束。check 挂在 PR 的 head commit 上，这正是 `required_status_checks` 需要的。

合并前会重新读一次 main 和 PR head：构建期间 main 可能前进，那时合并等于把 release commit rebase 到一个从未测试过的基上，所以宁可留着等下一轮。

`ci.yml` 加 `workflow_dispatch`，否则没法被 dispatch。**`paths-ignore` 保留**——它挡掉那个点不动的 pull_request run，只留 dispatch 的结果，避免同一个 commit 上出现两个同名 check 而结论不同。

prepare job 加 `actions: write`，没有它 `gh workflow run` 无法 dispatch。

## 合并之后

下一次发版会实际走这条路。确认 release PR 上出现四个 check 之后，就可以给本仓打开 `required_status_checks` 了，我可以接着做。

MSIME-Linux 需要同样的改动，而且要连带撤掉 #31 那个不起作用的 push 触发器——单独一个 PR。Apple 已经在用这套，#121 里关于它的分析（main 上存在没有 check 的提交）是另一回事，不受影响。
