### PR TITLE
fix(server): fall back to text when the icon font lacks the glyph

### DIFF
--- a/server/src/emoji-panel/emoji_panel_icons.cpp
+++ b/server/src/emoji-panel/emoji_panel_icons.cpp
@@ -1,8 +1,10 @@
 #include "emoji_panel_icons.h"
 
 #include "msimeui/DeviceResources.h"
+#include "msimeui/Fonts.h"
 #include "msimeui/Types.h"
 
+#include <cwchar>
 #include <d2d1.h>
 #include <dwrite.h>
 #include <wrl/client.h>
@@ -11,19 +13,31 @@ namespace msimeui
 {
 namespace
 {
-constexpr wchar_t kFluentIconsFont[] = L"Segoe Fluent Icons";
 constexpr float kIconFontSize = 28.0f;
+constexpr float kFallbackFontSize = 14.0f;
 
-// Windows emoji panel tab glyphs, in navigation order.
-constexpr wchar_t kTabGlyphs[] = {
-    0xF6B8, // Expressive Input Entry
-    0xE76E, // Emoji
-    0xF4AA, // Sticker
-    0xF4A9, // GIF
-    0xED59, // Emoji Tab Text Smiles
-    0xF6BA, // Emoji Tab More Symbols
-    0xE77F, // Paste
+// Windows emoji panel tab glyphs, in navigation order. "Segoe Fluent Icons"
+// ships with Windows 11 only, and the Windows 10 build of "Segoe MDL2 Assets"
+// is older than the one we can check here, so each tab also carries a text
+// label for the case where neither font has the glyph (issue #232).
+struct TabIcon
+{
+    wchar_t codepoint;
+    const wchar_t *fallbackText;
 };
+
+constexpr TabIcon kTabIcons[] = {
+    {0xF6B8, L"最近"},   // Expressive Input Entry
+    {0xE76E, L"表情"},   // Emoji
+    {0xF4AA, L"贴纸"},   // Sticker
+    {0xF4A9, L"GIF"},    // GIF
+    {0xED59, L"颜文字"}, // Emoji Tab Text Smiles
+    {0xF6BA, L"符号"},   // Emoji Tab More Symbols
+    {0xE77F, L"剪贴板"}, // Paste
+};
+
+static_assert(sizeof(kTabIcons) / sizeof(kTabIcons[0]) == static_cast<size_t>(EmojiPanelIcons::Tab::Count),
+              "tab icon table must cover every tab");
 
 D2D1_COLOR_F IconFillColor(bool lightTheme)
 {
@@ -39,20 +53,27 @@ bool EmojiPanelIcons::DrawTabIcon(DeviceResources &resources, Tab tab, const Rec
         return false;
     }
 
+    const TabIcon &icon = kTabIcons[index];
+    const IconGlyph resolved = ResolveIconGlyph(icon.codepoint);
+    const bool useGlyph = resolved.family != nullptr;
+
     ID2D1RenderTarget *target = resources.GetRenderTarget();
     IDWriteFactory *factory = resources.GetDWriteFactory();
-    IDWriteTextFormat *format = resources.GetTextFormat(kFluentIconsFont, kIconFontSize, DWRITE_FONT_WEIGHT_NORMAL,
-                                                        DWRITE_TEXT_ALIGNMENT_CENTER, DWRITE_PARAGRAPH_ALIGNMENT_CENTER,
-                                                        DWRITE_WORD_WRAPPING_NO_WRAP);
+    IDWriteTextFormat *format = resources.GetTextFormat(
+        useGlyph ? resolved.family : UiFontFamily(), useGlyph ? kIconFontSize : kFallbackFontSize,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_TEXT_ALIGNMENT_CENTER, DWRITE_PARAGRAPH_ALIGNMENT_CENTER,
+        DWRITE_WORD_WRAPPING_NO_WRAP);
     ID2D1SolidColorBrush *brush = resources.GetSolidColorBrush(IconFillColor(lightTheme));
     if (!target || !factory || !format || !brush)
     {
         return false;
     }
 
-    const wchar_t glyph[] = {kTabGlyphs[index], L'\0'};
+    const wchar_t glyph[] = {resolved.codepoint, L'\0'};
+    const wchar_t *text = useGlyph ? glyph : icon.fallbackText;
+    const UINT32 length = static_cast<UINT32>(std::wcslen(text));
     Microsoft::WRL::ComPtr<IDWriteTextLayout> layout;
-    if (FAILED(factory->CreateTextLayout(glyph, 1, format, designRect.width, designRect.height, &layout)))
+    if (FAILED(factory->CreateTextLayout(text, length, format, designRect.width, designRect.height, &layout)))
     {
         return false;
     }

--- a/server/src/window/floating_toolbar_presenter.cpp
+++ b/server/src/window/floating_toolbar_presenter.cpp
@@ -43,20 +43,29 @@ constexpr float kShadowPadRight = 18.0f;
 constexpr float kShadowPadBottom = 20.0f;
 constexpr float kToolbarGlyphFontSizeFactor = 0.82f;
 constexpr float kToolbarUnderlinedTextFontSizeFactor = 0.58f;
-constexpr wchar_t kFluentIconsFont[] = L"Segoe Fluent Icons";
+// Every toolbar icon carries a text fallback: "Segoe Fluent Icons" ships with
+// Windows 11 only, and the Windows 10 build of "Segoe MDL2 Assets" may predate
+// some of the IME-specific codepoints below. DirectWrite substitutes a font
+// silently rather than failing, so without this the button renders as a blank
+// box (issue #232).
+struct ToolbarIcon
+{
+    wchar_t codepoint;
+    const wchar_t *fallbackText;
+};
 
-constexpr wchar_t kGlyphJa = 0xE7DE;
-constexpr wchar_t kGlyphCn = 0xE982;
-constexpr wchar_t kGlyphEn = 0xE983;
-constexpr wchar_t kGlyphHalfWidth = 0xEC46;
-constexpr wchar_t kGlyphFullWidth = 0xF138;
-constexpr wchar_t kGlyphPuncEn = 0xF110;
-constexpr wchar_t kGlyphPuncCn = 0xF111;
-constexpr wchar_t kGlyphSimplified = 0xE88D;
-constexpr wchar_t kGlyphTraditional = 0xE88C;
-constexpr wchar_t kGlyphEmoji = 0xE76E;
-constexpr wchar_t kGlyphKeyboard = 0xE765;
-constexpr wchar_t kGlyphSettings = 0xE713;
+constexpr ToolbarIcon kIconJa = {0xE7DE, L"日"};
+constexpr ToolbarIcon kIconCn = {0xE982, L"中"};
+constexpr ToolbarIcon kIconEn = {0xE983, L"英"};
+constexpr ToolbarIcon kIconHalfWidth = {0xEC46, L"半"};
+constexpr ToolbarIcon kIconFullWidth = {0xF138, L"全"};
+constexpr ToolbarIcon kIconPuncEn = {0xF110, L","};
+constexpr ToolbarIcon kIconPuncCn = {0xF111, L"。"};
+constexpr ToolbarIcon kIconSimplified = {0xE88D, L"简"};
+constexpr ToolbarIcon kIconTraditional = {0xE88C, L"繁"};
+constexpr ToolbarIcon kIconEmoji = {0xE76E, L"表"};
+constexpr ToolbarIcon kIconKeyboard = {0xE765, L"键"};
+constexpr ToolbarIcon kIconSettings = {0xE713, L"设"};
 
 float ToolbarUserScale()
 {
@@ -71,7 +80,8 @@ class ToolbarIconButton : public msimeui::Visual
   public:
     using ClickHandler = std::function<void()>;
 
-    ToolbarIconButton(wchar_t glyph, std::wstring text, float size) : glyph_(glyph), text_(std::move(text)), size_(size)
+    ToolbarIconButton(wchar_t glyph, std::wstring glyphFamily, std::wstring text, float size)
+        : glyph_(glyph), glyphFamily_(std::move(glyphFamily)), text_(std::move(text)), size_(size)
     {
         SetWidth(size_);
         SetHeight(size_);
@@ -92,26 +102,6 @@ class ToolbarIconButton : public msimeui::Visual
     void SetUnderline(bool underline)
     {
         underline_ = underline;
-        InvalidateVisual();
-    }
-
-    void SetGlyph(wchar_t glyph)
-    {
-        if (glyph_ == glyph)
-        {
-            return;
-        }
-        glyph_ = glyph;
-        InvalidateVisual();
-    }
-
-    void SetLabel(std::wstring text)
-    {
-        if (text_ == text)
-        {
-            return;
-        }
-        text_ = std::move(text);
         InvalidateVisual();
     }
 
@@ -152,8 +142,8 @@ class ToolbarIconButton : public msimeui::Visual
             return;
         }
 
-        const bool useGlyph = glyph_ != 0;
-        const std::wstring family = useGlyph ? std::wstring(kFluentIconsFont) : std::wstring(msimeui::UiFontFamily());
+        const bool useGlyph = glyph_ != 0 && !glyphFamily_.empty();
+        const std::wstring family = useGlyph ? glyphFamily_ : std::wstring(msimeui::UiFontFamily());
         const float fontSize =
             size_ * (underline_ ? kToolbarUnderlinedTextFontSizeFactor : kToolbarGlyphFontSizeFactor);
         IDWriteTextFormat *format =
@@ -233,6 +223,7 @@ class ToolbarIconButton : public msimeui::Visual
 
   private:
     wchar_t glyph_ = 0;
+    std::wstring glyphFamily_;
     std::wstring text_;
     float size_ = 24.0f;
     bool underline_ = false;
@@ -427,16 +418,21 @@ void FloatingToolbarPresenter::RebuildScene()
     auto icons = std::make_shared<msimeui::HorizontalStackPanel>(gap);
     icons->SetVerticalContentAlignment(msimeui::VerticalAlignment::Center);
 
-    auto addGlyph = [&](wchar_t glyph, ToolbarIconButton::ClickHandler click) {
-        auto button = std::make_shared<ToolbarIconButton>(glyph, L"", iconSize);
+    auto addText = [&](std::wstring text, bool underline, ToolbarIconButton::ClickHandler click) {
+        auto button = std::make_shared<ToolbarIconButton>(0, L"", std::move(text), iconSize);
+        button->SetUnderline(underline);
         button->SetColors(impl_->glyph, impl_->hover);
         button->SetOnClick(std::move(click));
         icons->AddChild(button);
         return button;
     };
-    auto addText = [&](std::wstring text, bool underline, ToolbarIconButton::ClickHandler click) {
-        auto button = std::make_shared<ToolbarIconButton>(0, std::move(text), iconSize);
-        button->SetUnderline(underline);
+    auto addGlyph = [&](const ToolbarIcon &icon, ToolbarIconButton::ClickHandler click) {
+        const msimeui::IconGlyph resolved = msimeui::ResolveIconGlyph(icon.codepoint);
+        if (!resolved.family)
+        {
+            return addText(icon.fallbackText, false, std::move(click));
+        }
+        auto button = std::make_shared<ToolbarIconButton>(resolved.codepoint, resolved.family, L"", iconSize);
         button->SetColors(impl_->glyph, impl_->hover);
         button->SetOnClick(std::move(click));
         icons->AddChild(button);
@@ -462,7 +458,7 @@ void FloatingToolbarPresenter::RebuildScene()
     }
     else if (impl_->cnEn != 1)
     {
-        addGlyph(kGlyphEn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToCn); });
+        addGlyph(kIconEn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToCn); });
     }
     else if (impl_->englishInputMode == 1)
     {
@@ -470,11 +466,11 @@ void FloatingToolbarPresenter::RebuildScene()
     }
     else if (impl_->japaneseInputMode == 1)
     {
-        addGlyph(kGlyphJa, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToEn); });
+        addGlyph(kIconJa, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToEn); });
     }
     else
     {
-        addGlyph(kGlyphCn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToEn); });
+        addGlyph(kIconCn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToEn); });
     }
 
     const FloatingToolbarItemsConfig &items = GetConfiguredFloatingToolbarItems();
