### PR TITLE
fix(windows): include Chinese in IME display names

### DIFF
--- a/installer/msime_setup.iss
+++ b/installer/msime_setup.iss
@@ -17,7 +17,7 @@
 ; 打出不含词库的轻量包，安装时也不会删本机已有词库。
 ; 本仓库不包含任何预置代码签名证书。
 
-#define MyAppName      "Metasequoia IME"
+#define MyAppName      "Metasequoia IME 水杉输入法"
 #define MyAppVersion   "0.0.1"
 #define MyAppPublisher "Metasequoia"
 #define MyAppExeName   "MetasequoiaImeServer.exe"

--- a/windows/src/Register/Register.cpp
+++ b/windows/src/Register/Register.cpp
@@ -15,7 +15,7 @@ static const WCHAR RegInfo_Key_InProSvr32[] = L"InProcServer32";
 static const WCHAR RegInfo_Key_ThreadModel[] = L"ThreadingModel";
 
 // IME text service description, will be displayed in the language menu when switching IME
-static const WCHAR TEXTSERVICE_DESC[] = L"Metasequoia";
+static const WCHAR TEXTSERVICE_DESC[] = L"Metasequoia \u6c34\u6749\u8f93\u5165\u6cd5";
 
 static const GUID SupportCategories[] = {
     GUID_TFCAT_TIP_KEYBOARD,


### PR DESCRIPTION
## Summary

Fixes #67.

Append 水杉输入法 to the TSF profile display name and installer application name. Only two existing string definitions change. Profile GUID/CLSID, installer AppId, executable names, registry paths and installation directories remain unchanged. The C++ string uses Unicode escapes to be independent of the compiler source code page.

## Validation

Windows, MSVC 19.44, SDK 10.0.26100, existing windows/ CMake project and vcpkg:

- x64-windows-static (-A x64) and x86-windows-static (-A Win32) Release DLL builds passed.
- `cmake --build build/verify-x64-native --config Release --parallel 4`
- `cmake --build build/verify-x86-native --config Release --parallel 4`
- `ctest --test-dir build/verify-x64-native -C Release --output-on-failure`: 1/1 passed.
- `ctest --test-dir build/verify-x86-native -C Release --output-on-failure`: 1/1 passed.
- Verified both DLLs embed the exact UTF-16 display name `Metasequoia 水杉输入法`.
- Diff whitespace check passed using cr-at-eol, preserving existing source CRLF endings.

The root Python suite was also attempted: 19/22 passed; three were blocked by missing python3/bash entrypoints in this environment. No test infrastructure changes are included.

Inno Setup packaging, installation/upgrade and live Windows language-menu validation were not performed. This change does not register or replace the installed IME during verification.