### PR TITLE
Add the third-party notices the installer never carried

### DIFF
--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,588 @@
+Metasequoia IME for Windows - Third-Party Notices
+=================================================
+
+The installer ships the TSF text service, the Server process and its helper
+executables, the WebView2 interface resources, and the dictionary and helpcode
+data. Every binary in it statically links the shared engine from MSIME-Engine,
+which is licensed under the GNU General Public License version 3, so the product
+as a whole is distributed under the GPLv3; see the LICENSE file for its full
+text.
+
+This file lists the third-party components whose code is compiled into those
+binaries, the binaries redistributed as they are, and the data files installed
+alongside them, and reproduces the license each one requires.
+
+Third-party components in the installed product
+-----------------------------------------------
+
+The TSF text service is built against the static vcpkg triplet, so what it uses
+is compiled into MetasequoiaImeTsf.dll. The Server is built against the dynamic
+triplet and the installer copies its whole build output, so the Server's
+dependencies are installed beside it as DLLs rather than linked into it.
+
+  MSIME-Engine            GPL-3.0       https://github.com/metasequoiaime/MSIME-Engine
+  MSIME-UI (msimeui)      GPL-3.0       https://github.com/metasequoiaime/MSIME-UI
+  googlepinyinime-rev     Apache-2.0    https://github.com/metasequoiaime/Google-PinyinIME-Rev
+  OpenCC                  Apache-2.0    https://github.com/byvoid/opencc
+  cpp-pinyin              Apache-2.0    https://github.com/wolfgitpr/cpp-pinyin
+  utfcpp                  BSL-1.0       https://github.com/nemtrif/utfcpp
+  fmt                     MIT           https://github.com/fmtlib/fmt
+  spdlog                  MIT           https://github.com/gabime/spdlog
+  toml++                  MIT           https://github.com/marzer/tomlplusplus
+  nlohmann/json           MIT           https://github.com/nlohmann/json
+  libcurl                 curl          https://github.com/curl/curl
+  zlib                    zlib          https://github.com/madler/zlib
+  SQLite                  public domain https://www.sqlite.org/
+  Boost                   BSL-1.0       https://www.boost.org/
+
+Binaries redistributed unmodified
+---------------------------------
+
+  WebView2Loader.dll      Microsoft Edge WebView2 SDK
+
+The Server links the WebView2 loader and the installer ships the loader DLL as
+built by Microsoft. It is redistributed under the Microsoft Software License
+Terms for the WebView2 SDK, which permit redistribution of the loader with an
+application: https://developer.microsoft.com/microsoft-edge/webview2/
+
+Interface resources
+-------------------
+
+  MSIME-UiHtml            GPL-3.0       https://github.com/metasequoiaime/MSIME-UiHtml
+
+The candidate window, floating toolbar, tray menu and settings page are HTML,
+CSS and JavaScript loaded by the Server at runtime. They are part of this
+project and carry the same license as the rest of it.
+
+------------------------------------------------------------------------------
+1. MSIME-Engine, MSIME-UI and MSIME-UiHtml - GNU General Public License version 3
+------------------------------------------------------------------------------
+
+The shared input engine, the msimeui GUI framework and the WebView2 interface
+resources are all parts of this project and are licensed under the GNU General
+Public License version 3. Its full text is reproduced in the LICENSE file at the
+root of this repository and is not duplicated here.
+
+Sources:
+  https://github.com/metasequoiaime/MSIME-Engine
+  https://github.com/metasequoiaime/MSIME-UI
+  https://github.com/metasequoiaime/MSIME-UiHtml
+
+------------------------------------------------------------------------------
+2. googlepinyinime-rev, OpenCC and cpp-pinyin - Apache License 2.0
+------------------------------------------------------------------------------
+
+googlepinyinime-rev is a continuation of the Google Pinyin IME sources; the files
+under googlepinyinime-rev/src/share are compiled into the engine. OpenCC provides
+the Simplified and Traditional Chinese conversion the Server performs on output.
+cpp-pinyin provides Han-to-pinyin conversion used by the Server.
+
+All three are distributed under the Apache License 2.0, reproduced once below.
+
+Sources:
+  https://github.com/metasequoiaime/Google-PinyinIME-Rev
+  https://github.com/byvoid/opencc
+  https://github.com/wolfgitpr/cpp-pinyin
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+3. utfcpp - Boost Software License 1.0
+------------------------------------------------------------------------------
+
+UTF-8 handling, used as a header-only library by the engine.
+
+Source: https://github.com/nemtrif/utfcpp
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+------------------------------------------------------------------------------
+4. fmt - MIT License
+------------------------------------------------------------------------------
+
+Formatting library. The engine and the TSF text service use it header-only
+(FMT_HEADER_ONLY=1, fmt::fmt-header-only), so its code is compiled into those
+binaries. The Server links the compiled target and ships its DLL.
+
+Source: https://github.com/fmtlib/fmt
+
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------------------------------------------------------------------------------
+5. spdlog - MIT License
+------------------------------------------------------------------------------
+
+Logging library. The engine uses its header-only target with
+SPDLOG_FMT_EXTERNAL; the Server links the compiled target and ships its DLL.
+
+Source: https://github.com/gabime/spdlog
+
+The MIT License (MIT)
+
+Copyright (c) 2016 - present, Gabi Melman and spdlog contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+-- NOTE: Third party dependency used by this software --
+This software depends on the fmt lib (MIT License),
+and users must comply to its license: https://raw.githubusercontent.com/fmtlib/fmt/master/LICENSE
+
+
+------------------------------------------------------------------------------
+6. Boost - Boost Software License 1.0
+------------------------------------------------------------------------------
+
+The engine links Boost::headers, so the header-only Boost components it uses are
+compiled into the binaries. The Server additionally links Boost.Locale and
+Boost.JSON, which are compiled libraries; they are built by vcpkg and their DLLs
+are installed beside the Server.
+
+Source: https://www.boost.org/
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+------------------------------------------------------------------------------
+7. toml++ - MIT License
+------------------------------------------------------------------------------
+
+Source: https://github.com/marzer/tomlplusplus
+
+MIT License
+
+Copyright (c) Mark Gillard <mark.gillard@outlook.com.au>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+8. nlohmann/json - MIT License
+------------------------------------------------------------------------------
+
+Source: https://github.com/nlohmann/json
+
+MIT License 
+
+Copyright (c) 2013-2026 Niels Lohmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+9. libcurl - curl License
+------------------------------------------------------------------------------
+
+Source: https://github.com/curl/curl
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2026, Daniel Stenberg, <daniel@haxx.se>, and many
+contributors, see the THANKS file.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization of the copyright holder.
+
+------------------------------------------------------------------------------
+10. zlib - zlib License
+------------------------------------------------------------------------------
+
+Source: https://github.com/madler/zlib
+
+Copyright notice:
+
+ (C) 1995-2026 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+------------------------------------------------------------------------------
+11. SQLite - Public Domain
+------------------------------------------------------------------------------
+
+Source: https://www.sqlite.org/
+
+SQLite is in the public domain. Its authors have dedicated the code to the
+public domain and it carries no copyright claim; see https://www.sqlite.org/copyright.html.
+
+------------------------------------------------------------------------------
+Bundled data files
+------------------------------------------------------------------------------
+
+The installer writes dictionary and helpcode data built from these repositories:
+
+  MSIME-Dict                https://github.com/metasequoiaime/MSIME-Dict
+  MSIME-HelpCode            https://github.com/metasequoiaime/MSIME-HelpCode
+
+Installed as msime.db, others.db, english.db, dict_japanese.dat, pinyin.txt and
+helpcodes/*.txt under the application data directory.
+
+Neither repository declares a license of its own, because most of their content
+is not their own work. They aggregate word lists and code tables from upstream
+projects. The upstream terms, which travel with the data, are as follows.
+
+Sources of msime.db, others.db and english.db, via MSIME-Dict:
+
+  rime-ice                GPL-3.0    https://github.com/iDvel/rime-ice
+  CustomPinyinDictionary  none       https://github.com/wuhgit/CustomPinyinDictionary
+  pinyin-data             MIT        https://github.com/mozillazg/pinyin-data
+  rime-wubi86-jidian      Apache-2.0 https://github.com/KyleBing/rime-wubi86-jidian
+  rime-jp_sela            none       https://github.com/Selaube/rime-jp_sela
+  rime_kaomoji_dict       MIT        https://github.com/aoguai/rime_kaomoji_dict
+  ECDICT                  MIT        https://github.com/skywind3000/ECDICT
+  Windows-classic-samples MIT        https://github.com/microsoft/Windows-classic-samples
+  Google count_1w         see source https://www.norvig.com/ngrams/count_1w.txt
+  OALD word forms         none       extracted headword list; rights with the dictionary's publisher
+
+The Chinese tables that msime.db is built from (cn/BaseDictAllV1Part1.txt and cn/BaseDictAllV1Part2.txt) merge rime-ice with CustomPinyinDictionary. rime-ice is licensed under the GNU General Public License version 3, which is the same license this project is distributed under, so its terms are satisfied by the distribution as a whole; this notice serves as its attribution, and its source remains available at the URL above.
+
+dict_japanese.dat is a Viterbi model built from the Mozc open source dictionary. The notice that dictionary ships with, which itself carries the IPAdic and Okinawa dictionary terms, is installed beside the model as MOZC_DICTIONARY_LICENSE.txt and is not duplicated here.
+
+  Mozc open source dictionary  https://github.com/google/mozc
+
+Sources of helpcodes/*.txt, via MSIME-HelpCode:
+
+  helpcode.txt                    lantian      蓝天小雨点 helpcode scheme
+  zrm_helpcode_big_unique.txt     ziranma      自然码, derived from
+                                               https://github.com/copperay/ZRM_Aux-code
+  shouyou2_0_helpcode.txt         shouyou2_0   首右 2.0 helpcode scheme
+  shouyouplus_helpcode.txt        shouyouplus  首右 plus helpcode scheme
+  xiaohe_helpcode.txt             xiaohe       小鹤 shape-code scheme
+
+Unresolved: CustomPinyinDictionary, rime-jp_sela and ZRM_Aux-code publish no license; the English word list in english.db includes word forms extracted from a commercial dictionary, whose rights belong to its publisher; and the helpcode tables reproduce input schemes whose rights belong to their respective authors. Redistributors who need an explicit grant for those parts should raise it with the Metasequoia IME maintainers rather than assume one. This notice will be updated as those terms are clarified.

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -34,6 +34,7 @@ dependencies are installed beside it as DLLs rather than linked into it.
   zlib                    zlib          https://github.com/madler/zlib
   SQLite                  public domain https://www.sqlite.org/
   Boost                   BSL-1.0       https://www.boost.org/
+  miniaudio               MIT-0         https://github.com/mackron/miniaudio
 
 Binaries redistributed unmodified
 ---------------------------------
@@ -540,6 +541,34 @@ Source: https://www.sqlite.org/
 
 SQLite is in the public domain. Its authors have dedicated the code to the
 public domain and it carries no copyright claim; see https://www.sqlite.org/copyright.html.
+
+------------------------------------------------------------------------------
+12. miniaudio - MIT No Attribution
+------------------------------------------------------------------------------
+
+Audio capture and playback for the voice input feature. It is vendored as a single header at
+src/voice-input/third_party/miniaudio.h in MSIME-Server and compiled into the Server, so its code is
+redistributed in the installer. Its author offers a choice of the Unlicense or MIT-0; MIT-0 is taken
+here and reproduced below.
+
+Source: https://github.com/mackron/miniaudio
+
+Copyright 2025 David Reid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ------------------------------------------------------------------------------
 Bundled data files


### PR DESCRIPTION
## Why

The installer ships the engine, the Server and its dependency DLLs, the WebView2 interface resources, and the dictionary and helpcode data. This repository had no third-party notice file at all.

`MSIME-Linux` and `MSIME-Apple` both carry one. Windows is the platform with the most users and the largest redistributed surface, and it carried none.

The concrete obligation is rime-ice: it is GPL-3.0, it requires attribution, and its content forms the bulk of `msime.db`. `MSIME-Dict`'s `NOTICE.md` records that requirement and, until now, recorded that this repository did not meet it (metasequoiaime/MSIME-Dict#13).

## Where the text comes from

The Apache-2.0, Boost and MIT license texts are the ones already reviewed in `MSIME-Linux/THIRD_PARTY_NOTICES.txt`, not newly transcribed. The curl, zlib, toml++ and nlohmann/json texts come from those projects' own `LICENSE` files.

## What is deliberately not copied from Linux

The component descriptions. The two builds differ in a way that matters for a notice:

| | vcpkg triplet | consequence |
|---|---|---|
| TSF text service | `x64-windows-static` / `x86-windows-static` | dependencies compiled into `MetasequoiaImeTsf.dll` |
| Server | `x64-windows` | dependencies installed beside it as DLLs |

`Prepare-PackageFiles.ps1` copies the Server's entire build output, so fmt, spdlog, Boost.Locale, Boost.JSON, SQLite, libcurl and zlib are redistributed as binaries. On Linux those same libraries come from the distribution and the notice says explicitly that they are *not* redistributed — reusing that wording here would have stated the opposite of what happens.

`WebView2Loader.dll` is likewise shipped as Microsoft built it, so it is listed under its SDK terms.

`dict_japanese.dat` is covered by reference rather than duplication: the Mozc dictionary notice, which itself carries the IPAdic and Okinawa dictionary terms, is already installed beside the model as `MOZC_DICTIONARY_LICENSE.txt`.

## Follow-up

This file only reaches users once the installer packages it. That is metasequoiaime/MSIME-Installer#3, which asserts this file's presence, so land this one first.
