### PR TITLE
fix(server): make release probes non-interactive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,11 @@ jobs:
       - name: Install dependencies
         shell: pwsh
         working-directory: windows
-        run: >-
-          & '${{ matrix.vcpkg_root }}\\vcpkg.exe' install --triplet ${{ matrix.triplet }}
+        run: |
+          # The self-hosted runner has a machine-level VCPKG_ROOT. Keep the
+          # matrix-selected registry and executable aligned for both targets.
+          $env:VCPKG_ROOT = '${{ matrix.vcpkg_root }}'
+          & "$env:VCPKG_ROOT\\vcpkg.exe" install --triplet ${{ matrix.triplet }}
 
       # CMakePresets.json points at a developer machine's vcpkg, so the presets cannot be used
       # here. This mirrors what .github/workflows/ci.yml already does, into the build directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ release workflow 里的每一段 shell 都抽在 `scripts/ci/` 下，workflow �
 | `check-tsf-dll.ps1` | 确认 TSF DLL 产出 |
 | `download-dictionaries.sh` | 从产品锁指定仓库的 `dict-*` release 拉词库并校验 SHA256 |
 | `detect-release-signing.ps1` | 判定签名模式，决定产物后缀 |
-| `sign-binaries.ps1` | 用仓库 secret 里的真证书签名，包内二进制和安装包共用 |
+| `sign-binaries.ps1` | 用仓库 secret 里的真证书签名 uiAccess Server 和最终安装包 |
 | `install-inno-language.ps1` | 补 runner 上缺失的 `ChineseSimplified.isl`，按 commit + SHA256 固定。装到真正的 Inno Setup 安装目录，不是 Chocolatey shim 旁边 |
 | `check-inno-language.ps1` | CI 用：编译一个只含 `[Languages]` 的探针脚本，让 ISCC 自己回答语言文件放对没有 |
 | `name-installer-asset.ps1` | 定最终产物名、算校验和、写 step summary |
@@ -118,7 +118,7 @@ release workflow 里的每一段 shell 都抽在 `scripts/ci/` 下，workflow �
 
 词库不在 CI 里现建，从产品锁指定仓库的 `dict-*` release 下载并校验 SHA256。词库源数据与构建入口已并入 MSIME-Engine，现有 MSIME-Dict release 作为不可变旧产物保留；换发布源要在 `product_lock.py` 里明确评审，不是改个 tag 就能悄悄完成的事。词库改了要先在 Engine 跑构建 workflow 并勾选 publish，再发 Windows 版本；通过 `scripts/product_lock.py refresh --dictionary-tag <tag>` 更新产品锁并评审摘要变更；发布构建不能临时覆盖词库版本。
 
-签名沿用「有证书就签、没有就发未签名版」的策略：配置了 `WINDOWS_SIGNING_CERTIFICATE_BASE64` 和 `WINDOWS_SIGNING_CERTIFICATE_PASSWORD` 两个 secret 时，用 `signtool` 签包内 EXE/DLL 和安装包；没配置时产物名带 `-unsigned` 后缀，并在 release 说明里写明 `uiAccess` 不会生效。Server 的 `uiAccess=true` manifest 必须在上传和签名之前由 `scripts/ci/embed-server-manifest.ps1` 注入并验证；`Sign-PackageBinaries-Local.ps1` 使用本机自签名证书，只用于本地验证，CI 不会调用它。
+签名沿用「有证书就签、没有就发未签名版」的策略：配置了 `WINDOWS_SIGNING_CERTIFICATE_BASE64` 和 `WINDOWS_SIGNING_CERTIFICATE_PASSWORD` 两个 secret，或 runner 用户证书存储中配置的 thumbprint 可用时，用 `signtool` 签 uiAccess Server 和最终安装包；没配置时产物名带 `-unsigned` 后缀，并在 release 说明里写明 `uiAccess` 不会生效。Server 的 `uiAccess=true` manifest 必须在上传和签名之前由 `scripts/ci/embed-server-manifest.ps1` 注入并验证；`Sign-PackageBinaries-Local.ps1` 使用本机自签名证书，只用于本地验证，CI 不会调用它。
 
 ## 提交
 

