### PR TITLE
ci(release): 修复历史版本 tag 创建的权限失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,35 @@ jobs:
         with:
           persist-credentials: false
 
-      # Two invocations, because release-please only creates a release for a release pull request that was already merged when it ran. The first refreshes the pull request against the commits this push brought, so the release about to be cut includes them; the second sees the merge that land-release-pr.sh performed in between and cuts it. Merging before the first invocation instead would release everything except the push that triggered the run.
-      - name: Refresh the release pull request
+      # Split release creation from PR writes so the metadata credential never updates branches.
+      # Recover an already-merged release before calculating the next PR, matching release-please's
+      # normal releases-then-pull-requests ordering.
+      - name: Require the release metadata credential
+        if: ${{ github.event_name == 'push' }}
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [[ -z "$RELEASE_TOKEN" ]]; then
+            echo '::error::RELEASE_PLEASE_TOKEN must allow contents and workflows writes to create release tags.'
+            exit 1
+          fi
+
+      - name: Recover releases from previously merged pull requests
         if: ${{ github.event_name == 'push' }}
         id: release_pr
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          skip-github-pull-request: true
+
+      - name: Refresh the release pull request
+        if: ${{ github.event_name == 'push' }}
+        id: release_update
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Branch writes remain token-scoped and cannot enqueue another Release run.
+          skip-github-release: true
 
       - name: Test and merge the release pull request
         if: ${{ github.event_name == 'push' }}
@@ -67,7 +89,10 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Creating a tag at a historical workflow-changing commit needs workflows:write.
+          # This credential may create metadata, but must never write the release branch.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          skip-github-pull-request: true
 
       - name: Resolve the release this run publishes
         if: ${{ github.event_name == 'push' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,9 +58,9 @@ cmake -S ui      -B ui/build -A x64                # GUI 框架
 
 这一整条链跑在那次 push 触发的同一个 run 里：
 
-1. release-please 把这次 push 的提交刷进 release PR。
+1. release-please 先用 `RELEASE_PLEASE_TOKEN` 补建已有合并版本的元数据，再用 `GITHUB_TOKEN` 把这次 push 的提交刷进 release PR。
 2. `land-release-pr.sh` 给该 PR 派发一次 CI（`GITHUB_TOKEN` 开不出 workflow run，必须用 `workflow_dispatch` 顶上，否则开着 required status check 的 release PR 永远合不了），绿了就合并它。
-3. release-please 再跑一次，把这个合并变成 draft release 和 tag。
+3. release-please 再跑一次，用 `RELEASE_PLEASE_TOKEN` 只创建 draft release 和 tag（`skip-github-pull-request: true`）。维护 PR 的调用只写版本分支（`skip-github-release: true`）。
 4. 构建、签名、把 exe 挂上去、draft 转正式。
 
 合并用的是 `GITHUB_TOKEN`，而用该 token 推的提交不会触发 workflow —— 这是设计依赖的性质，不是要绕开的限制：它保证一次 push 只有一个 Release run，不会再冒出第二个卡在 concurrency 上。手工点 merge 那个 PR 也能得到同样结果，只是提前了一个 run。

--- a/docs/product-release.md
+++ b/docs/product-release.md
@@ -44,3 +44,9 @@ python -m unittest discover -s tests -p 'test_product_lock.py'
 python scripts/product_lock.py verify-contracts .
 python scripts/product_lock.py fetch-dictionaries --staging-root /tmp/msime-product-data
 ```
+
+## 发布元数据令牌
+
+版本 PR 的创建、更新和合并仍用 `GITHUB_TOKEN`。维护 PR 的 release-please 调用设置 `skip-github-release: true`。它前后各有一次 `skip-github-pull-request: true` 的元数据调用，使用组织已有的 `RELEASE_PLEASE_TOKEN`：先补建已经手动合并的版本，再处理本次自动合并的版本，保持 release-please 原有的先发布、后计算下一版本的顺序。
+
+后者需要仓库内容和 workflow 写权限（经典 PAT 的 `repo` + `workflow`，或等价的细粒度权限）。主分支先前包含 workflow 变更时，`GITHUB_TOKEN` 创建历史提交的 tag 可能被 Git refs API 拒绝。该令牌不用于合并或更新版本分支，因此不会因 PAT 写入主分支额外触发一次 Release。缺少令牌时提前报出配置错误。


### PR DESCRIPTION
自动发布在给已合并的版本提交创建 tag 时返回 `Resource not accessible by integration`（main run 34003842896）。该提交包含 workflow 历史，内置 `GITHUB_TOKEN` 不能完成这次 refs 写入。

将 release-please 的分支写入与 Release/tag 写入分开：

- 已合并版本的补建，以及本次合并后的元数据创建，使用现有 `RELEASE_PLEASE_TOKEN` 并设置 `skip-github-pull-request: true`。
- 刷新版本 PR 仍使用 `GITHUB_TOKEN`，设置 `skip-github-release: true`；合并也继续使用 `GITHUB_TOKEN`，保持一次 main push 的发布周期。
- 在计算下一个版本 PR 前先补建已合并版本，保留原调用的先创建 release、后构造 PR 的语义。
- 缺少发布元数据令牌时提前给出配置错误，文档记录所需权限。

验证：actionlint（ShellCheck warning/error）、git diff --check 通过；使用固定 release-please action 的 action.yml 核对两个 skip 输入。最新提交的 Windows x64/Win32、Server、GUI、设置页、安装包、质量门禁与 CodeQL 全部通过。main 上的自动发布继续验证，PR 阶段没有使用发布凭据或执行签名。
