### PR TITLE
fix: 改进长句候选展示与候选排序

### DIFF
--- a/product-lock.json
+++ b/product-lock.json
@@ -3,7 +3,7 @@
   "repositories": {
     "engine": {
       "repository": "metasequoiaime/MSIME-Engine",
-      "commit": "8eb4b4e1ea448aa552eda773fd43d40daba34394"
+      "commit": "f1397379bbf630bdf26863bbffbfd9d7a9b9221b"
     }
   },
   "dictionary": {

--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -914,8 +914,16 @@ std::string BuildCurrentCandidatePage()
 
         CandidateViewItem view;
         view.text = word;
-        if (item.source == CandidateSource::Generated && !item.pinyin.empty())
-            view.annotation = " " + item.pinyin;
+        if (item.source == CandidateSource::Generated && show_helpcodes)
+        {
+            // Generated whole-sentence candidates carry the raw spelling in
+            // item.pinyin.  When helpcodes are enabled, do not expose that
+            // full preedit; sentence annotations must use the normal
+            // first/last-character helpcode rule instead.  If the helpcode
+            // cannot be computed, leave the annotation empty rather than
+            // falling back to the raw preedit.
+            view.annotation = g_inputSession->get_helpcode_annotation(item.word, uppercase_all_helpcodes);
+        }
         if (show_helpcodes && item.source != CandidateSource::EnglishDictionary &&
             item.source != CandidateSource::QuickPhrase && item.source != CandidateSource::Emoji &&
             item.source != CandidateSource::Kaomoji && item.source != CandidateSource::Generated)


### PR DESCRIPTION
## 改动摘要

本 PR 包含两部分改动：

1. 修复句子候选显示问题，避免在开启辅助码时将整句原始拼音作为候选注释展示。
2. 更新 Engine 子模块：
   - 优先展示 Google Pinyin 生成的整句候选。
   - 将词典 lattice 候选限制为最高分路径。
   - 避免重复候选占用候选位。
   - 同时覆盖全拼和双拼输入。

主仓库已基于最新的 `upstream/develop` 重新整理。

关联 Issue：无

## 怎么验证的

- 系统与版本：Windows CI，`windows-2025`
- 构建配置：Release
- 已执行命令：

```powershell
cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static
cmake --build build --config Release --parallel
ctest --test-dir build -C Release --output-on-failure --timeout 20
```

测试结果：

- 14 项测试中 11 项通过
- 3 项达到 CTest 的 20 秒单项超时限制：
- mixed_expressive_input_session
- temporary_input_session
- local_modes
- 这 3 项是超时，不是断言失败，均在约 20.2 秒时被 CTest 终止。
- 已确认本次 Engine 改动只涉及：
quanpin/quanpin_dictionary.cpp
shuangpin/shuangpin_dictionary.cpp
- temporary_input_session 和 local_modes 不经过本次新增的长句候选逻辑。
- mixed_expressive_input_session 使用两字符输入 ni，不会触发新增的至少三音节候选路径。

额外检查已通过：

```
git diff --check
python scripts/product_lock.py verify-contracts .
```

目前已在 Win32 EDIT、Excel、Chromium 或 UWP 宿主中完成手动输入验证。