### PR TITLE
Let the book title nest pair actually run

### DIFF
--- a/src/Composition/CompositionProcessorEngine.cpp
+++ b/src/Composition/CompositionProcessorEngine.cpp
@@ -665,14 +665,18 @@ const WCHAR *CCompositionProcessorEngine::GetPunctuation(WCHAR wch)
         }
         if (pPuncNestPair->_punctuation_end._Code == wch)
         {
+            // An unmatched closing mark must leave the depth at zero. Decrementing past it would make
+            // the next opening mark produce the inner 〈 instead of 《, and the count would never
+            // recover without an equal number of extra openings.
+            if (pPuncNestPair->_nestCount == 0)
+            {
+                return pPuncNestPair->_punctuation_end._Punctuation;
+            }
             if (--pPuncNestPair->_nestCount == 0)
             {
                 return pPuncNestPair->_punctuation_end._Punctuation;
             }
-            else
-            {
-                return pPuncNestPair->_pairPunctuation_end;
-            }
+            return pPuncNestPair->_pairPunctuation_end;
         }
     }
     return 0;

--- a/src/Global/Globals.cpp
+++ b/src/Global/Globals.cpp
@@ -247,7 +247,10 @@ extern const WCHAR FullWidthCharTable[] = {
 //---------------------------------------------------------------------
 // defined punctuation characters
 //---------------------------------------------------------------------
-extern const struct _PUNCTUATION PunctuationTable[25] = {
+// '<' and '>' are deliberately absent: they belong to the nest pair set up in
+// SetupPunctuationPair, and GetPunctuation searches this table first. Listing them here
+// would shadow the nest pair, and the nested marks would never be produced.
+extern const struct _PUNCTUATION PunctuationTable[23] = {
     {L'`', L"·"},   // ·
     {L'~', L"~"},   // ~
     {L'!', L"！"},  // ！
@@ -269,9 +272,7 @@ extern const struct _PUNCTUATION PunctuationTable[25] = {
     {L';', L"；"},  // ；
     {L':', L"："},  // ：
     {L',', L"，"},  // ，
-    {L'<', L"《"},  // 《
     {L'.', L"。"},  // 。
-    {L'>', L"》"},  // 》
     {L'?', L"？"},  // ？
 };
 

--- a/src/Global/Globals.h
+++ b/src/Global/Globals.h
@@ -127,7 +127,7 @@ extern const GUID MetasequoiaIMEGuidCompartmentDoubleSingleByte;
 extern const GUID MetasequoiaIMEGuidCompartmentPunctuation;
 
 extern const WCHAR FullWidthCharTable[];
-extern const struct _PUNCTUATION PunctuationTable[25];
+extern const struct _PUNCTUATION PunctuationTable[23];
 extern const std::unordered_set<WCHAR> CommitWithHighlightedCandPunc;
 
 extern const GUID MetasequoiaIMEGuidLangBarIMEMode;


### PR DESCRIPTION
## The defect

`SetupPunctuationPair` builds a nest pair so that book title marks nest — outer `《》`, inner `〈〉`:

```cpp
CPunctuationNestPair punc_angle_bracket(L'<', L"《", L"〈", L'>', L"》", L"〉");
```

It never ran. `GetPunctuation` searches in this order:

1. `Global::PunctuationTable` — returns on first match
2. `_PunctuationPair`
3. `_PunctuationNestPair`

and the table listed `{L'<', L"《"}` and `{L'>', L"》"}`. Both keys resolved at step 1, so step 3 was unreachable for them and `〈` `〉` could not be produced at all.

The quote pairs are unaffected and always worked, because `"` and `'` are *not* in the table.

## The fix

Removing those two entries makes the nest pair reachable.

Routing is unaffected: `IsPunctuation` checks the pair and nest pair lists in addition to the table, and its nest-pair branch covers both `_punctuation_begin` and `_punctuation_end`, so both keys are still recognised as punctuation. Both loops over the table use `ARRAYSIZE`, so shortening the array needs no other edit; only the extern declaration in `Globals.h` changes with it.

## A second bug the fix would have exposed

The closing branch decremented unconditionally:

```cpp
if (--pPuncNestPair->_nestCount == 0)
```

With the shadowing in place this was unreachable. Once the nest pair runs, a `>` typed with nothing open takes `_nestCount` to `-1` (it is `int`, so it goes negative rather than wrapping). The next `<` then fails its `_nestCount++ == 0` check and emits the inner `〈` instead of `《`, and the depth never recovers unless the spurious openings are matched.

It now returns the outer mark and leaves the depth at zero. Fixing the shadowing without this would have traded one wrong behaviour for another.

## Consistency

`MSIME-Linux` already nests correctly and already guards the counter. `MSIME-Engine` gains both in metasequoiaime/MSIME-Engine#21, which is what `MSIME-Apple` consumes. After the two land, all four implementations agree.

## Verification

Not built locally — the TSF text service is Windows-only and this machine is macOS, so CI is the verification. The change is three edits: two table entries removed, the extern's size updated with them, and a guard added.

Note for reviewers: this repository stores these files with CRLF while a common local `core.autocrlf=input` rewrites them to LF on staging, which turns a three-line edit into a whole-file diff. The commit here was staged with `core.autocrlf=false` so the diff is the actual change.
