### PR TITLE
Fix/icon font followups

### DIFF
--- a/server/src/emoji-panel/EmojiPanel.cpp
+++ b/server/src/emoji-panel/EmojiPanel.cpp
@@ -26,6 +26,7 @@ constexpr float kPanelScale = 2.0f / 3.0f;
 constexpr float kHeaderHeight = 58.0f;
 constexpr float kNavTop = 66.0f;
 constexpr float kNavHeight = 58.0f;
+constexpr float kNavTitleFontSize = 24.0f;
 constexpr float kSearchTop = 142.0f;
 constexpr float kSearchHeight = 52.0f;
 constexpr float kContentTop = 218.0f;
@@ -48,7 +49,6 @@ constexpr UINT_PTR kClipboardPollTimerId = 44;
 constexpr UINT kClipboardPollMs = 400;
 constexpr float kClipboardRowHeight = 80.0f;
 constexpr float kClipboardRowGap = 8.0f;
-constexpr float kClipboardTitleFontSize = 24.0f;
 constexpr float kClipboardHintFontSize = 24.0f;
 constexpr float kClipboardButtonFontSize = 22.0f;
 constexpr float kClipboardItemFontSize = 22.0f;
@@ -2235,21 +2235,21 @@ void EmojiPanel::Render(DeviceResources &resources)
         }
         else
         {
+            // Keep these in step with the tab labels in emoji_panel_icons.cpp,
+            // which the tabs fall back to when no icon font has the glyph.
             const wchar_t *title = L"";
             if (page_ == Page::Sticker)
-                title = L"Sticker";
+                title = L"贴纸";
             else if (page_ == Page::Gif)
                 title = L"GIF";
             else if (page_ == Page::Kaomoji)
-                title = L"Kaomoji";
+                title = L"颜文字";
             else if (page_ == Page::Symbols)
-                title = L"Symbols";
+                title = L"符号";
             else if (page_ == Page::Clipboard)
                 title = L"剪贴板";
-            DrawText(resources, title, {bounds_.x + 70.0f, bounds_.y + kNavTop, 280.0f, kNavHeight},
-                     page_ == Page::Clipboard ? kClipboardTitleFontSize : 18.0f, text,
-                     page_ == Page::Clipboard ? CjkUiFont() : L"Segoe UI", DWRITE_TEXT_ALIGNMENT_LEADING,
-                     DWRITE_FONT_WEIGHT_SEMI_BOLD);
+            DrawText(resources, title, {bounds_.x + 70.0f, bounds_.y + kNavTop, 280.0f, kNavHeight}, kNavTitleFontSize,
+                     text, CjkUiFont(), DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_FONT_WEIGHT_SEMI_BOLD);
         }
     }
     else

--- a/ui/src/Fonts.cpp
+++ b/ui/src/Fonts.cpp
@@ -31,7 +31,11 @@ bool FontFamilyExists(IDWriteFactory *factory, const wchar_t *name)
 
 IDWriteFactory *SharedFactory()
 {
+    // Called from several window threads, so the lazy creation needs a lock of
+    // its own; the factory is never reset, so the returned pointer stays valid.
+    static std::mutex mutex;
     static ComPtr<IDWriteFactory> factory;
+    std::lock_guard<std::mutex> lock(mutex);
     if (!factory)
     {
         DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
@@ -81,23 +85,27 @@ struct IconFontEntry
     ComPtr<IDWriteFont> font;
 };
 
-// Installed icon fonts, in preference order. Built once per process, so a font
-// installed while the process runs is only picked up after a restart.
+// Installed icon fonts, in preference order. Kept once the probe finds one, so
+// a font installed while the process runs is only picked up after a restart. An
+// empty result is not kept: a transient DirectWrite failure on the first call
+// would otherwise degrade every icon to its text label for the whole process.
+// Callers must hold the ResolveIconGlyph mutex, its only caller.
 const std::vector<IconFontEntry> &IconFonts()
 {
-    static const std::vector<IconFontEntry> entries = []() {
-        std::vector<IconFontEntry> list;
-        IDWriteFactory *factory = SharedFactory();
-        if (ComPtr<IDWriteFont> fluent = FindFont(factory, kFluentIconsFamily))
-        {
-            list.push_back({kFluentIconsFamily, false, std::move(fluent)});
-        }
-        if (ComPtr<IDWriteFont> mdl2 = FindFont(factory, kMdl2IconsFamily))
-        {
-            list.push_back({kMdl2IconsFamily, true, std::move(mdl2)});
-        }
-        return list;
-    }();
+    static std::vector<IconFontEntry> entries;
+    if (!entries.empty())
+    {
+        return entries;
+    }
+    IDWriteFactory *factory = SharedFactory();
+    if (ComPtr<IDWriteFont> fluent = FindFont(factory, kFluentIconsFamily))
+    {
+        entries.push_back({kFluentIconsFamily, false, std::move(fluent)});
+    }
+    if (ComPtr<IDWriteFont> mdl2 = FindFont(factory, kMdl2IconsFamily))
+    {
+        entries.push_back({kMdl2IconsFamily, true, std::move(mdl2)});
+    }
     return entries;
 }
 
@@ -139,7 +147,14 @@ IconGlyph ResolveIconGlyph(wchar_t fluentCodepoint, wchar_t mdl2Codepoint)
     }
 
     IconGlyph resolved;
