### PR TITLE
fix(installer): sign releases from runner certificate store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,7 @@ jobs:
         env:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          CERTIFICATE_THUMBPRINT: ${{ vars.WINDOWS_SIGNING_CERTIFICATE_THUMBPRINT }}
         run: ./scripts/ci/detect-release-signing.ps1
 
       - name: Collect the installer payload
@@ -414,6 +415,7 @@ jobs:
         env:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          CERTIFICATE_THUMBPRINT: ${{ vars.WINDOWS_SIGNING_CERTIFICATE_THUMBPRINT }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
         run: ../scripts/ci/sign-binaries.ps1 -Path 'server_exe/MetasequoiaImeServer.exe'
 
@@ -433,6 +435,7 @@ jobs:
         env:
           CERTIFICATE_BASE64: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_BASE64 }}
           CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}
+          CERTIFICATE_THUMBPRINT: ${{ vars.WINDOWS_SIGNING_CERTIFICATE_THUMBPRINT }}
           TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL || 'http://timestamp.digicert.com' }}
           TARGET_VERSION: ${{ needs.prepare.outputs.version }}
         run: ../scripts/ci/sign-binaries.ps1 -Path "Output/MetasequoiaIME_Setup_v$env:TARGET_VERSION.exe"

--- a/scripts/ci/detect-release-signing.ps1
+++ b/scripts/ci/detect-release-signing.ps1
@@ -8,10 +8,18 @@
 # Writes signing_enabled and asset_suffix to GITHUB_OUTPUT.
 $ErrorActionPreference = 'Stop'
 
-if ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD) {
+$storeCert = $null
+if ($env:CERTIFICATE_THUMBPRINT) {
+    $normalized = $env:CERTIFICATE_THUMBPRINT -replace '\s', ''
+    $storeCert = Get-ChildItem Cert:\CurrentUser\My\$normalized -ErrorAction SilentlyContinue
+    if (-not $storeCert -or -not $storeCert.HasPrivateKey) { $storeCert = $null }
+}
+
+if ($storeCert -or ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD)) {
     "signing_enabled=true" >> $env:GITHUB_OUTPUT
     "asset_suffix=" >> $env:GITHUB_OUTPUT
-    Write-Host 'Signing certificate present: the installer and its binaries will be signed.'
+    if ($storeCert) { Write-Host 'Signing certificate present in the runner user certificate store.' }
+    else { Write-Host 'Signing certificate secret present: the installer and its binaries will be signed.' }
 }
 else {
     "signing_enabled=false" >> $env:GITHUB_OUTPUT

--- a/scripts/ci/sign-binaries.ps1
+++ b/scripts/ci/sign-binaries.ps1
@@ -35,15 +35,20 @@ $signtool = Get-ChildItem 'C:\Program Files (x86)\Windows Kits\10\bin\*\x64\sign
     Sort-Object FullName -Descending | Select-Object -First 1
 if (-not $signtool) { throw 'signtool.exe not found in the Windows SDK.' }
 
-$pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
-[IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
-try {
-    & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 `
-        /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
+if ($env:CERTIFICATE_THUMBPRINT) {
+    $thumbprint = $env:CERTIFICATE_THUMBPRINT -replace '\s', ''
+    $cert = Get-ChildItem Cert:\CurrentUser\My\$thumbprint -ErrorAction SilentlyContinue
+    if (-not $cert -or -not $cert.HasPrivateKey) { throw "Certificate with thumbprint $thumbprint is not available with a private key." }
+    & $signtool.FullName sign /sha1 $thumbprint /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
     if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
 }
-finally {
-    Remove-Item $pfx -Force -ErrorAction SilentlyContinue
+else {
+    $pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
+    [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
+    try {
+        & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
+        if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
+    } finally { Remove-Item $pfx -Force -ErrorAction SilentlyContinue }
 }
 
 Write-Host "Signed $($targets.Count) file(s)."


### PR DESCRIPTION
Use the authorized self-hosted runner certificate store for SimplySign signing, with the existing PFX secret path as fallback. Keep release signing limited to the uiAccess server and installer.