### PR TITLE
fix(server,ui-html): 降低设置窗口拖动与工具栏首屏卡顿

### DIFF
--- a/server/src/settings/settings_app.cpp
+++ b/server/src/settings/settings_app.cpp
@@ -493,30 +493,31 @@ void PostConfig(bool refresh_skin_catalog = false)
     g_worker->Submit([refresh_skin_catalog] { return ConfigCompletion(refresh_skin_catalog); });
 }
 
-void PostWindowState(HWND hwnd)
+void PostValidatedServerMessage(json::object payload)
 {
     if (!g_webview)
         return;
-    nlohmann::json payload = {{"type", "windowState"}, {"data", {{"isMaximized", IsZoomed(hwnd) != FALSE}}}};
     payload["protocolVersion"] = metasequoia::webview::Version;
-    const std::string serialized = payload.dump();
-    if (!metasequoia::webview::Validate(json::parse(serialized), "server"))
+    if (!metasequoia::webview::Validate(payload, "server"))
         return;
-    const std::wstring message = string_to_wstring(serialized);
+    const std::wstring message = string_to_wstring(json::serialize(payload));
     g_webview->PostWebMessageAsJson(message.c_str());
+}
+
+void PostWindowState(HWND hwnd)
+{
+    PostValidatedServerMessage({
+        {"type", "windowState"},
+        {"data", {{"isMaximized", IsZoomed(hwnd) != FALSE}}},
+    });
 }
 
 void PostMaximizeButtonEvent(const char *event_name)
 {
-    if (!g_webview)
-        return;
-    nlohmann::json payload = {{"type", "maxButtonEvent"}, {"data", {{"event", event_name}}}};
-    payload["protocolVersion"] = metasequoia::webview::Version;
-    const std::string serialized = payload.dump();
-    if (!metasequoia::webview::Validate(json::parse(serialized), "server"))
-        return;
-    const std::wstring message = string_to_wstring(serialized);
-    g_webview->PostWebMessageAsJson(message.c_str());
+    PostValidatedServerMessage({
+        {"type", "maxButtonEvent"},
+        {"data", {{"event", event_name}}},
+    });
 }
 
 bool ApplyConfigUpdate(const json::object &data)
@@ -1282,7 +1283,6 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM w_param, LPARAM l_pa
                 g_webview3->Resume();
             if (g_controller)
                 g_controller->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
-            PostConfig();
         }
         break;
     }

--- a/server/src/webview2/windows_webview2.cpp
+++ b/server/src/webview2/windows_webview2.cpp
@@ -40,6 +40,7 @@
 #include <fstream>
 #include <functional>
 #include <optional>
+#include <sstream>
 #include <vector>
 
 // WebView diagnostics were useful while fixing the rendering issues, but they
@@ -1357,19 +1358,12 @@ bool GetCandidateWebviewState(bool &isVisible, RECT &bounds)
 
 std::wstring ReadHtmlFile(const std::wstring &filePath)
 {
-    std::wifstream file(filePath);
+    std::ifstream file(filePath, std::ios::binary);
     if (!file)
-    {
-        (void)0;
         return L"";
-    }
-    // Use Boost Locale to handle UTF-8
-    file.imbue(boost::locale::generator().generate("en_US.UTF-8"));
-    std::wstringstream buffer;
+    std::ostringstream buffer;
     buffer << file.rdbuf();
-    std::wstring content = buffer.str();
-    (void)0;
-    return content;
+    return string_to_wstring(buffer.str());
 }
 
 std::wstring GetAppdataPath()

--- a/server/tests/src/test_inline_protocol.cpp
+++ b/server/tests/src/test_inline_protocol.cpp
@@ -28,6 +28,14 @@ TEST_CASE(protocol_inline_keeps_fallback_if_assets_are_missing)
     REQUIRE_EQ(html, L"<body>legacy toolbar</body>");
 }
 
+TEST_CASE(protocol_inline_replaces_scripts_after_markup)
+{
+    std::wstring html = L"<head></head><body>toolbar</body>" + imports;
+    REQUIRE(InlineWebViewProtocolScripts(html, L"const schema = {};", L"const runtime = schema;"));
+    REQUIRE(html.find(L"src=") == std::wstring::npos);
+    REQUIRE(html.find(L"<body>toolbar</body>") < html.find(L"const schema"));
+}
+
 TEST_CASE(protocol_inline_escapes_embedded_html_end_tags)
 {
     std::wstring html = imports;

--- a/ui-html/webview2/candwnd/horizontal_candidate_window.html
+++ b/ui-html/webview2/candwnd/horizontal_candidate_window.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "candidate");</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>(IME)horizontalCandidateWindow</title>
@@ -16,6 +13,9 @@
     .cand-content { min-width: 0; }
     .cand-translation { display: block; font-size: 0.78em; line-height: 1.25; opacity: 0.62; }
   </style>
+  <script src="https://msime-contracts/schema.js"></script>
+  <script src="https://msime-contracts/runtime.js"></script>
+  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "candidate");</script>
   <script>
     let lastPointerScreenPosition = null;
     let pointerProbeCount = 0;

