### PR TITLE
fix(release): 语言文件装到真正的 Inno Setup 目录,修掉八个版本都卡住的打包失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,28 @@ jobs:
         run: cmake --build build --config Release --parallel
       - name: Test the wire contract on this architecture
         run: ctest --test-dir build -C Release --output-on-failure
+
+      # The release job's only Inno Setup input is this language file, and it landed next to the
+      # Chocolatey shim instead of in the Inno Setup installation for eight releases in a row: the
+      # script reported success and packaging failed later with an unrelated-looking include error.
+      # Compiling a script that resolves compiler:Languages\ChineseSimplified.isl is the assertion
+      # that the file is somewhere ISCC actually looks, and it costs seconds on an image that
+      # already has Inno Setup. Architecture-independent, so it runs once.
+      - name: Check the installer language file lands where ISCC looks
+        if: ${{ matrix.name == 'x64' }}
+        shell: pwsh
+        run: |
+          ./scripts/ci/install-inno-language.ps1
+          $probe = Join-Path $env:RUNNER_TEMP 'language-probe.iss'
+          @(
+            '[Setup]'
+            'AppName=Language probe'
+            'AppVersion=1.0'
+            'DefaultDirName={autopf}\LanguageProbe'
+            "OutputDir=$env:RUNNER_TEMP"
+            'OutputBaseFilename=language-probe'
+            '[Languages]'
+            'Name: "chinesesimplified"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"'
+          ) | Set-Content -Path $probe -Encoding UTF8
+          ISCC.exe $probe
+          if ($LASTEXITCODE -ne 0) { throw "ISCC could not resolve compiler:Languages\ChineseSimplified.isl" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,27 +56,8 @@ jobs:
       - name: Test the wire contract on this architecture
         run: ctest --test-dir build -C Release --output-on-failure
 
-      # The release job's only Inno Setup input is this language file, and it landed next to the
-      # Chocolatey shim instead of in the Inno Setup installation for eight releases in a row: the
-      # script reported success and packaging failed later with an unrelated-looking include error.
-      # Compiling a script that resolves compiler:Languages\ChineseSimplified.isl is the assertion
-      # that the file is somewhere ISCC actually looks, and it costs seconds on an image that
-      # already has Inno Setup. Architecture-independent, so it runs once.
+      # Architecture-independent, so it runs once rather than on both matrix legs.
       - name: Check the installer language file lands where ISCC looks
         if: ${{ matrix.name == 'x64' }}
         shell: pwsh
-        run: |
-          ./scripts/ci/install-inno-language.ps1
-          $probe = Join-Path $env:RUNNER_TEMP 'language-probe.iss'
-          @(
-            '[Setup]'
-            'AppName=Language probe'
-            'AppVersion=1.0'
-            'DefaultDirName={autopf}\LanguageProbe'
-            "OutputDir=$env:RUNNER_TEMP"
-            'OutputBaseFilename=language-probe'
-            '[Languages]'
-            'Name: "chinesesimplified"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"'
-          ) | Set-Content -Path $probe -Encoding UTF8
-          ISCC.exe $probe
-          if ($LASTEXITCODE -ne 0) { throw "ISCC could not resolve compiler:Languages\ChineseSimplified.isl" }
+        run: ./scripts/ci/check-inno-language.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,9 +325,6 @@ jobs:
       contents: write
     env:
       DICTIONARY_TAG: ${{ needs.dependencies.outputs.dictionary_tag }}
-      # jrsoftware/issrc pinned by commit, with the checksum of the file at that commit.
-      ISL_URL: https://raw.githubusercontent.com/jrsoftware/issrc/1ae7bf81dc0d2013235dfe4bb0b6f4e4a0b6b25c/Files/Languages/ChineseSimplified.isl
-      ISL_SHA256: e0b0b350e2245f3c5e65586dfe43d574f6e7f06f2261149aba284954b3fc9a8d
     steps:
       - name: Check out MSIME-Windows at the release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,8 @@ release workflow 里的每一段 shell 都抽在 `scripts/ci/` 下，workflow �
 | `download-dictionaries.sh` | 从 MSIME-Dict 的 `dict-*` release 拉词库并校验 SHA256 |
 | `detect-release-signing.ps1` | 判定签名模式，决定产物后缀 |
 | `sign-binaries.ps1` | 用仓库 secret 里的真证书签名，包内二进制和安装包共用 |
-| `install-inno-language.ps1` | 补 runner 上缺失的 `ChineseSimplified.isl`，按 commit + SHA256 固定 |
+| `install-inno-language.ps1` | 补 runner 上缺失的 `ChineseSimplified.isl`，按 commit + SHA256 固定。装到真正的 Inno Setup 安装目录，不是 Chocolatey shim 旁边 |
+| `check-inno-language.ps1` | CI 用：编译一个只含 `[Languages]` 的探针脚本，让 ISCC 自己回答语言文件放对没有 |
 | `name-installer-asset.ps1` | 定最终产物名、算校验和、写 step summary |
 | `revalidate-draft-release.sh` | 发布前复查 draft 仍指向被构建的那个 commit |
 | `publish-release.sh` | 上传产物、追加说明、发布 |

--- a/scripts/ci/check-inno-language.ps1
+++ b/scripts/ci/check-inno-language.ps1
@@ -1,0 +1,35 @@
+# Prove ISCC can resolve the Chinese language file, by compiling a script that needs it.
+#
+# install-inno-language.ps1 used to write the file next to the Chocolatey ISCC shim rather than into
+# the Inno Setup installation, report success, and let packaging fail several steps later with an
+# include error naming a path nothing had written to. Eight releases went out as unpublished drafts
+# before anybody connected the two.
+#
+# Asserting the file exists where install-inno-language.ps1 put it would only restate that script's
+# own belief about where ISCC looks, which is precisely the thing that was wrong. Compiling a script
+# whose only content is a [Languages] entry pointing at compiler:Languages\ChineseSimplified.isl is
+# what makes ISCC answer the question. Seconds on an image that already ships Inno Setup.
+$ErrorActionPreference = 'Stop'
+
+& "$PSScriptRoot/install-inno-language.ps1"
+
+$output = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+$probe = Join-Path $output 'language-probe.iss'
+
+@(
+    '[Setup]'
+    'AppName=Language probe'
+    'AppVersion=1.0'
+    'DefaultDirName={autopf}\LanguageProbe'
+    "OutputDir=$output"
+    'OutputBaseFilename=language-probe'
+    '[Languages]'
+    'Name: "chinesesimplified"; MessagesFile: "compiler:Languages\ChineseSimplified.isl"'
+) | Set-Content -Path $probe -Encoding UTF8
+
+ISCC.exe $probe
+if ($LASTEXITCODE -ne 0) {
+    throw "ISCC could not resolve compiler:Languages\ChineseSimplified.isl (exit code $LASTEXITCODE)"
+}
+
+Write-Host 'ISCC resolved compiler:Languages\ChineseSimplified.isl'

--- a/scripts/ci/install-inno-language.ps1
+++ b/scripts/ci/install-inno-language.ps1
@@ -1,15 +1,53 @@
-# Put the Chinese language file next to the Inno Setup compiler.
+# Put the Chinese language file where the Inno Setup compiler will actually look for it.
 #
 # msime_setup.iss declares a chinesesimplified language pointing at
 # compiler:Languages\ChineseSimplified.isl, and the Inno Setup on the runner does not ship that
 # file, so ISCC aborts on the [Languages] section. Pinned by commit and checksum rather than
 # tracking a branch, so the installer's Chinese text cannot change under a rebuild.
 #
-# Requires ISL_URL and ISL_SHA256.
+# "Where ISCC.exe is" is not the answer. On the windows-2025 image Inno Setup comes from Chocolatey
+# and `Get-Command ISCC.exe` resolves to the shim at C:\ProgramData\Chocolatey\bin\ISCC.exe, so
+# deriving the directory from it installed the file to C:\ProgramData\Chocolatey\bin\Languages\.
+# ISPP resolves compiler: against the real installation, which is why every release build reported
+# "Installed ... ChineseSimplified.isl" and then failed two steps later with "Couldn't open include
+# file c:\program files (x86)\inno setup 6\Languages\ChineseSimplified.isl".
+#
+# So find the installation by a file only it has, and refuse to guess. Getting this wrong silently
+# is what made it cost a whole release cycle to notice.
 $ErrorActionPreference = 'Stop'
 
-$iscc = Get-Command 'ISCC.exe' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-$root = if ($iscc) { Split-Path $iscc.Source -Parent } else { 'C:\Program Files (x86)\Inno Setup 6' }
+# The pin lives here rather than in the workflow so that ci.yml can run this script as a regression
+# check without keeping a second copy of the URL and digest in step with this one.
+$url = 'https://raw.githubusercontent.com/jrsoftware/issrc/1ae7bf81dc0d2013235dfe4bb0b6f4e4a0b6b25c/Files/Languages/ChineseSimplified.isl'
+$expected = 'e0b0b350e2245f3c5e65586dfe43d574f6e7f06f2261149aba284954b3fc9a8d'
+
+# Present in the installation directory and absent from a shim directory.
+$markers = @('ISPPBuiltins.iss', 'Default.isl')
+
+$candidates = [System.Collections.Generic.List[string]]::new()
+foreach ($key in @(
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 6_is1',
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Inno Setup 6_is1')) {
+    $location = (Get-ItemProperty -Path $key -Name 'InstallLocation' -ErrorAction SilentlyContinue).InstallLocation
+    if ($location) { $candidates.Add($location.TrimEnd('\')) }
+}
+foreach ($base in @(${env:ProgramFiles(x86)}, $env:ProgramFiles)) {
+    if ($base) { $candidates.Add((Join-Path $base 'Inno Setup 6')) }
+}
+foreach ($command in @(Get-Command 'ISCC.exe' -CommandType Application -ErrorAction SilentlyContinue)) {
+    $candidates.Add((Split-Path $command.Source -Parent))
+}
+
+$root = $candidates |
+    Where-Object { $_ -and (Test-Path $_) } |
+    Where-Object { $directory = $_; $markers | Where-Object { Test-Path (Join-Path $directory $_) } } |
+    Select-Object -First 1
+
+if (-not $root) {
+    throw "Could not find the Inno Setup installation. Looked in: $($candidates -join '; ')"
+}
+Write-Host "Inno Setup installation: $root"
+
 $languages = Join-Path $root 'Languages'
 $target = Join-Path $languages 'ChineseSimplified.isl'
 
@@ -19,12 +57,12 @@ if (Test-Path $target) {
 }
 
 New-Item -ItemType Directory -Path $languages -Force | Out-Null
-Invoke-WebRequest -Uri $env:ISL_URL -OutFile $target -MaximumRetryCount 3 -RetryIntervalSec 5
+Invoke-WebRequest -Uri $url -OutFile $target -MaximumRetryCount 3 -RetryIntervalSec 5
 
 $actual = (Get-FileHash $target -Algorithm SHA256).Hash.ToLower()
-if ($actual -ne $env:ISL_SHA256) {
+if ($actual -ne $expected) {
     Remove-Item $target -Force
-    throw "ChineseSimplified.isl checksum mismatch: expected $env:ISL_SHA256, got $actual"
+    throw "ChineseSimplified.isl checksum mismatch: expected $expected, got $actual"
 }
 
 Write-Host "Installed $target ($((Get-Item $target).Length) bytes)"


### PR DESCRIPTION
`#146` 只合进了第一个提交,这两个还没上 main。这才是「现在全是 draft」的真正原因。

## 病因

自打包流水线落地起,**每一次** release 构建都停在 `Compile the installer`:

```
Error on line 63 in msime_setup.iss: Couldn't open include file
"c:\program files (x86)\inno setup 6\Languages\ChineseSimplified.isl"
```

`install-inno-language.ps1` 用 `Get-Command ISCC.exe` 推目标目录。windows-2025 镜像上 Inno Setup 来自 Chocolatey,于是解析到 shim `C:\ProgramData\Chocolatey\bin\ISCC.exe`,文件被写到 `C:\ProgramData\Chocolatey\bin\Languages\`。而 ISPP 的 `compiler:` 是相对**真实安装目录**解析的。

这个 bug 能活过八个版本,是因为它伪装得很好:那一步打印 `Installed ... (21516 bytes)` 并且 exit 0,失败发生在两步之后,报的还是一个从来没人写过的路径。

## 修法

按「只有真实安装目录才有的文件」来定位——`ISPPBuiltins.iss` 或 `Default.isl`,shim 旁边都没有。依次查卸载注册表键、两个 Program Files 位置、以及 PATH 上的任何 `ISCC.exe`;都找不到就带着尝试过的清单报错,不再回退到猜测。

回归检查不是「断言文件存在于本脚本算出来的路径」——那只是把脚本自己的信念复述一遍,而错的恰恰就是那个信念。改成编译一个只含 `[Languages]` 指向 `compiler:Languages\ChineseSimplified.isl` 的探针脚本,让 ISCC 自己回答。URL 和摘要的 pin 从 workflow 挪进脚本,免得这个检查再抄一份。

探针那段 shell 抽在 `scripts/ci/check-inno-language.ps1`,和本仓其它 CI 脚本一致,workflow 里只剩一行调用。

## 验证

在分支上 dispatch 了一次 CI(`33977477449`),五个 check 全绿。新检查的实际输出:

```
Inno Setup installation: C:\Program Files (x86)\Inno Setup 6
Installed C:\Program Files (x86)\Inno Setup 6\Languages\ChineseSimplified.isl (21516 bytes)
Successful compile (1.125 sec).
ISCC resolved compiler:Languages\ChineseSimplified.isl
```

对照修改前的同一行:`Installed C:\ProgramData\Chocolatey\bin\Languages\ChineseSimplified.isl`。落点变了,而且 ISCC 确认能找到。