@@ -482,12 +478,12 @@ void FloatingToolbarPresenter::RebuildScene()
     {
         if (impl_->doubleSingleByte == 1)
         {
-            addGlyph(kGlyphFullWidth,
+            addGlyph(kIconFullWidth,
                      []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToHalfwidth); });
         }
         else
         {
-            addGlyph(kGlyphHalfWidth,
+            addGlyph(kIconHalfWidth,
                      []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToFullwidth); });
         }
     }
@@ -495,19 +491,17 @@ void FloatingToolbarPresenter::RebuildScene()
     {
         if (impl_->punctuation == 1)
         {
-            addGlyph(kGlyphPuncCn,
-                     []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToPuncEn); });
+            addGlyph(kIconPuncCn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToPuncEn); });
         }
         else
         {
-            addGlyph(kGlyphPuncEn,
-                     []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToPuncCn); });
+            addGlyph(kIconPuncEn, []() { SendWorker(Global::DataFromServerMsgTypeToTsfWorkerThread::SwitchToPuncCn); });
         }
     }
     if (items.character_set)
     {
         const bool traditional = GetConfiguredCharacterSet() == "traditional";
-        addGlyph(traditional ? kGlyphTraditional : kGlyphSimplified, []() {
+        addGlyph(traditional ? kIconTraditional : kIconSimplified, []() {
             const std::string next = GetConfiguredCharacterSet() == "traditional" ? "simplified" : "traditional";
             if (SetConfiguredCharacterSet(next))
             {
@@ -519,15 +513,15 @@ void FloatingToolbarPresenter::RebuildScene()
     }
     if (items.emoji)
     {
-        addGlyph(kGlyphEmoji, []() { OpenEmojiPanelApplication(); });
+        addGlyph(kIconEmoji, []() { OpenEmojiPanelApplication(); });
     }
     if (items.screen_keyboard)
     {
-        addGlyph(kGlyphKeyboard, []() { OpenKeyboardPanelApplication(); });
+        addGlyph(kIconKeyboard, []() { OpenKeyboardPanelApplication(); });
     }
     if (items.settings)
     {
-        addGlyph(kGlyphSettings, []() { OpenSettingsApplication(); });
+        addGlyph(kIconSettings, []() { OpenSettingsApplication(); });
     }
 
     row->AddChild(leading);

--- a/ui/include/msimeui/Fonts.h
+++ b/ui/include/msimeui/Fonts.h
@@ -7,4 +7,19 @@ namespace msimeui
 const wchar_t *UiFontFamily();
 const wchar_t *UiFontFallbackFamily();
 void ApplyUiFontFallback(IDWriteFactory *factory, IDWriteTextFormat *format);
+
+// Resolved icon font/codepoint pair. `family` is null when no installed icon
+// font can actually render the requested glyph, in which case the caller must
+// fall back to plain text instead of drawing tofu.
+struct IconGlyph
+{
+    const wchar_t *family = nullptr;
+    wchar_t codepoint = 0;
+};
+
+// Picks the first installed icon font that really contains the glyph:
+// "Segoe Fluent Icons" (Windows 11) first, then "Segoe MDL2 Assets"
+// (Windows 10). `mdl2Codepoint` overrides the codepoint used when probing
+// Segoe MDL2 Assets; pass 0 when both fonts share the same codepoint.
+IconGlyph ResolveIconGlyph(wchar_t fluentCodepoint, wchar_t mdl2Codepoint = 0);
 } // namespace msimeui

--- a/ui/src/Fonts.cpp
+++ b/ui/src/Fonts.cpp
@@ -1,6 +1,10 @@
 #include "msimeui/Fonts.h"
 
 #include <dwrite_2.h>
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
 #include <wrl/client.h>
 
 namespace msimeui
@@ -35,6 +39,77 @@ IDWriteFactory *SharedFactory()
     }
     return factory.Get();
 }
+
+constexpr wchar_t kFluentIconsFamily[] = L"Segoe Fluent Icons";
+constexpr wchar_t kMdl2IconsFamily[] = L"Segoe MDL2 Assets";
+
+ComPtr<IDWriteFont> FindFont(IDWriteFactory *factory, const wchar_t *name)
+{
+    if (!factory || !name)
+    {
+        return nullptr;
+    }
+    ComPtr<IDWriteFontCollection> fonts;
+    if (FAILED(factory->GetSystemFontCollection(fonts.GetAddressOf())) || !fonts)
+    {
+        return nullptr;
+    }
+    UINT32 index = 0;
+    BOOL exists = FALSE;
+    if (FAILED(fonts->FindFamilyName(name, &index, &exists)) || !exists)
+    {
+        return nullptr;
+    }
+    ComPtr<IDWriteFontFamily> family;
+    if (FAILED(fonts->GetFontFamily(index, family.GetAddressOf())))
+    {
+        return nullptr;
+    }
+    ComPtr<IDWriteFont> font;
+    if (FAILED(family->GetFirstMatchingFont(DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+                                            DWRITE_FONT_STYLE_NORMAL, font.GetAddressOf())))
+    {
+        return nullptr;
+    }
+    return font;
+}
+
+struct IconFontEntry
+{
+    const wchar_t *family = nullptr;
+    bool isMdl2 = false;
+    ComPtr<IDWriteFont> font;
+};
+
+// Installed icon fonts, in preference order. Built once per process, so a font
+// installed while the process runs is only picked up after a restart.
+const std::vector<IconFontEntry> &IconFonts()
+{
+    static const std::vector<IconFontEntry> entries = []() {
+        std::vector<IconFontEntry> list;
+        IDWriteFactory *factory = SharedFactory();
+        if (ComPtr<IDWriteFont> fluent = FindFont(factory, kFluentIconsFamily))
+        {
+            list.push_back({kFluentIconsFamily, false, std::move(fluent)});
+        }
+        if (ComPtr<IDWriteFont> mdl2 = FindFont(factory, kMdl2IconsFamily))
+        {
+            list.push_back({kMdl2IconsFamily, true, std::move(mdl2)});
+        }
+        return list;
+    }();
+    return entries;
+}
+
+bool FontHasCodepoint(IDWriteFont *font, wchar_t codepoint)
+{
+    if (!font || codepoint == 0)
+    {
+        return false;
+    }
+    BOOL exists = FALSE;
+    return SUCCEEDED(font->HasCharacter(codepoint, &exists)) && exists;
+}
 } // namespace
 
 const wchar_t *UiFontFallbackFamily()
@@ -48,6 +123,34 @@ const wchar_t *UiFontFamily()
     static const wchar_t *family =
         FontFamilyExists(factory, L"Noto Sans SC") ? L"Noto Sans SC" : UiFontFallbackFamily();
     return family;
+}
+
+IconGlyph ResolveIconGlyph(wchar_t fluentCodepoint, wchar_t mdl2Codepoint)
+{
+    static std::mutex mutex;
+    static std::map<std::pair<wchar_t, wchar_t>, IconGlyph> cache;
+
+    const std::pair<wchar_t, wchar_t> key{fluentCodepoint, mdl2Codepoint};
+    std::lock_guard<std::mutex> lock(mutex);
+    const auto cached = cache.find(key);
+    if (cached != cache.end())
+    {
+        return cached->second;
+    }
+
+    IconGlyph resolved;
+    for (const IconFontEntry &entry : IconFonts())
+    {
+        const wchar_t codepoint = (entry.isMdl2 && mdl2Codepoint != 0) ? mdl2Codepoint : fluentCodepoint;
+        if (FontHasCodepoint(entry.font.Get(), codepoint))
+        {
+            resolved.family = entry.family;
+            resolved.codepoint = codepoint;
+            break;
+        }
+    }
+    cache.emplace(key, resolved);
+    return resolved;
 }
 
 void ApplyUiFontFallback(IDWriteFactory *factory, IDWriteTextFormat *format)

