### PR TITLE
chore(ci): CodeQL 仅在午夜定时运行

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,9 +1,8 @@
 name: CodeQL
 on:
-  pull_request:
   schedule:
-    - cron: '11 3 * * 1'
-  workflow_dispatch:
+    # Daily at 00:00 Asia/Tokyo (UTC+09:00).
+    - cron: '0 15 * * *'
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
CodeQL 统一为每天东京时间 00:00（UTC 15:00）定时运行，移除 push、pull_request 和 workflow_dispatch 触发。扫描语言、权限和分析步骤保持不变。

验证：`actionlint .github/workflows/codeql.yml`、`git diff --check` 均通过；PyYAML BaseLoader 确认唯一触发事件是 schedule，并逐字比较确认触发区外的配置保持不变。仅修改工作流触发配置，未运行原生构建或 CodeQL 扫描。

此修改与其他仓库无合并顺序依赖。

相关 PR：

- [.github](https://github.com/metasequoiaime/.github/pull/21)
- [MSIME-Apple](https://github.com/metasequoiaime/MSIME-Apple/pull/330)
- [MSIME-Docs](https://github.com/metasequoiaime/MSIME-Docs/pull/16)
- [MSIME-Engine](https://github.com/metasequoiaime/MSIME-Engine/pull/65)
- [MSIME-Linux](https://github.com/metasequoiaime/MSIME-Linux/pull/106)
- [MSIME-Web](https://github.com/metasequoiaime/MSIME-Web/pull/35)
