### PR TITLE
fix(ci): avoid duplicate CodeQL scans on pushes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,5 @@
 name: CodeQL
 on:
-  push:
-    branches: [develop, main]
   pull_request:
   schedule:
     - cron: '11 3 * * 1'


### PR DESCRIPTION
Run CodeQL on pull requests, the weekly schedule, and manual dispatch only. Remove redundant scans on pushes to develop and main.