--- a/ui-html/webview2/candwnd/vertical_candidate_window.html
+++ b/ui-html/webview2/candwnd/vertical_candidate_window.html
@@ -3,14 +3,14 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "candidate");</script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>(IME)verticalCandidateWindow</title>
     <!-- Candidate layout and behavior are shared. The native host injects the selected built-in skin CSS here. -->
 
+  <script src="https://msime-contracts/schema.js"></script>
+  <script src="https://msime-contracts/runtime.js"></script>
+  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "candidate");</script>
   <script>
     let lastPointerScreenPosition = null;
     let pointerProbeCount = 0;

--- a/ui-html/webview2/ftb/default.html
+++ b/ui-html/webview2/ftb/default.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(FTB)</title>
   <style>
@@ -271,6 +268,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/default_light.html
+++ b/ui-html/webview2/ftb/default_light.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(FTB)</title>
   <style>
@@ -270,6 +267,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/graphite.html
+++ b/ui-html/webview2/ftb/graphite.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(FTB)</title>
   <style>
@@ -284,6 +281,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/graphite_light.html
+++ b/ui-html/webview2/ftb/graphite_light.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(FTB)</title>
   <style>
@@ -283,6 +280,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/wechat.html
+++ b/ui-html/webview2/ftb/wechat.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(WeChat FTB)</title>
   <style>
@@ -279,6 +276,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/wechat_light.html
+++ b/ui-html/webview2/ftb/wechat_light.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(WeChat Light FTB)</title>
   <style>
@@ -278,6 +275,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/willow_green.html
+++ b/ui-html/webview2/ftb/willow_green.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(WeChat FTB)</title>
   <style>
@@ -280,6 +277,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/ftb/willow_green_light.html
+++ b/ui-html/webview2/ftb/willow_green_light.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
   <meta charset="UTF-8">
   <title>IME(WeChat Light FTB)</title>
   <style>
@@ -279,6 +276,9 @@
     </div>
   </div>
 </body>
+<script src="https://msime-contracts/schema.js"></script>
+<script src="https://msime-contracts/runtime.js"></script>
+<script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "toolbar");</script>
 <script>
   // 
   // 左侧拖拽区域

--- a/ui-html/webview2/menu/default.html
+++ b/ui-html/webview2/menu/default.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "menu");</script>
   <meta charset="UTF-8">
   <title>(IME)TrayMenu</title>
   <style>
@@ -215,6 +212,9 @@
     </div>
   </div>
 
+  <script src="https://msime-contracts/schema.js"></script>
+  <script src="https://msime-contracts/runtime.js"></script>
+  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "menu");</script>
   <script>
     // Initial state comes from C++ (SyncMenuFloatingToolbarToggle) so this
     // toggle stays in sync with Settings / general.floating_toolbar.

--- a/ui-html/webview2/menu/default_light.html
+++ b/ui-html/webview2/menu/default_light.html
@@ -3,9 +3,6 @@
 
 <head>
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://msime-contracts; style-src 'unsafe-inline'; img-src data: https://appassets https://candidate-skins; font-src data: https://appassets https://candidate-skins">
-  <script src="https://msime-contracts/schema.js"></script>
-  <script src="https://msime-contracts/runtime.js"></script>
-  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "menu");</script>
   <meta charset="UTF-8">
   <title>(IME)TrayMenu</title>
   <style>
@@ -215,6 +212,9 @@
     </div>
   </div>
 
+  <script src="https://msime-contracts/schema.js"></script>
+  <script src="https://msime-contracts/runtime.js"></script>
+  <script>const serializeHostMessage = message => MsimeProtocol.serializeClientMessage(message, "menu");</script>
   <script>
     // Initial state comes from C++ (SyncMenuFloatingToolbarToggle) so this
     // toggle stays in sync with Settings / general.floating_toolbar.

--- a/ui-html/webview2/settings/ime-settings/src/main.ts
+++ b/ui-html/webview2/settings/ime-settings/src/main.ts
@@ -19,6 +19,56 @@ const windowState = {
 };
 
 let onWindowStateChanged: ((isMaximized: boolean) => void) | null = null;
