### PR TITLE
chore(ci): sync workflows to main

### DIFF
--- a/.github/workflows/branch-guard.yml
+++ b/.github/workflows/branch-guard.yml
@@ -1,0 +1,37 @@
+name: Branch guard
+
+# main is the release branch: it only moves when develop is promoted for a release, or when
+# release-please lands the version commit it generates on top of that promotion. Everything else
+# targets develop.
+#
+# This is a check rather than a ruleset rule because GitHub rulesets can protect a base branch but
+# cannot say which head branches may target it. Add it to main's required status checks so a pull
+# request opened against the wrong base cannot be merged.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  base:
+    name: Base branch
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check the head branch may target main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          case "$HEAD_REF" in
+            develop | release/* | release-please--*)
+              echo "$HEAD_REF may target main."
+              ;;
+            *)
+              echo "::error::'$HEAD_REF' cannot target main. Day-to-day changes are merged into develop; main only receives develop promotions and release-please version branches. Retarget this pull request at develop."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,7 @@
 name: CodeQL
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
   pull_request:
   schedule:
     - cron: '11 3 * * 1'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,7 +25,7 @@ jobs:
           SHELLCHECK_OPTS: --severity=warning
         run: actionlint -color
       # Part of "Workflow validation" rather than a job of its own: it is a two-second grep, and this
-      # job is already a required check, so the guard starts protecting main immediately.
+      # job is already a required check, so the guard starts protecting both branches immediately.
       - name: Reject developer-specific paths in build inputs
         run: bash scripts/ci/check-developer-paths.sh
       # Formatting is platform independent, so it runs here on Ubuntu rather than costing a Windows
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # This job must not skip. It is one of main's required status checks, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event left the release pull request unmergeable by its own automation: ci.yml ignores that pull request by path and the release workflow dispatches ci.yml on the release branch instead, so this job saw workflow_dispatch and skipped, and land-release-pr.sh got "the base branch policy prohibits the merge" after everything else came back green.
+      # This job must not skip. It is one of the required status checks on main and develop, and a required check that reports "skipped" blocks a merge instead of passing it. Guarding it on the pull_request event left the release pull request unmergeable by its own automation: ci.yml ignores that pull request by path and the release workflow dispatches ci.yml on the release branch instead, so this job saw workflow_dispatch and skipped, and land-release-pr.sh got "the base branch policy prohibits the merge" after everything else came back green.
       #
       # A pull_request event supplies both refs on its own. Every other trigger has to be told what to compare, and comparing the default branch against the checked-out commit is the same question the pull request asks.
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
         id: release_pr
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          # release-please reads and writes the repository's default branch unless told otherwise, and that is now develop. The release branch is main: without this the version pull request, the changelog and the tag all land on develop, and the branch this workflow waits for (release-please--branches--main--*) is never created.
+          target-branch: main
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           skip-github-pull-request: true
 
@@ -74,6 +76,7 @@ jobs:
         id: release_update
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          target-branch: main
           # A trusted credential starts normal PR checks without manual workflow approval.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           skip-github-release: true
@@ -90,6 +93,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          target-branch: main
           # Creating a tag at a historical workflow-changing commit needs workflows:write.
           # Only GITHUB_TOKEN merges to main, preventing a second Release run.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Brings `.github/workflows/` on `main` up to what `develop` already has. This is a workflow-only sync; no source, docs or version files change.

Two of these only work if they are on `main`:

- **`release.yml` runs from `main`.** The `target-branch: main` fix landed on `develop`, but the workflow that actually executes on a `main` push is the copy on `main`. Until this merges, release-please still opens the version pull request, the changelog and the tag against the default branch, which is now `develop`. MSIME-Engine already produced one such stray pull request before the fix.
- **`branch-guard.yml` is evaluated from the base branch.** GitHub loads workflows for a `pull_request` event from the base, so a pull request targeting `main` sees `main`'s workflow set. With the guard only on `develop`, nothing stops a feature branch from targeting `main` — which is exactly what happened three times in MSIME-Apple during the switch.

The `develop` push triggers and the comment updates come along because they live in the same files; keeping both branches on one workflow definition is also what avoids the next promotion showing a spurious diff.

## Verification

- `SHELLCHECK_OPTS=--severity=warning actionlint` clean.
- Files are byte-identical to `develop`, so the next `develop` to `main` promotion carries no workflow diff.
