### PR TITLE
ci: 补齐仓库验证与自动安全维护

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,20 @@ on:
       - .release-please-manifest.json
   workflow_dispatch:
 
+  merge_group:
+
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.ref || github.ref_name }}
+  group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   lock:
     name: Product inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       # The dictionary validator is compared against the engine's copy of it, so this job needs the
       # submodule's contents and not just its gitlink.
@@ -48,6 +51,7 @@ jobs:
   windows:
     name: Windows ${{ matrix.name }}
     runs-on: windows-2025
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +92,7 @@ jobs:
         shell: pwsh
         run: cmake --build windows/build --config Release --parallel
       - name: Test the wire contract on this architecture
-        run: ctest --test-dir windows/build -C Release --output-on-failure
+        run: ctest --no-tests=error --test-dir windows/build -C Release --output-on-failure
 
       # Architecture-independent, so it runs once rather than on both matrix legs.
       - name: Check the installer language file lands where ISCC looks
@@ -159,7 +163,7 @@ jobs:
         run: cmake --build ui/build --config Release --parallel
       - name: Test
         shell: pwsh
-        run: ctest --test-dir ui/build -C Release --verbose --timeout 60
+        run: ctest --no-tests=error --test-dir ui/build -C Release --verbose --timeout 60
 
   pages:
     name: Settings page

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quality:
+    uses: ./.github/workflows/quality.yml
+
   lock:
     name: Product inputs
     runs-on: ubuntu-24.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '11 3 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: codeql-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  analyze:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, c-cpp, javascript-typescript, python]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          # C/C++ source analysis complements, rather than replaces, native build CI.
+          build-mode: none
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,44 @@
+name: Repository quality
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: quality-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  workflows:
+    name: Workflow validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: '1.26'
+          cache: false
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Validate workflows and embedded shell scripts
+        env:
+          # Ignore style suggestions, but fail on shell correctness warnings and errors.
+          SHELLCHECK_OPTS: --severity=warning
+        run: actionlint -color
+  dependencies:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,15 +1,9 @@
 name: Repository quality
+# Called by CI so release-please's workflow_dispatch receives these checks too.
 on:
-  push:
-    branches: [main]
-  pull_request:
-  merge_group:
-  workflow_dispatch:
+  workflow_call:
 permissions:
   contents: read
-concurrency:
-  group: quality-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   workflows:
     name: Workflow validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
   prepare:
     name: Prepare release metadata
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       # actions: write lets check-release-pr.sh dispatch ci.yml on the release branch, which is the
       # only trigger GITHUB_TOKEN is allowed to fire.
@@ -74,6 +75,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.should_publish == 'true' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     outputs:
       dictionary_tag: ${{ steps.lock.outputs.dictionary_tag }}
     steps:


### PR DESCRIPTION
Windows 产品 CI 增加 actionlint、依赖漏洞审查和定期 CodeQL，所有原生任务补齐超时。质量检查通过仓内复用工作流接入 CI，使 release-please 手动派发的发布 PR 也能获得门禁；并发键区分事件，避免 PR 运行取消手动验证。

验证：本 PR 最新提交的全部适用 GitHub 检查通过，包括 quality / Workflow validation、CodeQL / actions、CodeQL / c-cpp、CodeQL / javascript-typescript、CodeQL / python、quality / Dependency review、Product inputs、Windows x64、Windows Win32、GUI framework、Settings page、Package contents、Server、CodeQL。本地 actionlint、git diff --check 通过。

保留既有产品锁、语义化版本和发布规则；没有执行正式发布或证书签名。
