### PR TITLE
fix(ci): find the release pull request by branch, not by prs_created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge the release pull request
-        if: ${{ github.event_name == 'push' && steps.release.outputs.prs_created == 'true' }}
+      - name: Build and merge the release pull request
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: bash scripts/ci/merge-release-pr.sh
 
       - name: Validate requested draft release

--- a/scripts/ci/merge-release-pr.sh
+++ b/scripts/ci/merge-release-pr.sh
@@ -11,10 +11,27 @@
 # what lets required_status_checks be turned on for this repository (see MSIME-Windows#121). This
 # mirrors what MSIME-Apple's release automation already does.
 #
-# Requires GH_TOKEN, GH_REPO, RELEASE_PR (the JSON release-please emits).
+# The pull request is found by branch rather than from release-please's payload. It only reports a
+# pull request as created once, but it rewrites that branch on every later push to main, and a
+# release pull request that could not be merged the first time -- main advancing mid-build is the
+# normal way that happens -- would then never be retried.
+#
+# Requires GH_TOKEN and GH_REPO.
 set -euo pipefail
 
-number=$(jq -er .number <<< "$RELEASE_PR")
+branch=$(gh api "repos/$GH_REPO/git/matching-refs/heads/release-please--" \
+    --jq '.[0].ref // empty' | sed 's|^refs/heads/||')
+if [[ -z "$branch" ]]; then
+    echo "No release branch exists; nothing to build or merge."
+    exit 0
+fi
+
+number=$(gh pr list --repo "$GH_REPO" --head "$branch" --state open --limit 1 \
+    --json number --jq '.[0].number // empty')
+if [[ -z "$number" ]]; then
+    echo "Release branch $branch has no open pull request; nothing to merge."
+    exit 0
+fi
 
 pr_json=$(gh pr view "$number" --repo "$GH_REPO" \
     --json state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid)


### PR DESCRIPTION
修 #135 里我留下的一个 bug，在 MSIME-Linux#38 上被独立发现，两边同源。

## 问题

`Merge the release pull request` 这一步的条件是 `steps.release.outputs.prs_created == 'true'`，而那个只在 release-please **首次开 PR** 时为真。

两个后果：

1. 那条分支在之后每次 push 到 main 时都会被重写，新的 head commit 拿不到 dispatch 出来的 check
2. 更严重的是，脚本本身有一条保护——构建期间 main 前进了就**故意不合并**，把 PR 留到下一轮。但下一轮 `prs_created` 是 false，这一步压根不跑。**那个 PR 会永远停在那里。**

第 2 条是我自己在 #135 里加的保护和这个条件互相作用出来的，两个单看都合理。

## 改法

用 `git/matching-refs/heads/release-please--` 找分支，再找它对应的 open PR。两种情况都覆盖到：head 被重写了就重新构建一次，PR 被留下了下次 push 就接着处理。

没有 release 分支或没有 open PR 时 exit 0，属于正常情况。