--- a/ui/tests/CMakeLists.txt
+++ b/ui/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_EXECUTABLE_NAME "msimeui-tests")
 
 add_executable(${TEST_EXECUTABLE_NAME}
     src/main.cpp
+    src/test_fonts.cpp
     src/test_layout.cpp
     includes/test_framework.h
 )

--- a/ui/tests/src/test_fonts.cpp
+++ b/ui/tests/src/test_fonts.cpp
@@ -1,0 +1,64 @@
+#include "tests/includes/test_framework.h"
+
+#include "msimeui/Fonts.h"
+
+#include <cwchar>
+
+namespace
+{
+// Spelled numerically: this target is not built with /utf-8, so a literal CJK
+// character in the source would not survive as the codepoint we mean to probe.
+constexpr wchar_t kCjkZhong = 0x4E2D; // 中
+constexpr wchar_t kCjkWen = 0x6587;   // 文
+
+bool IsKnownIconFamily(const wchar_t *family)
+{
+    return family != nullptr &&
+           (std::wcscmp(family, L"Segoe Fluent Icons") == 0 || std::wcscmp(family, L"Segoe MDL2 Assets") == 0);
+}
+} // namespace
+
+// A codepoint no icon font carries must report "no family" rather than handing
+// back a font that would render a blank box. This is the whole point of the
+// probe: DirectWrite silently substitutes fonts, so absence has to be detected
+// before drawing, not after.
+TEST_CASE(icon_glyph_reports_missing_glyph)
+{
+    const msimeui::IconGlyph resolved = msimeui::ResolveIconGlyph(kCjkZhong);
+    REQUIRE(resolved.family == nullptr);
+    REQUIRE(resolved.codepoint == 0);
+}
+
+// The MDL2 override must not smuggle in a glyph the font does not have either.
+TEST_CASE(icon_glyph_reports_missing_glyph_with_mdl2_override)
+{
+    const msimeui::IconGlyph resolved = msimeui::ResolveIconGlyph(kCjkZhong, kCjkWen);
+    REQUIRE(resolved.family == nullptr);
+    REQUIRE(resolved.codepoint == 0);
+}
+
+// Whatever the host happens to have installed, a successful resolution has to
+// name one of the icon fonts we probe and keep the codepoint we asked for.
+// Machines with neither font installed legitimately resolve to nothing.
+TEST_CASE(icon_glyph_resolves_consistently)
+{
+    const msimeui::IconGlyph settings = msimeui::ResolveIconGlyph(0xE713);
+    if (settings.family != nullptr)
+    {
+        REQUIRE(IsKnownIconFamily(settings.family));
+        REQUIRE(settings.codepoint == 0xE713);
+    }
+    else
+    {
+        REQUIRE(settings.codepoint == 0);
+    }
+}
+
+// Results are cached; repeated lookups must not drift.
+TEST_CASE(icon_glyph_resolution_is_stable)
+{
+    const msimeui::IconGlyph first = msimeui::ResolveIconGlyph(0xE76E);
+    const msimeui::IconGlyph second = msimeui::ResolveIconGlyph(0xE76E);
+    REQUIRE(first.family == second.family);
+    REQUIRE(first.codepoint == second.codepoint);
+}