+let maximizeButtonRectFrame = 0;
+
+function getActiveMaxButton(): HTMLElement | null {
+  const restoreBtn = document.getElementById('btn-restore');
+  const maximizeBtn = document.getElementById('btn-maximize');
+  if (windowState.isMaximized && restoreBtn instanceof HTMLElement) {
+    return restoreBtn;
+  }
+  if (maximizeBtn instanceof HTMLElement) {
+    return maximizeBtn;
+  }
+  return null;
+}
+
+function postMaximizeButtonRect(): void {
+  if (!window.chrome?.webview || titlebarDragState.isDraggingFromTitlebar || maximizeButtonRectFrame) {
+    return;
+  }
+  maximizeButtonRectFrame = window.requestAnimationFrame(() => {
+    maximizeButtonRectFrame = 0;
+    if (titlebarDragState.isDraggingFromTitlebar) {
+      return;
+    }
+    const activeBtn = getActiveMaxButton();
+    if (!activeBtn) {
+      return;
+    }
+    const rect = activeBtn.getBoundingClientRect();
+    window.chrome.webview.postMessage(
+      serializeHostMessage({
+        type: 'maximizeButtonRect',
+        data: {
+          x: rect.left,
+          y: rect.top,
+          width: rect.width,
+          height: rect.height,
+          dpr: window.devicePixelRatio || 1
+        }
+      })
+    );
+  });
+}
+
+function endTitlebarDrag(): void {
+  if (!titlebarDragState.isDraggingFromTitlebar) {
+    return;
+  }
+  titlebarDragState.isDraggingFromTitlebar = false;
+  postMaximizeButtonRect();
+}
 
 function applyMaximizeRestoreState(): void {
   const maximizeBtn = document.getElementById('btn-maximize');
@@ -86,41 +136,6 @@ function setupTitlebarButtons(): void {
     } else {
       console.warn('[windowControl] webview2 not available:', value);
     }
-  };
-
-  const getActiveMaxButton = (): HTMLElement | null => {
-    if (windowState.isMaximized && restoreBtn instanceof HTMLElement) {
-      return restoreBtn;
-    }
-    if (maximizeBtn instanceof HTMLElement) {
-      return maximizeBtn;
-    }
-    return null;
-  };
-
-  const postMaximizeButtonRect = () => {
-    if (!window.chrome?.webview) {
-      return;
-    }
-
-    const activeBtn = getActiveMaxButton();
-    if (!activeBtn) {
-      return;
-    }
-
-    const rect = activeBtn.getBoundingClientRect();
-    window.chrome.webview.postMessage(
-      serializeHostMessage({
-        type: 'maximizeButtonRect',
-        data: {
-          x: rect.left,
-          y: rect.top,
-          width: rect.width,
-          height: rect.height,
-          dpr: window.devicePixelRatio || 1
-        }
-      })
-    );
   };
 
   const restoreWindowControlsHoverState = () => {
@@ -306,11 +321,7 @@ function setupTitlebarDrag(): void {
     titlebarDragState.suspendCursorSyncUntilMouseMove = true;
 
     if (window.chrome?.webview) {
-      window.chrome.webview.postMessage(
-        serializeHostMessage({
-          type: 'dragStart'
-        })
-      );
+      window.chrome.webview.postMessage(serializeHostMessage({ type: 'dragStart' }));
     }
   });
 
@@ -457,7 +468,7 @@ function setupResizeHitTest(): void {
     lastPointer = { clientX: e.clientX, clientY: e.clientY };
 
     if (titlebarDragState.isDraggingFromTitlebar) {
-      titlebarDragState.isDraggingFromTitlebar = false;
+      endTitlebarDrag();
       clearResizeCursorState();
       return;
     }
@@ -476,6 +487,7 @@ function setupResizeHitTest(): void {
   });
 
   window.addEventListener('blur', () => {
+    endTitlebarDrag();
     setResizeUiBlocked(false);
     setCursor('');
   });


### PR DESCRIPTION
## 改动摘要

Fixes #155

页面接入协议序列化之后，设置窗口自绘标题栏拖动掉帧，Server 启动时悬浮工具栏首屏也偏慢。两条路径都被同一类成本打中：主线程上同步做协议校验 / 序列化，以及 WebView 在首屏之前加载 schema / runtime。

- 设置窗口每次 `WM_ACTIVATE` 都把整份配置 dump、再 parse 校验、再 post。激活（含拖完标题栏松手）会卡一下。激活时不再重推快照，配置仍由既有同步路径更新。
- `ReadHtmlFile` 用 Boost.Locale 生成器 + 宽流读 UTF-8 HTML。Locale 生成器构造贵，启动要读候选窗 / 工具栏 / 菜单多份页面。改为按字节读 UTF-8，再 `string_to_wstring`。
- 契约脚本原先在 `<head>` 最前，内联 schema / runtime 之后堵住首屏。挪到标记之后，HTML / CSS 先解析。
- 标题栏拖动时 `resize` / `ResizeObserver` 会连续 post `maximizeButtonRect`（同样走序列化）。用 rAF 合并，拖动期间不发，mouseup / blur 再补一次。

不改协议字段。

## 如何验证

**自动化测试**

| 测试项 | 命令 | 结果 |
|---|---|---|
| Server | `MetasequoiaImeServerTests` | 含新增 `protocol_inline_replaces_scripts_after_markup`（本机未跑） |
| 设置页类型检查 | `cd ui-html/webview2/settings/ime-settings; pnpm exec tsc --noEmit` | 通过 |

**手工**

1. 打开设置窗口，按住自绘标题栏反复拖动，不应再明显掉帧
2. 最大化 / 还原按钮的 hover、按下、点击仍正常
3. 重启 Server，悬浮工具栏应更快出现内容
4. 候选窗选词、托盘菜单开关悬浮栏仍正常

未在本机跑 Server 测试与原生宿主手测。

## 跨仓库

否。
