### PR TITLE
fix: finish local monorepo packaging and required Windows checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           python3 scripts/product_lock.py outputs --github-output "$GITHUB_OUTPUT"
 
   windows:
-    name: Windows tip ${{ matrix.name }}
+    name: Windows ${{ matrix.name }}
     runs-on: windows-2025
     strategy:
       fail-fast: false

--- a/installer/Prepare-PackageFiles.ps1
+++ b/installer/Prepare-PackageFiles.ps1
@@ -2,14 +2,12 @@
 param(
     [string]$TargetVersion = '0.0.1',
     [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
-    # Source checkouts are addressed by directory name under $RepoRoot. The defaults are the
-    # historical names, which is what MSIME-Windows' release workflow stages its checkouts as and
-    # what a local side-by-side clone looks like. They are parameters so that a caller using the
-    # current repository names does not have to rename directories to satisfy this script.
+    # Component paths are relative to RepoRoot. CI and local product scripts pass windows/,
+    # server/ and ui-html/ explicitly; the standalone historical names remain valid overrides.
     [string]$TsfDirectory = 'MetasequoiaImeTsf',
     [string]$ServerDirectory = 'MetasequoiaImeServer',
     [string]$UiHtmlDirectory = 'MetasequoiaImeUiHtml',
-    [string]$HelpCodeDirectory = 'MetasequoiaImeEngine/helpcode',
+    [string]$HelpCodeDirectory = 'vendor/MetasequoiaImeEngine/helpcode',
     [string]$DictionaryDirectory = 'MetasequoiaImeDict',
     # THIRD_PARTY_NOTICES.txt used to sit next to the tip's sources. In the consolidated repository
     # the notice covers the whole product and lives at the root, one level above windows/, so where

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,6 +1,6 @@
 # Metasequoia IME Installer
 
-本仓的脚本从相邻源码仓库收集产物、签名、用 Inno Setup 打成安装包。它服务两条流程：
+本目录的脚本从 Windows 合仓目录收集产物、签名、用 Inno Setup 打成安装包。它服务两条流程：
 
 - **正式发布**：由 `MSIME-Windows` 的 release workflow 驱动，用真实证书，产物是挂在 Release 上的 `MetasequoiaIME_Setup_v<版本>.exe`。见下面「CI 契约」
 - **本地测试**：手工跑，用本机自签名证书，用来在自己机器上验证安装流程。本文其余部分讲的是这条
@@ -13,9 +13,9 @@
 
 ## CI 契约
 
-根 `.github/workflows/release.yml` **不加修改地调用本目录的 `Prepare-PackageFiles.ps1` 和 `Compile-Installer.ps1`**。源目录名是 `Prepare-PackageFiles.ps1` 的参数，不是写死在脚本里的字面量：默认值仍是历史目录名（`MetasequoiaImeTsf`、`MetasequoiaImeServer`、`MetasequoiaImeUiHtml`、`MetasequoiaImeHelpCode`、`MetasequoiaImeDict`），`tests/package-files.ps1` 的 fixture 就按默认值搭。
+根 `.github/workflows/release.yml` **不加修改地调用本目录的 `Prepare-PackageFiles.ps1` 和 `Compile-Installer.ps1`**。源目录名是 `Prepare-PackageFiles.ps1` 的参数，不是写死在脚本里的字面量：TSF、Server 和页面仍支持历史目录默认值；当前 workflow 与 `tests/package-files.ps1` 均显式使用 `windows/`、`server/`、`ui-html/` 和仓根授权文件。辅助码默认读取 `vendor/MetasequoiaImeEngine/helpcode/`，词库缓存位于 `MetasequoiaImeDict/out/`。
 
-合仓后 release workflow 传的是本仓的目录名，词库和辅助码仍从仓外取，落在仓根：
+合仓后 release workflow 传的是本仓的目录名，辅助码随固定 Engine gitlink 检出，词库按产品锁下载到仓根缓存：
 
 ```powershell
 pwsh -File ./Prepare-PackageFiles.ps1 -TargetVersion 1.2.3 -RepoRoot .. `
@@ -28,7 +28,7 @@ pwsh -File ./Prepare-PackageFiles.ps1 -TargetVersion 1.2.3 -RepoRoot .. `
 - **改动 `Prepare-PackageFiles.ps1` 里那些 `Assert-PathExists` 的源路径，会直接弄坏发布流水线。** 它断言的源路径由 workflow 逐一准备，改了要同步改 `.github/workflows/release.yml`。目录名本身可以由调用方指定，但每个目录内部的相对路径（如 `build-release\bin\Release`）仍是硬契约
 - **`THIRD_PARTY_NOTICES.txt` 从 `-NoticesDirectory` 指向的目录取，随安装包装到程序目录。** 合仓后这份声明覆盖整个产品、放在仓根，所以它和 `-TsfDirectory` 分成了两个参数。词库主体含 rime-ice（GPL-3.0）内容，其许可要求保留署名，所以这份文件缺失会让打包直接失败，而不是静默跳过
 - **`Sign-PackageBinaries-Local.ps1` 和 `Sign-Installer-Local.ps1` 只用于本地验证，CI 不会调用它们。** 它们创建本机自签名证书并尝试写入受信任存储，正式发布走 workflow 里用仓库 secret 中真实证书的签名步骤
-- 词库不再从相邻的 `MetasequoiaImeDict` 工作目录取，CI 从 `MSIME-Dict` 的 `dict-*` release 下载并校验 SHA256，再放到脚本期望的位置
+- 词库不再从相邻的 `MetasequoiaImeDict` 工作目录取，CI 从 `MSIME-Engine` 的 `dict-*` release 下载并校验 SHA256，再放到脚本期望的位置
 - `windows-2025` runner 自带 Inno Setup 6.7.1，`Compile-Installer.ps1` 能自己找到 `ISCC.exe`。但它不带 `ChineseSimplified.isl`，`msime_setup.iss` 的 `[Languages]` 段依赖那个文件，所以 workflow 会在编译前按固定 revision 和校验和把它装进去
 
 ## 依赖
@@ -36,44 +36,26 @@ pwsh -File ./Prepare-PackageFiles.ps1 -TargetVersion 1.2.3 -RepoRoot .. `
 - Windows 10/11，PowerShell 7（`pwsh`）
 - [Inno Setup](https://jrsoftware.org/isinfo.php) 6.6 或更高版本
 - Windows SDK（提供 `signtool.exe`）
-- 下列源码仓库需要你自己准备，并先完成 Release 编译 / 词库构建：
-  - `MetasequoiaImeTsf`（或用 `-TsfDirectory` 指定实际目录名，下同）
-  - `MetasequoiaImeServer`
-  - `MetasequoiaImeUiHtml`
-  - `MetasequoiaImeHelpCode`
-  - `MetasequoiaImeDict`
+- 先初始化本仓 submodule，并完成 `windows/`、`server/` 的 Release 编译以及 `ui-html/` 设置页构建。
+- 在仓库根目录运行 `python scripts/product_lock.py fetch-dictionaries --staging-root .`，下载并验证产品锁中的词库。
+- `vendor/MetasequoiaImeEngine/helpcode/helpcodes/` 随引擎检出，无需旧 HelpCode 仓库。
 
-## 本地跑之前请先改路径
+## 本地打包路径
 
-下面这段只针对本地测试；CI 不需要改路径，因为它就是按这些名字准备目录的。
-
-脚本里写死的默认布局是：本仓库和上面那些项目都在**同一个父目录**下（例如都在 `IMECodes\` 里）。这只是作者本机的相对路径，**换到你自己的机器上通常对不上**。
-
-请按自己的目录改这些地方，尤其是收集安装文件时的复制源：
-
-- `Prepare-PackageFiles.ps1`：`$serverRelease`、`$tsf32Release`、`$tsf64Release`、`$webviewRoot`、`$helpcodeSource`、词库 `msime.db` / `english.db` 等，都是从其他项目里 **Copy** 过来的。路径不对就会直接报“不存在”。
-- `test.ps1`：TSF / Server 的编译脚本、设置页的 `pnpm run build` 目录同样要改。
-
-如果只是父目录不同、各子项目文件夹名没变，可以不改脚本，运行时传入：
-
-```powershell
-pwsh -File .\Prepare-PackageFiles.ps1 -RepoRoot "D:\your\src"
-```
-
-子项目不在同一父目录、或编译输出目录和默认不一致时，请直接改脚本里的那些路径。
+从 `installer/` 运行上面的带参数打包命令即可。`-RepoRoot` 指向 MSIME-Windows 根目录；目录不同时通过参数指定，无需编辑脚本中的复制路径。
 
 ## 一键测试
 
-先确认上一节的路径已经改成你本机的。然后在管理员 PowerShell 中（把本机测试证书写入受信任存储需要提升权限）：
+先准备上述构建依赖与锁定词库。然后在管理员 PowerShell 中（把本机测试证书写入受信任存储需要提升权限）：
 
 ```powershell
-cd path\to\msime-installer
+cd path\to\MSIME-Windows\installer
 pwsh -File .\test.ps1
 ```
 
 `test.ps1` 会按顺序做这些事：
 
-1. 若找到相邻仓库，则编译 TSF、Server，并构建设置页
+1. 编译本仓 TSF、Server，并构建设置页；缺少组件入口则失败
 2. `Prepare-PackageFiles.ps1` — 收集 `server_exe\`、`tsf_dll\`、`app_data\`，并把 `msime_setup.iss` 的版本写成 `0.0.1`
 3. `Sign-PackageBinaries-Local.ps1` — 本机自签名包内 EXE/DLL
 4. `Compile-Installer.ps1` — 编译出 `Output\MetasequoiaIME_Setup_v0.0.1.exe`

--- a/installer/tests/package-files.ps1
+++ b/installer/tests/package-files.ps1
@@ -13,45 +13,45 @@ try {
     Copy-Item (Join-Path $PSScriptRoot '../msime_setup.iss') $installer
     Copy-Item (Join-Path $PSScriptRoot '../default_config') $installer -Recurse
     foreach ($file in @(
-        'MetasequoiaImeServer/build-release/bin/Release/MetasequoiaImeServer.exe',
-        'MetasequoiaImeServer/build-release/bin/Release/MetasequoiaImeDictionaryReplay.exe',
-        'MetasequoiaImeServer/build-release/bin/Release/MetasequoiaImeServerTests.exe',
-        'MetasequoiaImeTsf/build32-release/Release/MetasequoiaImeTsf.dll',
-        'MetasequoiaImeTsf/build64-release/Release/MetasequoiaImeTsf.dll',
-        'MetasequoiaImeTsf/THIRD_PARTY_NOTICES.txt',
-        'MetasequoiaImeServer/assets/config/config.toml',
-        'MetasequoiaImeServer/src/resource/MetasequoiaIME.ico',
-        'MetasequoiaImeEngine/helpcode/helpcodes/helpcode.txt',
+        'server/build-release/bin/Release/MetasequoiaImeServer.exe',
+        'server/build-release/bin/Release/MetasequoiaImeDictionaryReplay.exe',
+        'server/build-release/bin/Release/MetasequoiaImeServerTests.exe',
+        'windows/build32-release/Release/MetasequoiaImeTsf.dll',
+        'windows/build64-release/Release/MetasequoiaImeTsf.dll',
+        'THIRD_PARTY_NOTICES.txt',
+        'server/assets/config/config.toml',
+        'server/src/resource/MetasequoiaIME.ico',
+        'vendor/MetasequoiaImeEngine/helpcode/helpcodes/helpcode.txt',
         'MetasequoiaImeDict/out/msime.db',
         'MetasequoiaImeDict/out/others.db',
         'MetasequoiaImeDict/out/dict_japanese.dat',
         'MetasequoiaImeDict/source/mozc_dictionary_oss/README.txt',
-        'MetasequoiaImeUiHtml/webview2/shared/runtime.js',
-        'MetasequoiaImeUiHtml/webview2/candwnd/index.html',
-        'MetasequoiaImeUiHtml/webview2/menu/index.html',
-        'MetasequoiaImeUiHtml/webview2/ftb/index.html',
-        'MetasequoiaImeUiHtml/webview2/settings/ime-settings/dist/index.html'
+        'ui-html/webview2/shared/runtime.js',
+        'ui-html/webview2/candwnd/index.html',
+        'ui-html/webview2/menu/index.html',
+        'ui-html/webview2/ftb/index.html',
+        'ui-html/webview2/settings/ime-settings/dist/index.html'
     )) { Write-Fixture $file }
-    Write-Fixture 'MetasequoiaImeServer/assets/tables/pinyin.txt' 'xing'
+    Write-Fixture 'server/assets/tables/pinyin.txt' 'xing'
     Write-Fixture 'MetasequoiaImeDict/out/dictionary-manifest.json' '{"manifest_version":1}'
     $english = Join-Path $fixture 'MetasequoiaImeDict/out/english.db'
     python -c "import sqlite3,sys; sqlite3.connect(sys.argv[1]).execute('CREATE TABLE english_words(word TEXT,display TEXT,weight INTEGER,PRIMARY KEY(word,display))')" $english
     if ($LASTEXITCODE -ne 0) { throw 'Failed to create packaging fixture' }
-    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TargetVersion '2026.9.1'
+    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory . -TargetVersion '2026.9.1'
     foreach ($file in @('app_data/html/webview2/shared/runtime.js', 'app_data/dictionary-manifest.json',
                          'tsf_dll/32/MetasequoiaImeTsf.dll', 'tsf_dll/64/MetasequoiaImeTsf.dll',
-                         'THIRD_PARTY_NOTICES.txt', 'app_data/helpcodes/helpcode.txt')) {
+                         'app_data/helpcodes/helpcode.txt', 'THIRD_PARTY_NOTICES.txt')) {
         if (-not (Test-Path (Join-Path $installer $file))) { throw "Missing packaged file: $file" }
     }
     if (Test-Path (Join-Path $installer 'server_exe/MetasequoiaImeServerTests.exe')) { throw 'Packaged a test executable' }
     $database = Join-Path $installer 'app_data/msime.db'
     [IO.File]::WriteAllText($database, 'preserved user data')
-    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -Light
+    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory . -Light
     if ([IO.File]::ReadAllText($database) -ne 'preserved user data') { throw 'Light package replaced dictionary data' }
     if (-not (Test-Path (Join-Path $installer 'app_data/html/webview2/shared/runtime.js'))) { throw 'Light package lost shared contracts' }
-    Remove-Item (Join-Path $fixture 'MetasequoiaImeUiHtml/webview2/shared') -Recurse -Force
+    Remove-Item (Join-Path $fixture 'ui-html/webview2/shared') -Recurse -Force
     $rejected = $false
-    try { & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture } catch { $rejected = $true }
+    try { & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory . } catch { $rejected = $true }
     if (-not $rejected) { throw 'Missing shared contracts were accepted' }
     if ([IO.File]::ReadAllText($database) -ne 'preserved user data') { throw 'Rejected package damaged previous staging' }
     Write-Host 'Full/light package contracts, provenance, exclusions and failure staging passed'

--- a/scripts/ci/test-server.ps1
+++ b/scripts/ci/test-server.ps1
@@ -14,6 +14,8 @@ if (-not (Test-Path -LiteralPath $helpcodes -PathType Container)) {
 }
 python (Join-Path $automationRoot 'scripts/product_lock.py') verify-contracts $automationRoot
 if ($LASTEXITCODE -ne 0) { throw 'The engine submodule does not match the product lock' }
+python (Join-Path $automationRoot 'scripts/product_lock.py') verify-checkout engine (Join-Path $automationRoot 'vendor/MetasequoiaImeEngine')
+if ($LASTEXITCODE -ne 0) { throw 'The Engine checkout does not match the product lock' }
 python (Join-Path $automationRoot 'scripts/product_lock.py') fetch-dictionaries --staging-root $StagingRoot
 if ($LASTEXITCODE -ne 0) { throw 'Could not provision locked dictionaries' }
 $verified = (Resolve-Path (Join-Path $StagingRoot 'MetasequoiaImeDict/out')).Path

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -20,8 +20,8 @@ CI 现在会真的跑它：根 `.github/workflows/ci.yml` 的 Server job 在 Bui
 
 **关键在于这些测试依赖真实词库，不是 fixture。**引擎从数据根目录读数据，默认 `%LOCALAPPDATA%\metasequoiaime`，可用 `METASEQUOIA_IME_DATA_DIR` 环境变量覆盖。`scripts/ci/test-server.ps1` 往那里放了四样东西，本地跑测试要凑齐同样的：
 
-- `msime.db`、`others.db`、`english.db`——从 MSIME-Dict 的 release 下载，CI 逐个核对 `SHA256SUMS.txt`。词库损坏要立刻失败，而不是拖到测试里表现成「候选为空」这种难查的样子
-- `helpcodes/`——五套辅助码方案，本组件 `assets/tables` 只有其中一套，从同一个 Engine submodule 的 `helpcode/helpcodes` 取全
+- `msime.db`、`others.db`、`english.db`——从 MSIME-Engine 的 release 下载，CI 逐个核对 `SHA256SUMS.txt`。词库损坏要立刻失败，而不是拖到测试里表现成「候选为空」这种难查的样子
+- `helpcodes/`——五套辅助码方案，本仓 `assets/tables` 只有其中一套，得从 `../vendor/MetasequoiaImeEngine/helpcode/` 取全
 - `assets/tables/*` 和 `assets/config/config.toml`
 
 数据不全时的典型症状是候选查询返回空集，断言信息看起来像逻辑错误，实际是缺数据。排查测试失败前先确认数据根目录是齐的。
@@ -85,5 +85,3 @@ Boost 是静态链接但没有写进 `vcpkg.json`，所以只能用 classic 模�
   和相关布局；优先沿用项目已有的 DPI 获取与缩放辅助函数，避免各处自行实现不一致的换算规则。
 - 涉及尺寸或布局的改动，至少检查 100%、125%、150%、200% 缩放，以及不同 DPI 显示器之间移动时
   是否出现裁切、错位、模糊、点击区域偏移或窗口越出工作区。
-
-语音采集使用 Engine 的 `MetasequoiaIme::VoiceCapture`，16 kHz 单声道 float PCM。录音控制线程串行调用 start/stop，stop 返回后才能释放豆包流式客户端或样本缓冲。不要重新内嵌 miniaudio 实现；提示音暂用同一 Engine 固定的 miniaudio 头文件与实现。

--- a/server/README.md
+++ b/server/README.md
@@ -16,43 +16,27 @@ Make sure vcpkg and Boost are installed by **Scoop**.
 
 ### Build steps(For Dev)
 
-**First**, build IME dictonary and prepare assets,
-
-```powershell
-cd $env:LOCALAPPDATA
-mkdir metasequoiaime
-cd metasequoiaime
-git clone --recursive https://github.com/metasequoiaime/MSIME-Dict.git MetasequoiaImeDict
-cd .\MetasequoiaImeDict\makecikudb\xnheulpb\makedb\separated_jp_version
-python .\create_db_and_table.py
-python .\insert_data.py
-python .\create_index_for_db.py
-Copy-Item -Path .\out\msime.db -Destination $env:LOCALAPPDATA\metasequoiaime
-```
-
-**Then**, clone the product repository and build the server,
+Clone the product and provision the reviewed dictionary release from its root:
 
 ```powershell
 git clone --recursive https://github.com/metasequoiaime/MSIME-Windows.git
+cd MSIME-Windows
+python scripts/product_lock.py fetch-dictionaries --staging-root .
+if ($LASTEXITCODE -ne 0) { throw 'Dictionary verification failed' }
+$devData = Join-Path $PWD 'build/dev-data'
+New-Item -ItemType Directory -Force $devData | Out-Null
+Copy-Item MetasequoiaImeDict/out/* $devData -Force
+Copy-Item vendor/MetasequoiaImeEngine/helpcode/helpcodes $devData -Recurse -Force
+Copy-Item server/assets/tables/* $devData -Force
+Copy-Item server/assets/config/config.toml $devData -Force
+$env:METASEQUOIA_IME_DATA_DIR = $devData
+cd server
+python scripts/prepare_env.py
 ```
 
-Prepare environment,
-
-```powershell
-cd MSIME-Windows/server
-python .\scripts\prepare_env.py
-Copy-Item -Path .\assets\tables\* -Destination $env:LOCALAPPDATA\metasequoiaime
-New-Item -ItemType SymbolicLink -Path "$env:LOCALAPPDATA\metasequoiaime\config.toml" -Target ".\assets\config\config.toml"
-```
-
-e.g.
-
-```powershell
-cd MetasequoiaImeServer
-python .\scripts\prepare_env.py
-Copy-Item -Path .\assets\tables\* -Destination $env:LOCALAPPDATA\metasequoiaime
-New-Item -ItemType SymbolicLink -Path "C:\Users\sonnycalcr\AppData\Local\metasequoiaime\config.toml" -Target "C:\Users\sonnycalcr\EDisk\CppCodes\IMECodes\MetasequoiaImeServer\assets\config\config.toml"
-```
+This uses the same locked data as CI and a separate development data directory.
+Dictionary source changes belong in Engine's `dictionary/`; use its root `build_profile.py`
+to build data instead of calling internal stages in the archived Dict repository.
 
 Then, build and run,
 


### PR DESCRIPTION
The release workflow explicitly passes the new Engine helpcode path, but local installer scripts use Prepare-PackageFiles.ps1 defaults. That default still points outside vendor/, so a normal monorepo checkout cannot produce a full local package.

Use vendor/MetasequoiaImeEngine/helpcode as the default and exercise real windows/server/ui-html paths and root notices in the full/light package fixtures. Update local setup instructions to fetch the locked Engine dictionary release instead of building archived Dict stages. Server integration now verifies the actual Engine checkout as well as the gitlink/lock pair before copying its tables.

Validation: git diff --check passes. Full/light package checks run on native Windows CI. No local installation or signing was performed.

The repository ruleset still requires `Windows x64` and `Windows Win32`, while the monorepo renamed those real jobs to `Windows tip ...`. Restore the required names for the same native architecture builds; no ruleset or test coverage is relaxed. All seven checks passed before this naming fix; the new run reports the names required for normal auto-merge.
