### PR TITLE
docs(contributing): route dictionary reports to the consolidated Engine

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
         - Server / 引擎服务 / MSIME-Server
         - 设置界面 / Settings
         - 候选窗 UI / Candidate UI
-        - 词典 / MSIME-Dict
+        - 词典 / MSIME-Engine/dictionary
         - 辅助码 / MSIME-Engine
         - 安装器 / Installer
         - 文档 / 官网

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,7 +22,7 @@ body:
         - Server / 引擎服务 / MSIME-Server
         - 设置界面 / Settings
         - 候选窗 UI / Candidate UI
-        - 词典 / MSIME-Dict
+        - 词典 / MSIME-Engine/dictionary
         - 辅助码 / MSIME-Engine
         - 安装器 / Installer
         - 文档 / 官网


### PR DESCRIPTION
两个 issue 表单将词库组件名称改为 MSIME-Engine/dictionary，与当前维护目录一致。

验证：只改动下拉选项文字；git diff --check 通过。