### PR TITLE
docs(.github): 让新用户更容易填写问题与功能建议

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug 反馈 / Bug Report
-description: 报告水杉输入法的错误或异常行为。Report a bug or unexpected behavior.
+description: 遇到出错、无法输入或显示异常？请描述现象，我们一起排查。Report something that is not working.
 title: "[Bug] "
 labels: ["bug"]
 type: Bug
@@ -16,7 +16,7 @@ body:
     id: component
     attributes:
       label: 相关组件 / Component
-      description: 问题主要出现在哪个部分？Which part is primarily affected?
+      description: 可选择多项。不知道属于哪个部分时，选“不确定”即可。Select all that apply; choose Not sure if unsure.
       multiple: true
       options:
         - 候选窗 / Candidate window
@@ -35,19 +35,19 @@ body:
     attributes:
       label: 问题与行为 / Problem & Actual behavior
       description: 发生了什么？What happened?
-      placeholder: |
-        简要说明问题现象与行为。
+      placeholder: |-
+        例如：打开记事本，切换到水杉输入法后，候选字显示成方框，无法辨认。其他软件中也会出现。
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: 复现步骤 / Steps to Reproduce
-      description: 请尽量给出可复现步骤。Please provide reproducible steps.
-      placeholder: |
-        1. …
-        2. …
-        3. …
+      description: 按顺序写下你做了什么。偶尔出现、无法稳定重现也可以反馈，请写出当时的操作。Describe what you did, even if the issue only happens sometimes.
+      placeholder: |-
+        1. 打开一个文本编辑器，切换到水杉输入法
+        2. 输入测试拼音 nihao
+        3. 观察候选字是否正常显示
     validations:
       required: true
   - type: textarea
@@ -55,21 +55,22 @@ body:
     attributes:
       label: 预期行为 / Expected Behavior
       description: 正常情况下应该怎样？What should happen instead?
+      placeholder: 例如：候选字应正常显示为汉字，按数字键可以选中。
     validations:
       required: true
   - type: input
     id: version
     attributes:
       label: 版本 / Version
-      description: 安装包版本、Release 标签，或 commit hash。Installer version, release tag, or commit hash.
-      placeholder: e.g. 0.0.1 / v0.x.x / abc1234
+      description: 填写你安装的输入法版本号，可查看安装包文件名或下载记录。暂时找不到请填“不确定”。Use the installed version; enter Not sure if unavailable.
+      placeholder: 例如：安装包中的 vX.Y.Z；不知道请填“不确定”
     validations:
       required: true
   - type: input
     id: os
     attributes:
       label: 系统环境 / OS
-      description: Windows 版本与版本号。Windows edition and version.
+      description: Windows 版本与版本号。Windows edition and version. 知道多少写多少，不清楚的项目可写“不确定”。Include what you know; unknown details are OK.
       placeholder: e.g. Windows 11 Pro 24H2 / Windows 10 Pro 22H2
     validations:
       required: true
@@ -83,6 +84,8 @@ body:
         - 五笔 / Wubi
         - 其他 / Other
         - 不适用 / N/A
+        - 不确定 / Not sure
+      description: 选择当时使用的输入方式；不知道名称可以选“不确定”。Choose your input method, or Not sure.
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: 功能建议 / Feature Request
-description: 为水杉输入法提出新功能或改进建议。Propose a new feature or improvement.
+description: 希望增加功能或改善体验？说说你的使用场景。Suggest a feature or improvement.
 title: "[Feat] "
 labels: ["enhancement"]
 type: Feature
@@ -16,7 +16,7 @@ body:
     id: component
     attributes:
       label: 相关组件 / Component
-      description: 该功能主要涉及哪个部分？Which part does this mainly involve?
+      description: 可选择多项。不知道属于哪个部分时，选“不确定”即可。Select all that apply; choose Not sure if unsure.
       multiple: true
       options:
         - 候选窗 / Candidate window
@@ -34,18 +34,19 @@ body:
     id: problem
     attributes:
       label: 问题与动机 / Problem & Motivation
-      description: 当前缺少什么，或现有体验哪里不够好？What problem does this solve?
-      placeholder: |
-        例如：无法…… / 使用某功能时很麻烦……
+      description: 说说你在什么情况下遇到不便，以及它对你的影响。不需要了解技术实现。Describe your situation and the difficulty.
+      placeholder: |-
+        例如：在高分辨率屏幕上打字时，候选字太小，看清后才能选字，打字容易中断。
     validations:
       required: true
   - type: textarea
     id: proposal
     attributes:
       label: 建议方案 / Proposal
-      description: 希望如何实现？可包含交互、快捷键、配置项等。Describe the desired behavior.
+      description: 描述你希望达到的效果即可，不用设计实现方案。还没想好可以跳过。Describe the result you would like; an implementation plan is not needed.
+      placeholder: 例如：希望能在设置里调大候选字，并立即看到调整效果。
     validations:
-      required: true
+      required: false
   - type: textarea
     id: alternatives
     attributes:


### PR DESCRIPTION
新用户无需了解技术术语或先想好实现方案，就能提交有效反馈。为问题描述、操作步骤、期望效果补充示例；版本和环境允许填写已知信息或“不确定”；功能建议的方案改为可选。

模板仍由本仓维护，官网读取这些字段及校验规则；单选在官网显示为圆形按钮，多选保留复选框。

验证：两份 YAML 均经 MSIME-Web 的生产模板解析器校验，最少必填内容可通过提交校验；`git diff --check` 通过。仅修改 issue 模板，未执行原生应用构建。