### PR DESCRIPTION
## 问题

Ref #232 

悬浮工具栏和表情面板把图标字体硬编码成了 `Segoe Fluent Icons`，而这个字体只随
Windows 11 分发。DirectWrite 在字体缺失时的行为是**静默替换**而不是失败，所以在
Windows 10 上，工具栏绘制的每一个私有区码位（U+E982、U+F110、U+F138 ……）都渲染成
空白方块——按钮还能点，但完全看不出当前状态。

## 方案

**按码位解析，而不是按字体族解析。** `Segoe MDL2 Assets`（Win10/Win11 都有）是
`Segoe Fluent Icons` 的子集，只把字体族整体换掉，遇到 MDL2 没有的字形照样是豆腐块。

三级兜底：

1. `Segoe Fluent Icons`（Win11）
2. `Segoe MDL2 Assets`（Win10 / Win11）
3. 文本标签

具体改动：

- 新增 `msimeui::ResolveIconGlyph()`：用 `IDWriteFont::HasCharacter()` 逐个探测已安装的
  图标字体，返回**真正含有该字形**的第一个字体族；都没有则返回空字体族，由调用方走文本兜底。
  结果按 (码位, MDL2 覆盖码位) 缓存，加锁保护。
- 工具栏和表情面板的每个图标都配了文本兜底：中/英、半/全、简/繁、日、表、键、设，
  以及最近/表情/贴纸/GIF/颜文字/符号/剪贴板。
- 删掉未使用的 `ToolbarIconButton::SetGlyph()` / `SetLabel()`——它们会绕过已解析的字体族，
  留着就是个坑。
- 补了解析器的单元测试，覆盖"字形不存在"这条在装有 Segoe Fluent Icons 的机器上走不到的路径。