### PR TITLE
fix(server): 设置变更时重建 D2D 悬浮工具栏外观

### DIFF
--- a/server/src/webview2/windows_webview2.cpp
+++ b/server/src/webview2/windows_webview2.cpp
@@ -2523,7 +2523,7 @@ bool ApplyConfiguredFloatingToolbarAppearance(std::function<void()> onComplete)
 {
     if (FloatingToolbarPresenter::Instance().IsBound())
     {
-        FloatingToolbarPresenter::Instance().RelayoutHost();
+        FloatingToolbarPresenter::Instance().ApplyAppearance();
         if (onComplete)
         {
             onComplete();

--- a/server/src/window/floating_toolbar_presenter.cpp
+++ b/server/src/window/floating_toolbar_presenter.cpp
@@ -567,6 +567,11 @@ void FloatingToolbarPresenter::ApplyTheme()
         impl_->hover = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.10f);
         impl_->divider = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.15f);
     }
+    ApplyAppearance();
+}
+
+void FloatingToolbarPresenter::ApplyAppearance()
+{
     RebuildScene();
     RelayoutHost();
 }
@@ -649,8 +654,7 @@ void FloatingToolbarPresenter::SyncUi(int cnEn, int doubleSingleByte, int punctu
     {
         return;
     }
-    RebuildScene();
-    RelayoutHost();
+    ApplyAppearance();
 }
 
 void FloatingToolbarPresenter::Present()

--- a/server/src/window/floating_toolbar_presenter.h
+++ b/server/src/window/floating_toolbar_presenter.h
@@ -12,6 +12,7 @@ class FloatingToolbarPresenter
     bool IsBound() const;
     void Present();
     void ApplyTheme();
+    void ApplyAppearance();
     void RelayoutHost(FLOAT scaleOverride = 0.0f);
     void SyncUi(int cnEn, int doubleSingleByte, int punctuation, int englishInputMode, int capsLock,
                 int japaneseInputMode);

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -1803,7 +1803,7 @@ void ApplyConfiguredFloatingToolbarSize()
 {
     if (FloatingToolbarPresenter::Instance().IsBound())
     {
-        FloatingToolbarPresenter::Instance().RelayoutHost();
+        FloatingToolbarPresenter::Instance().ApplyAppearance();
         return;
     }
     ::FTB_WND_WIDTH = ConfiguredFloatingToolbarWidth();


### PR DESCRIPTION
## 改动摘要

Fixes #267

默认 `ui_backend = d2d` 时，设置里改「工具栏缩放 / 图标尺寸」不生效；WebView2 后端和设置页预览（HTML）是正常的。#231 里「改悬浮工具栏缩放没效果」是同一条路径。

D2D 把 `floating_toolbar_scale * (font_size / 24)` 写进 Visual 构造参数（`RebuildScene`）。设置变更只走了 `RelayoutHost()`：对已有 scene 再测一次、按系统 DPI 改 HWND，几何不变，窗口也不变。主题、中英状态、组件显隐本来就会 `RebuildScene`，所以那些是好的。系统 DPI 变化只该 relayout，不能重建。

- 新增 `FloatingToolbarPresenter::ApplyAppearance()`：`RebuildScene` + `RelayoutHost`
- 尺寸 / 外观配置应用的 D2D 分支改调它
- `ApplyTheme` / `SyncUi` 复用同一对，避免两处各写一遍
- `WM_DPICHANGED` 与 DPI remeasure 仍只 `RelayoutHost`

未改配置读写、WebView2 CSS 路径，也未对齐 D2D 基准图标 26px 与 WebView2 的 24px（跟「设了没反应」无关）。

## 如何验证

未在本机跑原生宿主手测。请合入前用默认 D2D 后端确认：

1. 工具栏缩放 75 / 100 / 150、图标尺寸 16 / 28，真工具栏立刻跟着变
2. 组件勾选、主题、中英切换仍正常
3. 拖到另一 DPI 屏幕只随系统缩放，不闪、不丢按钮
4. `ui_backend = webview2` 回归：CSS 尺寸仍生效

## 跨仓库

否。
