### PR TITLE
refactor(voice): use shared Engine codecs in Windows providers

### DIFF
--- a/product-lock.json
+++ b/product-lock.json
@@ -3,7 +3,7 @@
   "repositories": {
     "engine": {
       "repository": "metasequoiaime/MSIME-Engine",
-      "commit": "d0dc0c2b594b5540b5de99ad12085c786410626e"
+      "commit": "cc21e42916cf93ce43051fec474e87eeeba305bf"
     }
   },
   "dictionary": {

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -195,6 +195,7 @@ set(SRC_FILES
     "./src/voice-input/system_audio_muter.h"
     "./src/voice-input/doubao_asr_client.cpp"
     "./src/voice-input/doubao_asr_client.h"
+    "./src/voice-input/voice_batch_protocol.cpp"
     "./src/voice-input/voice_providers.cpp"
     "./src/voice-input/voice_providers.h"
     "./src/voice-input/wave_overlay.cpp"
@@ -218,7 +219,7 @@ target_include_directories(${PROJECT_NAME}
     "${MSIME_VENDOR_DIR}/MetasequoiaImeEngine/voice/third_party/miniaudio"
 )
 
-target_link_libraries(${PROJECT_NAME} PRIVATE MetasequoiaIme::Engine MetasequoiaIme::VoiceCapture)
+target_link_libraries(${PROJECT_NAME} PRIVATE MetasequoiaIme::Engine MetasequoiaIme::Voice MetasequoiaIme::VoiceCapture)
 target_link_libraries(${PROJECT_NAME} PRIVATE unofficial::sqlite3::sqlite3 fmt::fmt spdlog::spdlog Boost::locale Boost::json nlohmann_json::nlohmann_json)
 target_link_libraries(${PROJECT_NAME} PRIVATE OpenCC::OpenCC)
 add_dependencies(${PROJECT_NAME} Dictionaries)

--- a/server/README.md
+++ b/server/README.md
@@ -95,3 +95,7 @@ The server process includes a few built-in global shortcuts that are useful duri
 ![](https://i.postimg.cc/L96qQZT8/image.png)
 
 ![](https://i.postimg.cc/FNcz9QTv/image.png)
+
+## Shared voice providers
+
+The server links Engine VoiceCapture and Voice. WAV encoding and batch transcription/polish codecs come from the public library; Windows keeps provider configuration, SiliconFlow padding/retry behavior and Doubao streaming. Batch uploads are bounded to 20 MiB and responses to 1 MiB. Failed or empty polish responses retain the original transcript.

--- a/server/src/voice-input/voice_batch_protocol.cpp
+++ b/server/src/voice-input/voice_batch_protocol.cpp
@@ -1,0 +1,44 @@
+#include "voice_batch_protocol.h"
+#include "voice_providers.h"
+#include <msime/voice/wav_writer.h>
+#include <nlohmann/json.hpp>
+
+namespace VoiceInput
+{
+metasequoia::voice::MultipartRequest BuildBatchTranscription(const std::vector<float> &samples,
+                                                             const VoiceInputConfig &config)
+{
+    const bool siliconflow = NormalizeProviderId(config.asr_provider) == "siliconflow";
+    std::vector<float> padded;
+    if (siliconflow)
+    {
+        constexpr std::size_t pad_frames = metasequoia::voice::sample_rate / 5;
+        padded.reserve(samples.size() + pad_frames * 2);
+        padded.insert(padded.end(), pad_frames, 0.0f);
+        padded.insert(padded.end(), samples.begin(), samples.end());
+        padded.insert(padded.end(), pad_frames, 0.0f);
+        if (padded.size() < metasequoia::voice::sample_rate)
+            padded.resize(metasequoia::voice::sample_rate, 0.0f);
+    }
+    constexpr std::size_t upload_sample_limit = (metasequoia::voice::maximum_encoded_audio_bytes - 44) / 2;
+    const auto wav = metasequoia::voice::WavWriter::create_wav(siliconflow ? padded : samples,
+                                                               metasequoia::voice::sample_rate, upload_sample_limit);
+    // SiliconFlow rejects the optional language field. Keep the existing Windows mapping elsewhere.
+    const std::string language = !siliconflow && config.language == "zh-cn" ? "zh"
+                                 : !siliconflow && config.language == "en"  ? "en"
+                                                                            : "";
+    return metasequoia::voice::make_transcription_request(
+        std::string_view(reinterpret_cast<const char *>(wav.data()), wav.size()), ResolveAsrModel(config), language);
+}
+
+std::string BuildBatchPolish(const std::string &text, const VoiceInputConfig &config)
+{
+    auto body = nlohmann::json::parse(metasequoia::voice::make_polish_request(
+        ResolvePolishModel(config), ResolvePolishSystemPrompt(config), WrapAsrUserMessage(text)));
+    if (config.polish_provider == "siliconflow")
+        body["enable_thinking"] = false;
+    else if (config.polish_provider == "deepseek")
+        body["thinking"] = {{"type", "disabled"}};
+    return body.dump();
+}
+} // namespace VoiceInput

--- a/server/src/voice-input/voice_batch_protocol.h
+++ b/server/src/voice-input/voice_batch_protocol.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "config/ime_config.h"
+#include <msime/voice/provider_protocol.h>
+#include <string>
+#include <vector>
+
+namespace VoiceInput
+{
+metasequoia::voice::MultipartRequest BuildBatchTranscription(const std::vector<float> &samples,
+                                                             const VoiceInputConfig &config);
+std::string BuildBatchPolish(const std::string &text, const VoiceInputConfig &config);
+} // namespace VoiceInput

--- a/server/src/voice-input/voice_input_service.cpp
+++ b/server/src/voice-input/voice_input_service.cpp
@@ -1,9 +1,12 @@
 #include <msime/voice/audio_capture.h>
+#include <msime/voice/provider_protocol.h>
+#include <limits>
 
 #include "voice_input_service.h"
 #include "config/ime_config.h"
 #include "doubao_asr_client.h"
 #include "voice_providers.h"
+#include "voice_batch_protocol.h"
 #include "ipc/ipc.h"
 #include "system_audio_muter.h"
 #include "utils/common_utils.h"
@@ -350,42 +353,16 @@ LRESULT CALLBACK KeyboardHookProc(int code, WPARAM wparam, LPARAM lparam)
     return CallNextHookEx(g_keyboard_hook, code, wparam, lparam);
 }
 
-void AppendU16(std::vector<std::uint8_t> &out, std::uint16_t value)
-{
-    out.push_back(static_cast<std::uint8_t>(value));
-    out.push_back(static_cast<std::uint8_t>(value >> 8));
-}
-
-void AppendU32(std::vector<std::uint8_t> &out, std::uint32_t value)
-{
-    for (int shift = 0; shift < 32; shift += 8) out.push_back(static_cast<std::uint8_t>(value >> shift));
-}
-
-std::vector<std::uint8_t> MakeWav(const std::vector<float> &samples)
-{
-    std::vector<std::uint8_t> pcm;
-    pcm.reserve(samples.size() * 2);
-    for (float sample : samples)
-    {
-        const float clamped = (std::max)(-1.0f, (std::min)(1.0f, sample));
-        AppendU16(pcm, static_cast<std::uint16_t>(static_cast<std::int16_t>(clamped * 32767.0f)));
-    }
-    std::vector<std::uint8_t> wav;
-    wav.insert(wav.end(), {'R', 'I', 'F', 'F'});
-    AppendU32(wav, static_cast<std::uint32_t>(36 + pcm.size()));
-    wav.insert(wav.end(), {'W', 'A', 'V', 'E', 'f', 'm', 't', ' '});
-    AppendU32(wav, 16); AppendU16(wav, 1); AppendU16(wav, 1);
-    AppendU32(wav, kSampleRate); AppendU32(wav, kSampleRate * 2); AppendU16(wav, 2); AppendU16(wav, 16);
-    wav.insert(wav.end(), {'d', 'a', 't', 'a'});
-    AppendU32(wav, static_cast<std::uint32_t>(pcm.size()));
-    wav.insert(wav.end(), pcm.begin(), pcm.end());
-    return wav;
-}
-
 size_t WriteResponse(char *data, size_t size, size_t count, void *user)
 {
-    static_cast<std::string *>(user)->append(data, size * count);
-    return size * count;
+    constexpr size_t limit = 1024 * 1024;
+    if (size && count > (std::numeric_limits<size_t>::max)() / size) return 0;
+    const size_t length = size * count;
+    auto &response = *static_cast<std::string *>(user);
+    if (length > limit - response.size()) return 0;
+    try { response.append(data, length); }
+    catch (...) { return 0; }
+    return length;
 }
 
 size_t WriteHeader(char *data, size_t size, size_t count, void *user)
@@ -420,19 +397,6 @@ bool IsSiliconFlowAsr(const VoiceInputConfig &config)
             ch = static_cast<char>(ch - 'A' + 'a');
     }
     return provider == "siliconflow";
-}
-
-std::vector<float> PadAsrAudio(const std::vector<float> &samples)
-{
-    constexpr std::size_t kPadFrames = kSampleRate / 5; // 200 ms
-    std::vector<float> padded;
-    padded.reserve(samples.size() + kPadFrames * 2);
-    padded.insert(padded.end(), kPadFrames, 0.0f);
-    padded.insert(padded.end(), samples.begin(), samples.end());
-    padded.insert(padded.end(), kPadFrames, 0.0f);
-    if (padded.size() < kSampleRate)
-        padded.resize(kSampleRate, 0.0f);
-    return padded;
 }
 
 struct RecognitionResult
@@ -484,7 +448,15 @@ RecognitionResult Recognize(const std::vector<float> &samples, const VoiceInputC
     if (model_name.empty())
         return {{}, "ASR 模型名为空。"};
     const bool siliconflow = IsSiliconFlowAsr(config);
-    const auto wav = MakeWav(siliconflow ? PadAsrAudio(samples) : samples);
+    metasequoia::voice::MultipartRequest payload;
+    try
+    {
+        payload = VoiceInput::BuildBatchTranscription(samples, config);
+    }
+    catch (const metasequoia::voice::VoiceError &)
+    {
+        return {{}, "录音数据无效或超过 20 MiB 上传限制。"};
+    }
     const int attempts = siliconflow ? 2 : 1;
     std::string response;
     std::string trace_id;
@@ -505,27 +477,12 @@ RecognitionResult Recognize(const std::vector<float> &samples, const VoiceInputC
         headers = curl_slist_append(headers, ("Authorization: Bearer " + asr_token).c_str());
         // Some gateways 500 on libcurl's default Expect: 100-continue.
         headers = curl_slist_append(headers, "Expect:");
-        curl_mime *mime = curl_mime_init(curl);
-        curl_mimepart *file = curl_mime_addpart(mime);
-        curl_mime_name(file, "file");
-        curl_mime_filename(file, "audio.wav");
-        curl_mime_type(file, "audio/wav");
-        curl_mime_data(file, reinterpret_cast<const char *>(wav.data()), wav.size());
-        curl_mimepart *model = curl_mime_addpart(mime);
-        curl_mime_name(model, "model");
-        curl_mime_data(model, model_name.c_str(), CURL_ZERO_TERMINATED);
-        // SiliconFlow's /audio/transcriptions schema only accepts file + model.
-        // Sending Whisper's language field makes it return 400 and we previously
-        // swallowed that as an empty transcript.
-        if (!siliconflow && (config.language == "zh-cn" || config.language == "en"))
-        {
-            curl_mimepart *language = curl_mime_addpart(mime);
-            curl_mime_name(language, "language");
-            curl_mime_data(language, config.language == "zh-cn" ? "zh" : "en", CURL_ZERO_TERMINATED);
-        }
+        headers = curl_slist_append(headers, ("Content-Type: " + payload.content_type).c_str());
         curl_easy_setopt(curl, CURLOPT_URL, config.asr_endpoint.c_str());
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-        curl_easy_setopt(curl, CURLOPT_MIMEPOST, mime);
+        curl_easy_setopt(curl, CURLOPT_POST, 1L);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.body.data());
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.body.size()));
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteResponse);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, WriteHeader);
@@ -538,7 +495,6 @@ RecognitionResult Recognize(const std::vector<float> &samples, const VoiceInputC
         result = curl_easy_perform(curl);
         http_status = 0;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
-        curl_mime_free(mime);
         curl_slist_free_all(headers);
         curl_easy_cleanup(curl);
         if (result == CURLE_OK && http_status < 500)
@@ -549,7 +505,7 @@ RecognitionResult Recognize(const std::vector<float> &samples, const VoiceInputC
         const char *detail = curl_error[0] ? curl_error : curl_easy_strerror(result);
         return {{}, std::string("语音识别请求失败：") + detail};
     }
-    if (http_status >= 400)
+    if (http_status < 200 || http_status >= 300)
     {
         std::string detail = JsonErrorMessage(response);
         if (detail.empty())
@@ -564,10 +520,7 @@ RecognitionResult Recognize(const std::vector<float> &samples, const VoiceInputC
     }
     try
     {
-        const auto json = nlohmann::json::parse(response);
-        if (json.contains("text") && json["text"].is_string())
-            return {json["text"].get<std::string>(), {}};
-        return {{}, "语音识别返回了无法解析的结果。"};
+        return {metasequoia::voice::parse_transcription(response), {}};
     }
     catch (...)
     {
@@ -585,36 +538,30 @@ std::string Polish(const std::string &text, const VoiceInputConfig &config)
 {
     if (!ShouldPolish(text, config)) return text;
     const std::string polish_token = VoiceInput::ResolvePolishToken(config);
+    std::string payload;
+    try { payload = VoiceInput::BuildBatchPolish(text, config); }
+    catch (...) { return text; }
     CURL *curl = curl_easy_init();
     if (!curl) return text;
-    const std::string model_name = VoiceInput::ResolvePolishModel(config);
-    nlohmann::json body = {
-        {"model", model_name},
-        {"stream", false},
-        {"messages",
-         {{{"role", "system"}, {"content", VoiceInput::ResolvePolishSystemPrompt(config)}},
-          {{"role", "user"}, {"content", VoiceInput::WrapAsrUserMessage(text)}}}}};
-    if (config.polish_provider == "siliconflow")
-        body["enable_thinking"] = false;
-    else if (config.polish_provider == "deepseek")
-        body["thinking"] = {{"type", "disabled"}};
-    const std::string payload = body.dump();
     std::string response;
     curl_slist *headers = nullptr;
     headers = curl_slist_append(headers, "Content-Type: application/json");
     headers = curl_slist_append(headers, ("Authorization: Bearer " + polish_token).c_str());
     curl_easy_setopt(curl, CURLOPT_URL, config.polish_endpoint.c_str());
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, payload.data());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, static_cast<curl_off_t>(payload.size()));
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteResponse);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
     // Polishing is optional: if it cannot finish promptly, abort the request and
     // let the caller commit the original ASR text returned below.
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, kPolishTimeoutMs);
     const CURLcode result = curl_easy_perform(curl);
