### PR TITLE
fix(server): 全拼导入按汉字数选择切分并识别文件编码

### DIFF
--- a/server/src/settings/dictionary_manager.cpp
+++ b/server/src/settings/dictionary_manager.cpp
@@ -331,17 +331,22 @@ bool NormalizePinyin(const std::string &mode, const std::string &input, quanpin:
 bool ValidateChineseEntry(const std::string &mode, const std::string &code, const std::string &word,
                           quanpin::Segments &segments, std::string &normalized, std::string &message)
 {
+    (void)mode;
     if (word.empty())
     {
         message = "词条不能为空";
         return false;
     }
-    if (!NormalizePinyin(mode, code, segments, normalized, message))
-        return false;
     const size_t han_count = HelpcodeUtils::count_han_chars(word);
-    if (han_count == 0 || han_count != segments.size())
+    if (!Validation::NormalizeFullPinyin(code, segments, normalized, han_count))
     {
-        message = "拼音音节数量必须与汉字数量一致";
+        message = "全拼必须由拼音表中的完整音节组成，不能使用简拼";
+        return false;
+    }
+    if (han_count != segments.size())
+    {
+        message = "拼音音节数量必须与汉字数量一致（词 " + std::to_string(han_count) + " 字，拼音 " +
+                  std::to_string(segments.size()) + " 音节）";
         return false;
     }
     return true;

--- a/server/src/settings/dictionary_validation.cpp
+++ b/server/src/settings/dictionary_validation.cpp
@@ -10,7 +10,8 @@
 
 namespace SettingsDictionary::Validation
 {
-bool NormalizeFullPinyin(const std::string &input, quanpin::Segments &segments, std::string &normalized)
+bool NormalizeFullPinyin(const std::string &input, quanpin::Segments &segments, std::string &normalized,
+                         std::size_t expected_syllables)
 {
     std::string source = input;
     source.erase(std::remove_if(source.begin(), source.end(), [](unsigned char ch) { return std::isspace(ch); }),
@@ -33,6 +34,15 @@ bool NormalizeFullPinyin(const std::string &input, quanpin::Segments &segments, 
         if (cuts.empty())
             return false;
         segments = cuts.front();
+        if (expected_syllables != 0 && segments.size() != expected_syllables)
+        {
+            const auto alternatives = quanpin::enumerate_complete_segmentations(quanpin::build_syllable_graph(source));
+            const auto match = std::find_if(
+                alternatives.begin(), alternatives.end(),
+                [expected_syllables](const quanpin::Segments &cut) { return cut.size() == expected_syllables; });
+            if (match != alternatives.end())
+                segments = *match;
+        }
     }
 
     const auto &valid = quanpin::intact_pinyin_set();

--- a/server/src/settings/dictionary_validation.h
+++ b/server/src/settings/dictionary_validation.h
@@ -2,11 +2,13 @@
 
 #include "MetasequoiaImeEngine/quanpin/quanpin_query.h"
 
+#include <cstddef>
 #include <string>
 
 namespace SettingsDictionary::Validation
 {
-bool NormalizeFullPinyin(const std::string &input, quanpin::Segments &segments, std::string &normalized);
+bool NormalizeFullPinyin(const std::string &input, quanpin::Segments &segments, std::string &normalized,
+                         std::size_t expected_syllables = 0);
 bool ParseCodedImportLine(const std::string &line, std::string &word, std::string &code, int &weight,
                           std::string &message);
 bool QuickPhraseFitsNamedPipe(const std::string &phrase);

--- a/server/tests/src/test_dictionary_validation.cpp
+++ b/server/tests/src/test_dictionary_validation.cpp
@@ -17,6 +17,28 @@ TEST_CASE(DictionaryFullPinyinValidationRejectsAbbreviatedSyllables)
     REQUIRE(!SettingsDictionary::Validation::NormalizeFullPinyin("ni'", segments, normalized));
 }
 
+TEST_CASE(DictionaryFullPinyinPicksSegmentationMatchingSyllableCount)
+{
+    quanpin::Segments segments;
+    std::string normalized;
+
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin("xian", segments, normalized));
+    REQUIRE_EQ(normalized, std::string("xian"));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(1));
+
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin("xian", segments, normalized, 2));
+    REQUIRE_EQ(normalized, std::string("xi'an"));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(2));
+
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin("a'a'a'a'a'a'a'a", segments, normalized, 8));
+    REQUIRE_EQ(normalized, std::string("a'a'a'a'a'a'a'a"));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(8));
+
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin("abalatiyayunhai", segments, normalized, 7));
+    REQUIRE_EQ(normalized, std::string("a'ba'la'ti'ya'yun'hai"));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(7));
+}
+
 TEST_CASE(QuickPhraseValidationMatchesNamedPipeWcharCapacity)
 {
     REQUIRE(SettingsDictionary::Validation::QuickPhraseFitsNamedPipe(std::string(199, 'a')));
@@ -44,4 +66,31 @@ TEST_CASE(CodedDictionaryImportRequiresTabsAndPreservesSpacesInWords)
     REQUIRE(!SettingsDictionary::Validation::ParseCodedImportLine("普通词\tputongci", word, code, weight, message));
     REQUIRE(!SettingsDictionary::Validation::ParseCodedImportLine("普通词\tputongci\t10\textra", word, code, weight,
                                                                   message));
+}
+
+TEST_CASE(CodedQuanpinImportAcceptsExportedApostropheTsv)
+{
+    std::string word;
+    std::string code;
+    std::string message;
+    int weight = -1;
+    quanpin::Segments segments;
+    std::string normalized;
+
+    REQUIRE(SettingsDictionary::Validation::ParseCodedImportLine("啊啊啊啊啊啊啊啊\ta'a'a'a'a'a'a'a\t41", word, code,
+                                                                 weight, message));
+    REQUIRE_EQ(word, std::string("啊啊啊啊啊啊啊啊"));
+    REQUIRE_EQ(code, std::string("a'a'a'a'a'a'a'a"));
+    REQUIRE_EQ(weight, 41);
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin(code, segments, normalized, 8));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(8));
+
+    REQUIRE(SettingsDictionary::Validation::ParseCodedImportLine("阿巴拉提亚云海\ta'ba'la'ti'ya'yun'hai\t13", word,
+                                                                 code, weight, message));
+    REQUIRE_EQ(word, std::string("阿巴拉提亚云海"));
+    REQUIRE_EQ(code, std::string("a'ba'la'ti'ya'yun'hai"));
+    REQUIRE_EQ(weight, 13);
+    REQUIRE(SettingsDictionary::Validation::NormalizeFullPinyin(code, segments, normalized, 7));
+    REQUIRE_EQ(normalized, std::string("a'ba'la'ti'ya'yun'hai"));
+    REQUIRE_EQ(segments.size(), static_cast<size_t>(7));
 }

