### PR TITLE
fix(scripts): keep automatic releases as prereleases

### DIFF
--- a/scripts/ci/publish-release.sh
+++ b/scripts/ci/publish-release.sh
@@ -15,7 +15,7 @@ if [[ "$RELEASE_TRIGGER" == push ]]; then
     # Braces are required: bash takes the full-width bracket that follows as part of the name otherwise.
     title="${TAG_NAME}（自动构建）"
     banner='本版本由 CI 在合并到 `main` 后自动构建发布。'
-    channel=(--prerelease=false --latest)
+    channel=(--prerelease)
 else
     title="$TAG_NAME"
     banner=''


### PR DESCRIPTION
修复 release 发布频道判断：

- push 自动构建使用 `--prerelease`，与标题“（自动构建）”和仓库发布约定一致。
- workflow_dispatch 继续发布为正式 Latest。
- 已将现有由 push 产生的 v0.6.2 改回 Pre-release。

验证：`bash -n scripts/ci/publish-release.sh`。