-    for (const IconFontEntry &entry : IconFonts())
+    const std::vector<IconFontEntry> &fonts = IconFonts();
+    if (fonts.empty())
+    {
+        // No icon font found yet. Report the text fallback but do not cache it,
+        // so a later call can still pick one up once DirectWrite recovers.
+        return resolved;
+    }
+    for (const IconFontEntry &entry : fonts)
     {
         const wchar_t codepoint = (entry.isMdl2 && mdl2Codepoint != 0) ? mdl2Codepoint : fluentCodepoint;
         if (FontHasCodepoint(entry.font.Get(), codepoint))


### PR DESCRIPTION
## 背景

#264 引入了 `msimeui::ResolveIconGlyph()`，让图标按码位而非按字体族解析，并在两个图标字体都没有该字形时降级为文字标签。合入后的代码审查发现解析器本身有两个失效路径，另有一处文案不一致。本 PR 是 #264 的后续修复，不改变其设计。

## 改动

### 1. 图标解析器无法从 DirectWrite 失败中恢复（`ui/src/Fonts.cpp`）

`IconFonts()` 把结果存在只初始化一次的函数局部 static 里。如果首次调用时 `SharedFactory()` 返回 `nullptr`，或 `GetSystemFontCollection()` 失败（瞬时低资源、DWrite 初始化失败），空列表会被缓存整个进程生命周期——此后**所有**图标永久退化成文字标签，且不再重试。而 `SharedFactory()` 自身每次调用都会重试，两者行为不对称，现场很难定位。

改为：探测到字体才保留结果，空列表下次重新探测；同时 `ResolveIconGlyph()` 在列表为空时跳过缓存写入，否则负缓存会把重试路径挡死，等于没修。

### 2. `SharedFactory()` 的懒初始化没有同步（`ui/src/Fonts.cpp`）

`ResolveIconGlyph()` 用 `std::mutex` 保护自己的缓存，但锁内会走到 `SharedFactory()`，而后者的 `if (!factory) { DWriteCreateFactory(...) }` 无任何同步；`UiFontFamily()` 和 `ApplyUiFontFallback()` 又在渲染路径上**不持该锁**调用同一个函数。两个窗口线程可以同时看到空 factory，各自创建一个写进同一个 `ComPtr`，泄漏一个并竞争裸指针。外层那把锁反而给了虚假的安全感。

给 `SharedFactory()` 加一把自己的锁。factory 创建后不会被重置，因此解锁后返回的裸指针仍然有效。

> 这个缺陷早于 #264 就存在，但 #264 新增了从 `ResolveIconGlyph()` 过来的调用路径，把它暴露在了更多线程上。

### 3. emoji 面板子页标题与 tab 标签语言不一致（`server/src/emoji-panel/EmojiPanel.cpp`）

#264 给每个 tab 加的文字兜底标签是中文（贴纸 / 颜文字 / 符号），而对应子页的导航标题是英文（`Sticker` / `Kaomoji` / `Symbols`），只有剪贴板页已经是中文。在真正触发字体兜底的 Windows 10 上，用户点「贴纸」会进到标题写着 "Sticker" 的页面。

把标题统一成中文以对齐 tab 标签，并去掉「仅因为剪贴板是唯一中文标题」而存在的按页字体/字号三元分支；`kClipboardTitleFontSize` 随之更名为 `kNavTitleFontSize` 并移到其它 nav 度量旁边。`GIF` 保持不变——它是缩写，tab 标签本来也是 GIF。

## 验证

环境：Windows 11 Pro 26200，VS 2026（MSVC 19.50），CMake + vcpkg，x64 Debug。