--- a/ui-html/webview2/settings/ime-settings/src/modules/dict.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/dict.ts
@@ -1,4 +1,5 @@
 import { createDictionaryPager, DICTIONARY_PAGE_SIZE } from '../utils/dictionary-pagination';
+import { readDictionaryFile } from '../utils/dictionary-file';
 import { onHostMessage } from '../utils/host-messages';
 import type { SettingsMessage } from '../../../../shared/messages';
 type DictionaryRequest = Extract<SettingsMessage, { type: 'dictionaryRequest' }>['data'];
@@ -177,7 +178,7 @@ export function setupDictionary(): void {
     input.value = '';
     if (!file) return;
     try {
-      const content = await file.text();
+      const content = await readDictionaryFile(file);
       if (!content.trim()) { showToast('文件内容为空', false); return; }
       post('import', { content });
     } catch {
@@ -193,7 +194,7 @@ export function setupDictionary(): void {
     input.value = '';
     if (!file) return;
     try {
-      const content = await file.text();
+      const content = await readDictionaryFile(file);
       if (!content.trim()) { showToast('文件内容为空', false); return; }
       post('importHans', { content });
     } catch {

--- a/ui-html/webview2/settings/ime-settings/src/utils/dictionary-file.test.ts
+++ b/ui-html/webview2/settings/ime-settings/src/utils/dictionary-file.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { decodeDictionaryBytes } from './dictionary-file';
+
+const utf8 = new TextEncoder();
+
+function utf16LeWithBom(text: string): Uint8Array {
+  const payload = new Uint8Array(2 + text.length * 2);
+  payload[0] = 0xff;
+  payload[1] = 0xfe;
+  const view = new DataView(payload.buffer);
+  for (let i = 0; i < text.length; i += 1) {
+    view.setUint16(2 + i * 2, text.charCodeAt(i), true);
+  }
+  return payload;
+}
+
+function gbkDecoderAvailable(): boolean {
+  for (const label of ['gb18030', 'gbk']) {
+    try {
+      void new TextDecoder(label);
+      return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+describe('decodeDictionaryBytes', () => {
+  it('reads utf-8 with and without bom', () => {
+    const body = utf8.encode("你好\tni'hao\t1\n");
+    expect(decodeDictionaryBytes(body)).toBe("你好\tni'hao\t1\n");
+    const bom = new Uint8Array(3 + body.length);
+    bom.set([0xef, 0xbb, 0xbf]);
+    bom.set(body, 3);
+    expect(decodeDictionaryBytes(bom)).toBe("你好\tni'hao\t1\n");
+  });
+
+  it('reads utf-16le with bom', () => {
+    const text = "阿巴拉提亚云海\ta'ba'la'ti'ya'yun'hai\t13\n";
+    expect(decodeDictionaryBytes(utf16LeWithBom(text))).toBe(text);
+  });
+
+  it.skipIf(!gbkDecoderAvailable())('falls back from invalid utf-8 to gbk', () => {
+    const encoded = new Uint8Array([
+      0xc4, 0xe3, 0xba, 0xc3, 0x09, 0x6e, 0x69, 0x27, 0x68, 0x61, 0x6f, 0x09, 0x31,
+    ]);
+    expect(decodeDictionaryBytes(encoded)).toBe("你好\tni'hao\t1");
+  });
+});

--- a/ui-html/webview2/settings/ime-settings/src/utils/dictionary-file.ts
+++ b/ui-html/webview2/settings/ime-settings/src/utils/dictionary-file.ts
@@ -1,0 +1,31 @@
+function decodeUtf8(bytes: Uint8Array, fatal: boolean): string {
+  return new TextDecoder('utf-8', { fatal }).decode(bytes);
+}
+
+export function decodeDictionaryBytes(bytes: Uint8Array): string {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return decodeUtf8(bytes.subarray(3), true);
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return new TextDecoder('utf-16le').decode(bytes.subarray(2));
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return new TextDecoder('utf-16be').decode(bytes.subarray(2));
+  }
+  try {
+    return decodeUtf8(bytes, true);
+  } catch {
+    for (const label of ['gb18030', 'gbk']) {
+      try {
+        return new TextDecoder(label).decode(bytes);
+      } catch {
+        continue;
+      }
+    }
+    return decodeUtf8(bytes, false);
+  }
+}
+
+export async function readDictionaryFile(file: File): Promise<string> {
+  return decodeDictionaryBytes(new Uint8Array(await file.arrayBuffer()));
+}


### PR DESCRIPTION
## 改动摘要

全拼词库导入两条会打出同一句「拼音音节数量必须与汉字数量一致」的路径：

- 无 `'` 分隔时，按汉字数在完整切分里另选（`西安` + `xian` → `xi'an`）。correction 默认最短切分会把 `xian` 收成 1 音节。
- 设置页读导入文件按 BOM 识别 UTF-8 / UTF-16，无效 UTF-8 再回退 GBK。不再用 `file.text()`（只按 UTF-8）。

带撇号的水杉导出三列 TSV（#180 截图那种）本身已合法，回归测试钉住该格式。不改 IPC。

Related to #180。编码假说仍待用原件和 GBK/UTF-16 另存对一下，故不自动关 issue。

## 如何验证

**自动化测试**

| 测试项 | 命令 | 结果 |
|---|---|---|
| Server 测试 | `server/build-release/bin/Release/MetasequoiaImeServerTests.exe`（`METASEQUOIA_IME_DATA_DIR` 指向本机词库） | 271 项通过，含新增 `DictionaryFullPinyinPicksSegmentationMatchingSyllableCount`、`CodedQuanpinImportAcceptsExportedApostropheTsv` |
| 设置页 | `cd ui-html/webview2/settings/ime-settings; pnpm test` | 19 项通过 |

**手工**

1. 设置 → 词库 → 全拼 → 批量导入水杉导出的 UTF-8 原件，带 `'` 的三列 TSV 应成功
2. 把同样内容另存为 ANSI/GBK、UTF-16（记事本「Unicode」）再导入，汉字不应再被读烂
3. 手动新增或导入 `西安` + `xian`（无 `'`），应写入 `xi'an` 而不是报音节数不一致

## 跨仓库

否。

## 提交前确认

- [x] 我按上面写的方式实际验证过，不是只读代码判断
- [x] 没有在改动、截图或日志里带上接口密钥、凭据或真实输入内容
- [x] 如果用了人工智能生成的代码，我已自行逐行检查并测试过