+    long http_status = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_status);
     curl_slist_free_all(headers); curl_easy_cleanup(curl);
-    if (result != CURLE_OK) return text;
-    try { return nlohmann::json::parse(response).at("choices").at(0).at("message").value("content", text); }
+    if (result != CURLE_OK || http_status < 200 || http_status >= 300) return text;
+    try { return metasequoia::voice::parse_polished_text(response); }
     catch (...) { return text; }
 }
 

--- a/server/src/voice-input/voice_input_service.cpp
+++ b/server/src/voice-input/voice_input_service.cpp
@@ -1,5 +1,6 @@
 #include <msime/voice/audio_capture.h>
 #include <msime/voice/provider_protocol.h>
+#include <msime/voice/stt_service.h>
 #include <limits>
 
 #include "voice_input_service.h"

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ set(TEST_SOURCE_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_ipc_protocol_constants.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_voice_composition_pipe.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_voice_providers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/test_voice_batch_protocol.cpp"
+    "${CMAKE_SOURCE_DIR}/src/voice-input/voice_batch_protocol.cpp"
     "${CMAKE_SOURCE_DIR}/src/voice-input/voice_providers.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_floating_toolbar_visibility_policy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_terminal_deactivation_policy.cpp"
@@ -63,6 +65,8 @@ target_include_directories(${TEST_EXECUTABLE_NAME}
 target_link_libraries(${TEST_EXECUTABLE_NAME}
     PRIVATE
     MetasequoiaIme::Engine
+    MetasequoiaIme::Voice
+    nlohmann_json::nlohmann_json
     fmt::fmt
     spdlog::spdlog
     Boost::locale

--- a/server/tests/src/test_voice_batch_protocol.cpp
+++ b/server/tests/src/test_voice_batch_protocol.cpp
@@ -1,0 +1,45 @@
+#define NOMINMAX
+#include "voice-input/voice_batch_protocol.h"
+#include "tests/includes/test_framework.h"
+#include <msime/voice/stt_service.h>
+#include <nlohmann/json.hpp>
+
+TEST_CASE(voice_batch_protocol_preserves_provider_fields_and_padding)
+{
+    VoiceInputConfig config;
+    config.asr_provider = "openai";
+    config.language = "zh-cn";
+    config.asr_model = "fixture-asr";
+    const std::vector<float> samples(160, 0.125f);
+    const auto openai = VoiceInput::BuildBatchTranscription(samples, config);
+    REQUIRE(openai.body.find("name=\"language\"\r\n\r\nzh") != std::string::npos);
+    REQUIRE(openai.body.find("fixture-asr") != std::string::npos);
+    config.asr_provider = "siliconflow";
+    const auto siliconflow = VoiceInput::BuildBatchTranscription(samples, config);
+    REQUIRE(siliconflow.body.find("name=\"language\"") == std::string::npos);
+    const auto wave = siliconflow.body.find("RIFF");
+    REQUIRE(wave != std::string::npos);
+    // Tiny clips still contain a full second of padded PCM, as required by the existing provider adapter.
+    const auto *bytes = reinterpret_cast<const unsigned char *>(siliconflow.body.data() + wave);
+    const unsigned data_bytes = bytes[40] | (bytes[41] << 8) | (bytes[42] << 16) | (bytes[43] << 24);
+    REQUIRE_EQ(data_bytes, 32000u);
+    const std::vector<float> long_clip(61 * metasequoia::voice::sample_rate, 0.125f);
+    REQUIRE(VoiceInput::BuildBatchTranscription(long_clip, config).body.size() > long_clip.size() * 2);
+}
+
+TEST_CASE(voice_batch_protocol_preserves_polish_prompt_and_thinking_settings)
+{
+    VoiceInputConfig config;
+    config.polish_model = "fixture-polish";
+    config.polish_prompt = "fixture prompt";
+    config.polish_provider = "deepseek";
+    auto body = nlohmann::json::parse(VoiceInput::BuildBatchPolish("原始文本", config));
+    REQUIRE_EQ(body["model"].get<std::string>(), "fixture-polish");
+    REQUIRE_EQ(body["messages"][0]["content"].get<std::string>(), "fixture prompt");
+    REQUIRE_EQ(body["messages"][1]["content"].get<std::string>(), "<asr_text>\n原始文本\n</asr_text>");
+    REQUIRE_EQ(body["thinking"]["type"].get<std::string>(), "disabled");
+    config.polish_provider = "siliconflow";
+    body = nlohmann::json::parse(VoiceInput::BuildBatchPolish("原始文本", config));
+    REQUIRE_EQ(body["enable_thinking"].get<bool>(), false);
+    REQUIRE(!body.contains("thinking"));
+}


### PR DESCRIPTION
Server still duplicated WAV encoding, multipart construction and transcription/polish JSON handling after moving recording to public VoiceCapture. Use the Engine voice codecs for these operations, keeping Windows provider selection, SiliconFlow padding and retries/trace IDs, language rules, prompt presets/delimiters and provider-specific thinking flags. Doubao streaming and native input/focus/overlay handling retain their existing path.

The Windows adapter explicitly budgets encoded batch uploads at 20 MiB, so provider padding and clips over 60 seconds are preserved without changing the public PCM recognizer's default limit. Responses are bounded to 1 MiB, rejected outside HTTP 2xx, and empty/error polish responses preserve the original transcript.

Validation: five actual platform provider/protocol tests pass locally, covering token/model defaults, custom prompts, SiliconFlow minimum-duration padding and omitted language, a 61-second clip, and DeepSeek/SiliconFlow thinking fields. The same tests are registered in native Server CI; Windows x86/x64 and full product/data tests run in this PR. Tests use synthetic audio, with no microphone, provider credentials, signing or installation. Engine is pinned only after MSIME-Engine#29 has merged.
