### PR TITLE
chore(dict): follow the dictionary release to its semver tag

### DIFF
--- a/docs/product-release.md
+++ b/docs/product-release.md
@@ -11,7 +11,7 @@
 显式刷新后评审并提交清单，CI 通过后才能发布：
 
 ```sh
-python scripts/product_lock.py refresh --dictionary-tag dict-2026.09.05
+python scripts/product_lock.py refresh --dictionary-tag dict-v1.0.0
 python scripts/product_lock.py validate
 ```
 

--- a/product-lock.json
+++ b/product-lock.json
@@ -8,7 +8,7 @@
   },
   "dictionary": {
     "repository": "metasequoiaime/MSIME-Engine",
-    "tag": "dict-2026.09.06",
+    "tag": "dict-v1.0.0",
     "source_commit": "d0dc0c2b594b5540b5de99ad12085c786410626e",
     "assets": {
       "dictionary-manifest.json": "bc992419a3923ea3e75f35539b0c0a61932c13cedee92d3a7323f984db6ca9cd",

--- a/tests/test_product_lock.py
+++ b/tests/test_product_lock.py
@@ -68,7 +68,7 @@ class ProductLockTests(unittest.TestCase):
             lock.validate(self.data)
 
     def test_modern_dictionary_requires_a_compatible_locked_manifest(self):
-        self.data['dictionary']['tag'] = 'dict-2026.09.06'
+        self.data['dictionary']['tag'] = 'dict-v1.0.0'
         self.data['dictionary']['repository'] = lock.DICTIONARY_REPOSITORY
         self.data['dictionary']['assets'].pop(lock.PRODUCT_MANIFEST, None)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
The dictionary release was republished as `dict-v1.0.0`, so this pin has to follow it. Downloads under `dict-2026.09.06` now return 404.

The release was renamed through the API rather than rebuilt, so its assets are byte-identical and every SHA256 in `product-lock.json` is unchanged. Only the tag string moves. Verified against the live release:

```
dict-v1.0.0/SHA256SUMS.txt   -> 200, identical to the committed digests
dict-2026.09.06/SHA256SUMS.txt -> 404
```

`scripts/product_lock.py` needed no change: its tag pattern `dict-[A-Za-z0-9._-]+` already accepts the semver form. `LEGACY_DICTIONARY_TAG` keeps its calendar name because it names a historical release that stays immutable.

`python3 tests/test_product_lock.py` passes, 16 tests.