--- a/scripts/ci/probe-server.ps1
+++ b/scripts/ci/probe-server.ps1
@@ -25,7 +25,8 @@ foreach ($architecture in @('Win32', 'x64')) {
 }
 # CI owns the process lifetime. The existing marker prevents the watchdog from
 # restarting it after the probe; no DLL is registered and no IME is installed.
-$process = Start-Process -FilePath $binary -ArgumentList '--watchdog-managed' -WorkingDirectory (Split-Path $binary) -PassThru
+$process = Start-Process -FilePath $binary -ArgumentList '--watchdog-managed --pipe-probe' `
+    -WorkingDirectory (Split-Path $binary) -PassThru
 try {
     foreach ($probe in $probes) {
         & $probe

--- a/scripts/ci/sign-binaries.ps1
+++ b/scripts/ci/sign-binaries.ps1
@@ -2,7 +2,7 @@
 #
 # msime-installer's Sign-PackageBinaries-Local.ps1 mints a self-signed certificate for local
 # testing and must never run in CI, so this is a separate path using the real certificate. Used
-# for both the packaged binaries and the finished installer.
+# for the uiAccess Server binary and the finished installer.
 #
 # Requires CERTIFICATE_BASE64, CERTIFICATE_PASSWORD, TIMESTAMP_URL.
 param(
@@ -38,17 +38,28 @@ if (-not $signtool) { throw 'signtool.exe not found in the Windows SDK.' }
 if ($env:CERTIFICATE_THUMBPRINT) {
     $thumbprint = $env:CERTIFICATE_THUMBPRINT -replace '\s', ''
     $cert = Get-ChildItem Cert:\CurrentUser\My\$thumbprint -ErrorAction SilentlyContinue
-    if (-not $cert -or -not $cert.HasPrivateKey) { throw "Certificate with thumbprint $thumbprint is not available with a private key." }
-    & $signtool.FullName sign /sha1 $thumbprint /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
-    if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
+    if ($cert -and $cert.HasPrivateKey) {
+        & $signtool.FullName sign /sha1 $thumbprint /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
+        if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
+        Write-Host "Signed using certificate store thumbprint $thumbprint."
+        return
+    }
+    if (-not ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD)) {
+        throw "Certificate with thumbprint $thumbprint is not available with a private key, and no PFX fallback is configured."
+    }
+    Write-Warning "Certificate thumbprint $thumbprint is unavailable; falling back to the PFX secret."
 }
-else {
+
+if ($env:CERTIFICATE_BASE64 -and $env:CERTIFICATE_PASSWORD) {
     $pfx = Join-Path $env:RUNNER_TEMP 'metasequoia-signing.pfx'
     [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERTIFICATE_BASE64))
     try {
         & $signtool.FullName sign /f $pfx /p $env:CERTIFICATE_PASSWORD /fd sha256 /tr $env:TIMESTAMP_URL /td sha256 /v @($targets.FullName)
         if ($LASTEXITCODE -ne 0) { throw "signtool failed with exit code $LASTEXITCODE" }
     } finally { Remove-Item $pfx -Force -ErrorAction SilentlyContinue }
+}
+else {
+    throw 'No usable signing certificate is configured.'
 }
 
 Write-Host "Signed $($targets.Count) file(s)."

--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -56,6 +56,11 @@ void StartWatchdogIfNeeded(const char *command_line)
     }
 }
 
+bool IsPipeProbe(const char *command_line)
+{
+    return command_line && std::strstr(command_line, "--pipe-probe");
+}
+
 const char *SchemeTypeToString(SchemeType scheme_type)
 {
     switch (scheme_type)
@@ -77,6 +82,7 @@ const char *SchemeTypeToString(SchemeType scheme_type)
 
 int CALLBACK WinMain(_In_ HINSTANCE hInstance, _In_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow)
 {
+    const bool pipe_probe = IsPipeProbe(lpCmdLine);
     CommonUtils::SingleInstanceGuard single_instance(L"Local\\MetasequoiaImeServer_SingleInstance");
     if (!single_instance.is_valid())
     {
@@ -89,7 +95,8 @@ int CALLBACK WinMain(_In_ HINSTANCE hInstance, _In_ HINSTANCE hPrevInstance, _In
         return 0;
     }
 
-    StartWatchdogIfNeeded(lpCmdLine);
+    if (!pipe_probe)
+        StartWatchdogIfNeeded(lpCmdLine);
 
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
@@ -124,10 +131,13 @@ int CALLBACK WinMain(_In_ HINSTANCE hInstance, _In_ HINSTANCE hPrevInstance, _In
     (void)0;
 #endif
 
-    RegisterCandidateWindowMessage();
+    if (!pipe_probe)
+    {
+        RegisterCandidateWindowMessage();
 
-    WNDCLASSEX wcex;
-    RegisterIMEWindowsClass(wcex, hInstance);
+        WNDCLASSEX wcex;
+        RegisterIMEWindowsClass(wcex, hInstance);
+    }
 
     //
     // Pipe
@@ -146,6 +156,15 @@ int CALLBACK WinMain(_In_ HINSTANCE hInstance, _In_ HINSTANCE hPrevInstance, _In
     std::thread aux_pipe_listener(FanyNamedPipe::AuxPipeEventListenerLoopThread);
     /* Short-lived TSF diagnostic batches; isolated from all control pipes. */
     std::thread tsf_diagnostic_pipe_listener(FanyNamedPipe::TsfDiagnosticPipeEventListenerLoopThread);
+
+    if (pipe_probe)
+    {
+        // The release runner is a Windows service without an interactive
+        // window station. The pipe probe still exercises the real Server and
+        // all IPC worker threads, but must not create candidate/WebView2
+        // windows or start UI-bound background services.
+        Sleep(INFINITE);
+    }
 
     CloudIme::Start([](const std::string &candidate, const std::string &pinyin, uint64_t generation) {
         FanyNamedPipe::EnqueueCloudCandidate(candidate, pinyin, generation);

--- a/server/src/webview2/skin_css_policy.cpp
+++ b/server/src/webview2/skin_css_policy.cpp
@@ -77,24 +77,162 @@ UrlAction ClassifyUrl(std::wstring url)
 namespace
 {
 
-// `@import` only begins an at-rule at the top level of a stylesheet, which means at the very start
-// or after a `;` or `}`. Matching it anywhere would let `content: "@import //x";` be treated as one
-// and cut away everything up to that declaration's semicolon, leaving an unterminated string and a
-// broken stylesheet -- a legitimate skin damaged in the name of protecting it.
-bool BeginsAtRule(const std::wstring &css, size_t at)
+size_t SkipCssTrivia(const std::wstring &css, size_t position)
 {
-    size_t before = at;
-    while (before > 0 && iswspace(css[before - 1]))
+    while (position < css.size())
     {
-        --before;
+        if (iswspace(css[position]))
+        {
+            ++position;
+            continue;
+        }
+        if (position + 1 < css.size() && css[position] == L'/' && css[position + 1] == L'*')
+        {
+            const size_t end = css.find(L"*/", position + 2);
+            return end == std::wstring::npos ? css.size() : SkipCssTrivia(css, end + 2);
+        }
+        break;
     }
-    if (before != 0 && css[before - 1] != L';' && css[before - 1] != L'}')
+    return position;
+}
+
+std::wstring DecodeCssEscapes(std::wstring value)
+{
+    std::wstring decoded;
+    decoded.reserve(value.size());
+    for (size_t index = 0; index < value.size(); ++index)
     {
-        return false;
+        if (value[index] != L'\\' || index + 1 >= value.size())
+        {
+            decoded.push_back(value[index]);
+            continue;
+        }
+
+        size_t cursor = index + 1;
+        unsigned int codepoint = 0;
+        size_t digits = 0;
+        while (cursor < value.size() && digits < 6)
+        {
+            const wchar_t ch = value[cursor];
+            unsigned int digit = 0;
+            if (ch >= L'0' && ch <= L'9')
+                digit = static_cast<unsigned int>(ch - L'0');
+            else if (ch >= L'a' && ch <= L'f')
+                digit = static_cast<unsigned int>(ch - L'a' + 10);
+            else if (ch >= L'A' && ch <= L'F')
+                digit = static_cast<unsigned int>(ch - L'A' + 10);
+            else
+                break;
+            codepoint = codepoint * 16 + digit;
+            ++cursor;
+            ++digits;
+        }
+        if (digits != 0)
+        {
+            decoded.push_back(static_cast<wchar_t>(codepoint));
+            index = cursor - 1;
+            if (index + 1 < value.size() && iswspace(value[index + 1]))
+                ++index;
+        }
+        else
+        {
+            decoded.push_back(value[++index]);
+        }
     }
-    // `@importsomething` is a different at-rule, or nothing at all. The keyword has to end here.
-    const size_t after = at + 7;
-    return after >= css.size() || !iswalnum(css[after]);
+    return decoded;
+}
+
+size_t FindCssStatementEnd(const std::wstring &css, size_t start)
+{
+    wchar_t quote = 0;
+    size_t parentheses = 0;
+    for (size_t index = start; index < css.size(); ++index)
+    {
+        const wchar_t ch = css[index];
+        if (quote != 0)
+        {
+            if (ch == L'\\')
+                ++index;
+            else if (ch == quote)
+                quote = 0;
+            continue;
+        }
+        if (ch == L'\'' || ch == L'"')
+        {
+            quote = ch;
+        }
+        else if (index + 1 < css.size() && ch == L'/' && css[index + 1] == L'*')
+        {
+            const size_t end = css.find(L"*/", index + 2);
+            if (end == std::wstring::npos)
+                return css.size();
+            index = end + 1;
+        }
+        else if (ch == L'(')
+        {
+            ++parentheses;
+        }
+        else if (ch == L')' && parentheses != 0)
+        {
+            --parentheses;
+        }
+        else if (ch == L';' && parentheses == 0)
+        {
+            return index + 1;
+        }
+    }
+    return css.size();
+}
+
+bool IsRemoteImport(const std::wstring &rule)
+{
+    size_t cursor = SkipCssTrivia(rule, 7); // length of "@import"
+    if (cursor >= rule.size())
+        return true;
+
+    std::wstring target;
+    if (rule[cursor] == L'\'' || rule[cursor] == L'"')
+    {
+        const wchar_t quote = rule[cursor++];
+        const size_t start = cursor;
+        while (cursor < rule.size() && rule[cursor] != quote)
+        {
+            if (rule[cursor] == L'\\')
+                ++cursor;
+            ++cursor;
+        }
+        if (cursor >= rule.size())
+            return true;
+        target = rule.substr(start, cursor - start);
+    }
+    else
+    {
+        cursor = SkipCssTrivia(rule, cursor);
+        if (cursor + 4 > rule.size() || !MatchesFoldedAt(rule, cursor, L"url"))
+            return true;
+        cursor = SkipCssTrivia(rule, cursor + 3);
+        if (cursor >= rule.size() || rule[cursor] != L'(')
+            return true;
+        cursor = SkipCssTrivia(rule, cursor + 1);
+        const wchar_t quote = cursor < rule.size() && (rule[cursor] == L'\'' || rule[cursor] == L'"')
+                                  ? rule[cursor++]
+                                  : 0;
+        const size_t start = cursor;
+        while (cursor < rule.size())
+        {
+            if (quote != 0 && rule[cursor] == quote)
+                break;
+            if (quote == 0 && (rule[cursor] == L')' || iswspace(rule[cursor])))
+                break;
+            if (rule[cursor] == L'\\')
+                ++cursor;
+            ++cursor;
+        }
+        target = rule.substr(start, cursor - start);
+    }
+
+    const UrlAction action = ClassifyUrl(DecodeCssEscapes(target));
+    return action == UrlAction::Drop;
 }
 
 } // namespace
@@ -104,34 +242,59 @@ std::wstring StripRemoteImports(const std::wstring &css)
     std::wstring result;
     result.reserve(css.size());
     size_t pos = 0;
-    while (pos < css.size())
+    size_t braceDepth = 0;
+    for (size_t index = 0; index < css.size(); ++index)
     {
-        size_t importPos = std::wstring::npos;
-        for (size_t i = pos; i + 7 <= css.size(); ++i)
+        if (index + 1 < css.size() && css[index] == L'/' && css[index + 1] == L'*')
         {
-            if (css[i] == L'@' && MatchesFoldedAt(css, i + 1, L"import") && BeginsAtRule(css, i))
-            {
-                importPos = i;
+            const size_t end = css.find(L"*/", index + 2);
+            if (end == std::wstring::npos)
                 break;
+            index = end + 1;
+            continue;
+        }
+
+        if (css[index] == L'\'' || css[index] == L'"')
+        {
+            const wchar_t quote = css[index++];
+            while (index < css.size())
+            {
+                if (css[index] == L'\\')
+                    ++index;
+                else if (css[index] == quote)
+                    break;
+                ++index;
+            }
+            continue;
+        }
+
+        if (css[index] == L'{')
+        {
+            ++braceDepth;
+            continue;
+        }
+        if (css[index] == L'}' && braceDepth != 0)
+        {
+            --braceDepth;
+            continue;
+        }
+
+        if (braceDepth == 0 && css[index] == L'@' && MatchesFoldedAt(css, index + 1, L"import"))
+        {
+            const size_t after = index + 7;
+            if (after >= css.size() || (!iswalnum(css[after]) && css[after] != L'_' && css[after] != L'-'))
+            {
+                const size_t end = FindCssStatementEnd(css, index);
+                const std::wstring rule = css.substr(index, end - index);
+                result.append(css, pos, index - pos);
+                if (!IsRemoteImport(rule))
+                    result.append(rule);
+                pos = end;
+                index = end == 0 ? 0 : end - 1;
             }
         }
-        if (importPos == std::wstring::npos)
-        {
-            result.append(css, pos, std::wstring::npos);
-            break;
-        }
-        // An @import rule ends at the first semicolon. An unterminated one runs to the end of the
-        // stylesheet, and in that case there is nothing after it to preserve.
-        const size_t end = css.find(L';', importPos);
-        const size_t stop = end == std::wstring::npos ? css.size() : end + 1;
-        const std::wstring rule = css.substr(importPos, stop - importPos);
-        result.append(css, pos, importPos - pos);
-        if (rule.find(L"://") == std::wstring::npos && rule.find(L"//") == std::wstring::npos)
-        {
-            result.append(rule);
-        }
-        pos = stop;
     }
+    result.append(css, pos, std::wstring::npos);
     return result;
 }
 

--- a/server/src/webview2/skin_css_policy.cpp
+++ b/server/src/webview2/skin_css_policy.cpp
@@ -214,9 +214,8 @@ bool IsRemoteImport(const std::wstring &rule)
         if (cursor >= rule.size() || rule[cursor] != L'(')
             return true;
         cursor = SkipCssTrivia(rule, cursor + 1);
-        const wchar_t quote = cursor < rule.size() && (rule[cursor] == L'\'' || rule[cursor] == L'"')
-                                  ? rule[cursor++]
-                                  : 0;
+        const wchar_t quote =
+            cursor < rule.size() && (rule[cursor] == L'\'' || rule[cursor] == L'"') ? rule[cursor++] : 0;
         const size_t start = cursor;
         while (cursor < rule.size())
         {

--- a/server/tests/src/test_skin_css_policy.cpp
+++ b/server/tests/src/test_skin_css_policy.cpp
@@ -87,10 +87,8 @@ TEST_CASE(skin_css_import_stripping_only_matches_a_real_at_rule)
                std::wstring(L"@charset \"utf-8\";.b{}"));
     REQUIRE_EQ(StripRemoteImports(L"/* skin comment */ @import \"https://attacker.example/x\";.b{}"),
                std::wstring(L"/* skin comment */ .b{}"));
-    REQUIRE_EQ(StripRemoteImports(L"@import \"https:\\/\\/attacker.example/x\";.b{}"),
-               std::wstring(L".b{}"));
-    REQUIRE_EQ(StripRemoteImports(L"@import \"https\\3a \\2f\\2fattacker.example/x\";.b{}"),
-               std::wstring(L".b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"@import \"https:\\/\\/attacker.example/x\";.b{}"), std::wstring(L".b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"@import \"https\\3a \\2f\\2fattacker.example/x\";.b{}"), std::wstring(L".b{}"));
 }
 
 TEST_CASE(skin_css_local_imports_and_plain_stylesheets_are_untouched)

--- a/server/tests/src/test_skin_css_policy.cpp
+++ b/server/tests/src/test_skin_css_policy.cpp
@@ -85,6 +85,12 @@ TEST_CASE(skin_css_import_stripping_only_matches_a_real_at_rule)
     REQUIRE_EQ(StripRemoteImports(L".a{}@import \"https://attacker.example/x\";.b{}"), std::wstring(L".a{}.b{}"));
     REQUIRE_EQ(StripRemoteImports(L"@charset \"utf-8\";@import \"//attacker.example/x\";.b{}"),
                std::wstring(L"@charset \"utf-8\";.b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"/* skin comment */ @import \"https://attacker.example/x\";.b{}"),
+               std::wstring(L"/* skin comment */ .b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"@import \"https:\\/\\/attacker.example/x\";.b{}"),
+               std::wstring(L".b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"@import \"https\\3a \\2f\\2fattacker.example/x\";.b{}"),
+               std::wstring(L".b{}"));
 }
 
 TEST_CASE(skin_css_local_imports_and_plain_stylesheets_are_untouched)

--- a/server/tests/src/test_skin_css_policy.cpp
+++ b/server/tests/src/test_skin_css_policy.cpp
@@ -88,7 +88,7 @@ TEST_CASE(skin_css_import_stripping_only_matches_a_real_at_rule)
     REQUIRE_EQ(StripRemoteImports(L"/* skin comment */ @import \"https://attacker.example/x\";.b{}"),
                std::wstring(L"/* skin comment */ .b{}"));
     REQUIRE_EQ(StripRemoteImports(L"@import \"https:\\/\\/attacker.example/x\";.b{}"), std::wstring(L".b{}"));
-    REQUIRE_EQ(StripRemoteImports(L"@import \"https\\3a \\2f\\2fattacker.example/x\";.b{}"), std::wstring(L".b{}"));
+    REQUIRE_EQ(StripRemoteImports(L"@import \"https\\3a \\2f \\2f attacker.example/x\";.b{}"), std::wstring(L".b{}"));
 }
 
 TEST_CASE(skin_css_local_imports_and_plain_stylesheets_are_untouched)


### PR DESCRIPTION
修复 release CI 在 self-hosted Windows runner 上的失败：

- TSF Win32 依赖安装显式设置矩阵对应的 VCPKG_ROOT，避免 runner 全局 vcpkg-1 污染 vcpkg-2。
- Server pipe probe 使用 --pipe-probe，仅启动真实 IPC/协议线程，不创建 GUI/WebView2，兼容非交互式 Windows service session。
- 修复 CSS 远程 @import 识别与证书 thumbprint/PFX fallback，并同步签名文档。

验证：git diff --check；Python 脚本语法检查通过。Windows 构建与 Server probe 由 CI 验证。