### PR TITLE
fix(config): handle non-ASCII (e.g. Chinese) user profile paths

### DIFF
--- a/server/src/config/ime_config.cpp
+++ b/server/src/config/ime_config.cpp
@@ -628,7 +628,14 @@ bool LoadImeConfig()
         return false;
     try
     {
-        auto tbl = toml::parse_file(g_config_path.string());
+        // Read via the wide path and parse the text. toml::parse_file(g_config_path.string()) would run the
+        // path through the ANSI code page; on a non-ASCII (e.g. Chinese) config path that corrupts it, and on
+        // a code page that cannot represent the characters path::string() throws, crashing the process.
+        std::ifstream input(g_config_path, std::ios::binary);
+        if (!input)
+            return false;
+        const std::string text((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+        auto tbl = toml::parse(text);
 
         const int page_size = tbl["appearance"]["page_size"].value_or(6);
         g_candidate_page_size = page_size >= 3 && page_size <= 9 ? page_size : 6;
@@ -1072,12 +1079,14 @@ void MigrateLegacyVoiceInputConfig()
     if (!voice.asr_token.empty())
         return;
     const std::filesystem::path legacy_path =
-        std::filesystem::path(CommonUtils::get_local_appdata_path()) / "MetasequoiaVoiceInput" / "config.toml";
+        std::filesystem::path(CommonUtils::get_local_appdata_path_w()) / L"MetasequoiaVoiceInput" / L"config.toml";
     if (!std::filesystem::exists(legacy_path))
         return;
     try
     {
-        const toml::table legacy = toml::parse_file(legacy_path.string());
+        std::ifstream legacy_input(legacy_path, std::ios::binary);
+        const std::string legacy_text((std::istreambuf_iterator<char>(legacy_input)), std::istreambuf_iterator<char>());
+        const toml::table legacy = toml::parse(legacy_text);
         const std::string asr_token = legacy["asr_api"]["token"].value_or(std::string());
         if (asr_token.empty())
             return;
@@ -1217,7 +1226,10 @@ std::string MergeConfigIntoTemplate(const std::string &template_text, const std:
 
 void InitImeConfig()
 {
-    g_config_path = std::filesystem::path(CommonUtils::get_ime_data_path()) / "config.toml";
+    // Build the path from the wide accessor: std::filesystem::path(std::string) decodes with the
+    // system ANSI code page, which corrupts a non-ASCII (e.g. Chinese) user profile path on a
+    // non-UTF-8 ACP machine and makes every config read/write fail ("设置保存失败").
+    g_config_path = std::filesystem::path(CommonUtils::get_ime_data_path_w()) / L"config.toml";
     std::error_code create_error;
     std::filesystem::create_directories(g_config_path.parent_path(), create_error);
     SyncConfigWithInstalledTemplate();

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ set(TEST_SOURCE_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_terminal_deactivation_policy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_user_dictionary_journal.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_config_template_merge.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/test_config_non_ascii_path.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_system_font_family.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_dictionary_validation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_skin_css_policy.cpp"

--- a/server/tests/src/test_config_non_ascii_path.cpp
+++ b/server/tests/src/test_config_non_ascii_path.cpp
@@ -1,0 +1,81 @@
+#include "tests/includes/test_framework.h"
+
+#include "config/ime_config.h"
+
+#include <windows.h>
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+namespace
+{
+// Sets an environment variable for the duration of a scope and restores it afterwards, so the config
+// module can be pointed at a throwaway profile directory without leaking into other tests.
+class ScopedEnv
+{
+  public:
+    ScopedEnv(const wchar_t *name, const std::wstring &value) : name_(name)
+    {
+        wchar_t buffer[32768];
+        const DWORD length = GetEnvironmentVariableW(name, buffer, 32768);
+        had_previous_ = length != 0 || GetLastError() != ERROR_ENVVAR_NOT_FOUND;
+        previous_.assign(buffer, length);
+        SetEnvironmentVariableW(name, value.c_str());
+    }
+    ~ScopedEnv()
+    {
+        SetEnvironmentVariableW(name_.c_str(), had_previous_ ? previous_.c_str() : nullptr);
+    }
+
+    ScopedEnv(const ScopedEnv &) = delete;
+    ScopedEnv &operator=(const ScopedEnv &) = delete;
+
+  private:
+    std::wstring name_;
+    std::wstring previous_;
+    bool had_previous_ = false;
+};
+} // namespace
+
+// A non-ASCII (e.g. Chinese) user profile path must not break config persistence. Whatever the system
+// ANSI code page is, writing a setting and reading it back has to round-trip, because the config module
+// builds and opens the path as wide characters instead of routing it through the ANSI encoding (which
+// corrupts the path, or throws on code pages that cannot represent the characters).
+TEST_CASE(config_round_trips_under_non_ascii_profile_path)
+{
+    namespace fs = std::filesystem;
+    const fs::path unique_root =
+        fs::temp_directory_path() / (L"msime-配置测试-" + std::to_wstring(GetCurrentProcessId()));
+    const fs::path local_app_data = unique_root / L"本地";
+    const fs::path data_dir = local_app_data / L"metasequoiaime";
+
+    std::error_code ec;
+    fs::remove_all(unique_root, ec);
+    fs::create_directories(data_dir, ec);
+    REQUIRE(!ec);
+    // Seed the shipped default so SyncConfigWithInstalledTemplate can create config.toml.
+    fs::copy_file(MSIME_DEFAULT_CONFIG_PATH, data_dir / L"config.default.toml", fs::copy_options::overwrite_existing,
+                  ec);
+    REQUIRE(!ec);
+
+    {
+        ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
+
+        InitImeConfig();
+        // The config file must land under the Chinese directory, not a mangled sibling.
+        REQUIRE(fs::exists(data_dir / L"config.toml"));
+
+        // Writing settings must succeed (this is what surfaced as "设置保存失败" for these users), using
+        // values that differ from the shipped defaults so the assertions below actually prove a change.
+        REQUIRE(SetConfiguredInputMode("japanese"));
+        REQUIRE(SetConfiguredInputScheme("wubi"));
+
+        // Re-initialise so the values are re-parsed from disk, proving they persisted through the file.
+        InitImeConfig();
+        REQUIRE_EQ(GetConfiguredInputMode(), std::string("japanese"));
+        REQUIRE_EQ(GetConfiguredInputSchemeName(), std::string("wubi"));
+    }
+
+    fs::remove_all(unique_root, ec);
+}

--- a/windows/src/Utils/FanyUtils.cpp
+++ b/windows/src/Utils/FanyUtils.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <cstdlib>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include "Define.h"
@@ -59,20 +61,23 @@ bool ParseTomlBool(const std::string &raw, bool fallback)
     return fallback;
 }
 
-std::string SharedConfigPath()
+std::filesystem::path SharedConfigPath()
 {
-    const char *localAppDataPath = std::getenv("LOCALAPPDATA");
+    // Build a wide path and open it as such. A narrow std::string path would be opened through the
+    // ANSI code page, which cannot round-trip a non-ASCII (e.g. Chinese) user profile path on a
+    // non-UTF-8 system, so the TSF would read the wrong file or fail to find the config.
+    const wchar_t *localAppDataPath = _wgetenv(L"LOCALAPPDATA");
     if (!localAppDataPath)
     {
         return {};
     }
-    return std::string(localAppDataPath) + "\\metasequoiaime\\config.toml";
+    return std::filesystem::path(localAppDataPath) / L"metasequoiaime" / L"config.toml";
 }
 } // namespace
 
 BOOL ReadConfiguredDefaultImeModeChinese()
 {
-    const std::string configPath = SharedConfigPath();
+    const std::filesystem::path configPath = SharedConfigPath();
     if (configPath.empty())
     {
         return TRUE;
@@ -125,7 +130,7 @@ BOOL ReadConfiguredDefaultImeModeChinese()
 
 int ReadConfiguredPunctuationLock()
 {
-    const std::string configPath = SharedConfigPath();
+    const std::filesystem::path configPath = SharedConfigPath();
     if (configPath.empty())
     {
         return Global::PunctuationLock::Follow;
@@ -191,7 +196,7 @@ void RefreshPunctuationLockFromConfig()
 
 BOOL ReadConfiguredJapaneseInputMode()
 {
-    const std::string configPath = SharedConfigPath();
+    const std::filesystem::path configPath = SharedConfigPath();
     if (configPath.empty())
     {
         return FALSE;
@@ -245,7 +250,7 @@ BOOL ReadConfiguredJapaneseInputMode()
 SwitchLanguageHotkeys ReadConfiguredSwitchLanguageHotkeys()
 {
     SwitchLanguageHotkeys result;
-    const std::string configPath = SharedConfigPath();
+    const std::filesystem::path configPath = SharedConfigPath();
     if (configPath.empty())
     {
         return result;


### PR DESCRIPTION
## 问题

Related to #242 

非 ASCII(如中文)用户名下,输入法配置无法保存:进入设置切换「日文」/「全拼」等任意项都会弹出 **`设置保存失败，请重试。`**。在部分系统代码页下,Server 进程还会在启动时崩溃,并被 watchdog 反复拉起。

## 根因

配置路径经过了**系统 ANSI 代码页(CP_ACP)**的窄字符转换:

- `g_config_path` 由 `std::filesystem::path(std::string)` 构造,而传入的是 UTF-8 字符串;`std::filesystem::path` 在 MSVC 上按系统 ACP 解释窄字节,并非 UTF-8。
- `LoadImeConfig` / `MigrateLegacyVoiceInputConfig` 用 `toml::parse_file(path.string())`,`.string()` 又把宽路径转回 ANSI。
- TSF DLL(`FanyUtils.cpp`)用窄 `std::string` 拼路径并 `std::ifstream` 打开。

后果:

1. 在中文系统(ACP=936/GBK)下,UTF-8 路径字节被当成 GBK 解码 → 路径损坏 → 配置文件打不开 → 所有写入失败 → `设置保存失败`。
2. 在无法表示这些字符的代码页(如 1252)下,`path::string()` 直接抛 `std::system_error`,未被 `catch (toml::parse_error)` 接住 → `terminate` → **Server 启动崩溃循环**。

只有「非 ASCII 用户名 **且** 非 UTF-8 系统代码页」的用户会命中;ASCII 用户名或 UTF-8(65001)代码页的机器不受影响,因此开发机通常无法复现。

## 修复

原则:**配置路径全程使用宽字符,绝不经过 ANSI 窄字符转换**(与仓库既有的 `u8path` / 宽字符约定一致)。

- **构造**:`g_config_path` 与语音旧配置路径改用宽访问器 `get_ime_data_path_w()` / `get_local_appdata_path_w()`。
- **读取**:`LoadImeConfig`、`MigrateLegacyVoiceInputConfig` 改为「按宽路径 `std::ifstream` 读出文本 → `toml::parse(text)`」,不再调用 `.string()`。
- **TSF**:`SharedConfigPath` 返回宽 `std::filesystem::path`,四处读取均按宽路径打开(DLL 加载进宿主进程、无法自设代码页,必须靠宽路径)。

## 改动文件

| 文件 | 说明 |
| --- | --- |
| `server/src/config/ime_config.cpp` | 宽路径构造 + 按宽路径读取解析 |
| `windows/src/Utils/FanyUtils.cpp` | TSF `SharedConfigPath` 及读取改为宽路径 |
| `server/tests/src/test_config_non_ascii_path.cpp` | 新增:中文路径下配置读写往返测试 |
| `server/tests/CMakeLists.txt` | 注册新测试 |

## 测试

- 新增单元测试 `config_round_trips_under_non_ascii_profile_path`:将 `LOCALAPPDATA` 指向一个中文名临时目录,执行 `InitImeConfig` + `SetConfiguredInputMode/Scheme`,再从磁盘重新解析并断言值往返成功。该用例在非 UTF-8 代码页下能捕获此回归。
- 全量服务端测试(`MetasequoiaImeServerTests`)通过。
- 通过崩溃转储(`cdb` `!analyze` + 调用栈)确认了启动崩溃的抛出点为 `LoadImeConfig` 中的 `path::string()`。

## 兼容性

- 对 ASCII 用户名 / UTF-8 代码页用户行为不变。
- 无新增依赖,无 Windows 版本门槛。