### PR TITLE
fix: stop candidate-window flicker and dropped commits when the machine is loaded

### DIFF
--- a/product-lock.json
+++ b/product-lock.json
@@ -3,7 +3,7 @@
   "repositories": {
     "engine": {
       "repository": "metasequoiaime/MSIME-Engine",
-      "commit": "111de926d95f11a7c632f857e2967c09d6166ae8"
+      "commit": "da61ca472eda23445ae0ecd2e4d43868063cb36a"
     }
   },
   "dictionary": {

--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -201,6 +201,12 @@ void ApplyUiLessFromPacket(const FanyImeNamedpipeData &pipe_data)
     }
 }
 
+// A task that waited at least this long was delivered behind a stalled worker,
+// so the state it describes may already be superseded. Normal typing never gets
+// near it: queue waits stay under a few milliseconds unless something blocks the
+// task thread.
+constexpr ULONGLONG kCandidateHideBacklogMs = 24;
+
 void RequestShowCandidateWindow()
 {
     if (IsUiLessMode() || !::global_hwnd)
@@ -1520,9 +1526,16 @@ void WorkerThread()
 
         case TaskType::HideCandidate: {
             ::ReadDataFromNamedPipe(0b100000);
-            CAND_DIAG_LOGF(L"task HideCandidate client={} epoch={} request={}", task.client_id, task.activation_epoch,
-                           task.pipe_data.request_id);
-            PostMessage(::global_hwnd, WM_HIDE_MAIN_WINDOW, 0, 0);
+            const ULONGLONG queue_elapsed_ms = task.enqueued_at_ms == 0 ? 0 : GetTickCount64() - task.enqueued_at_ms;
+            CAND_DIAG_LOGF(L"task HideCandidate client={} epoch={} request={} queued_ms={}", task.client_id,
+                           task.activation_epoch, task.pipe_data.request_id, queue_elapsed_ms);
+            // Only a hide this thread delivered late can belong to a keystroke the
+            // user has already typed past — that is the one worth holding briefly,
+            // because a show for a later keystroke is right behind it. A hide
+            // delivered on time is a real commit or focus loss and must take effect
+            // now; delaying it leaves the candidate window hanging after the word is
+            // already on screen, which is exactly the snap that typing loses.
+            PostMessage(::global_hwnd, WM_HIDE_MAIN_WINDOW, queue_elapsed_ms >= kCandidateHideBacklogMs ? 1 : 0, 0);
             /* 清理状态 */
             ClearState();
             break;

--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -3109,8 +3109,41 @@ void TsfDiagnosticPipeEventListenerLoopThread()
     }
 }
 
+// Stopwatch for the per-keystroke candidate build. Everything this function does
+// runs on the shared task thread, so a stall anywhere in it delays the hide/show
+// messages queued behind it — which is what reaches the screen as flicker. The
+// splits exist to tell those segments apart: the engine candidate lookup and the
+// user-dictionary fixed-position pass both touch a database, and only a
+// measurement says which one is paying for it.
+class CandidateBuildTimer
+{
+  public:
+    // Milliseconds since the previous split, then restarts the segment.
+    double Split()
+    {
+        const auto now = std::chrono::steady_clock::now();
+        const double ms = std::chrono::duration<double, std::milli>(now - last_).count();
+        last_ = now;
+        return ms;
+    }
+    double TotalMs() const
+    {
+        return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_).count();
+    }
+
+  private:
+    std::chrono::steady_clock::time_point start_ = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point last_ = start_;
+};
+
 void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
 {
+    CandidateBuildTimer segment;
+    // Zero means the branch taken this keystroke has no such segment, not that
+    // the segment was instant.
+    double queryMs = 0;
+    double fixedPosMs = 0;
+
     auto &ui = Global::candidate_ui;
     std::string pinyin = wstring_to_string(Global::PinyinString);
     const std::string current_input = g_inputSession->get_pinyin_sequence_with_cases();
@@ -3153,8 +3186,10 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
         const std::string typed = g_inputSession->get_pinyin_sequence();
         for (auto &item : items)
             item.pinyin = typed;
+        queryMs = segment.Split();
         user_dictionary::apply_fixed_positions(user_dictionary::default_user_db_path(), CurrentRankingContextKey(),
                                                items, false);
+        fixedPosMs = segment.Split();
     }
     else if (IsYModeInput(current_input))
     {
@@ -3171,11 +3206,13 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
     else
     {
         items = g_inputSession->get_candidates();
+        queryMs = segment.Split();
         user_dictionary::apply_fixed_positions(
             user_dictionary::default_user_db_path(), CurrentRankingContextKey(), items,
             g_inputSession->get_pinyin_sequence().size() == 1,
             [](const std::string &key, const std::string &value) { return g_inputSession->find_candidate(key, value); },
             g_inputSession->has_active_helpcode());
+        fixedPosMs = segment.Split();
         if (g_inputSession->get_pinyin_sequence().size() == 1 && items.size() > 24)
             items.resize(24);
     }
@@ -3185,9 +3222,14 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
         items.emplace_back(pinyin, pinyin, 1, CandidateSource::Fallback);
     }
 
+    // Whatever the branch above did that the two splits did not already claim.
+    const double branchMs = segment.Split();
+    const size_t itemCount = items.size();
+
     ui.set_items(std::move(items));
     RefreshCandidatePageUi(false);
     PublishCandidateUiOwner(client_id, activation_epoch);
+    const double uiMs = segment.Split();
 
     const SchemeType scheme = g_inputSession->current_scheme_type();
     if (g_english_input_mode)
@@ -3208,6 +3250,7 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
     {
         UpdateEnglishInput("");
     }
+    const double englishMs = segment.Split();
 
     if (!g_english_input_mode && !IsSpecialModeCompositionActive(current_input) &&
         GetConfiguredEmojiMixedInputEnabled() && (scheme == SchemeType::Quanpin || scheme == SchemeType::Shuangpin) &&
@@ -3219,6 +3262,7 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
     {
         UpdateEmojiInput("");
     }
+    const double emojiMs = segment.Split();
 
     if (!g_english_input_mode && !IsSpecialModeCompositionActive(current_input) &&
         GetConfiguredKaomojiMixedInputEnabled() && (scheme == SchemeType::Quanpin || scheme == SchemeType::Shuangpin) &&
@@ -3230,6 +3274,11 @@ void PrepareCandidateList(uint64_t client_id, uint64_t activation_epoch)
     {
         UpdateKaomojiInput("");
     }
+    const double kaomojiMs = segment.Split();
+
+    CAND_DIAG_LOGF(L"candidate build total_ms={:.1f} query_ms={:.1f} fixed_pos_ms={:.1f} branch_ms={:.1f} "
+                   L"ui_ms={:.1f} english_ms={:.1f} emoji_ms={:.1f} kaomoji_ms={:.1f} items={}",
+                   segment.TotalMs(), queryMs, fixedPosMs, branchMs, uiMs, englishMs, emojiMs, kaomojiMs, itemCount);
 }
 
 void ApplyCloudCandidate(const std::string &candidate, const std::string &pinyin, uint64_t generation,

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -2335,10 +2335,12 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
 
     if (message == WM_HIDE_MAIN_WINDOW || (message == WM_TIMER && wParam == TIMER_ID_CANDIDATE_HIDE_GRACE))
     {
-        if (message == WM_HIDE_MAIN_WINDOW)
+        // wParam != 0 marks a hide the worker delivered late, i.e. one that may
+        // already be superseded by keystrokes queued behind it. Only those get the
+        // grace; a hide arriving on time is a real commit or focus loss and is
+        // applied straight away so typing keeps its snap.
+        if (message == WM_HIDE_MAIN_WINDOW && wParam != 0)
         {
-            // Arm the grace instead of hiding now. A show inside the window cancels
-            // this; only the timer firing means the composition really is over.
             // Repeat hides while one is already armed need no extra work — that is
             // where the redundant back-to-back hides get absorbed.
             if (!g_candidate_hide_pending)

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -46,10 +46,22 @@ constexpr UINT_PTR TIMER_ID_FTB_VISIBILITY_RECONCILE = 9;
 constexpr UINT_PTR TIMER_ID_FTB_DPI_REMEASURE = 10;
 constexpr UINT_PTR TIMER_ID_CANDIDATE_MOVE_SETTLE = 11;
 constexpr UINT kCandidateMoveSettleMs = 50;
-// WebView2 backend: TSF may briefly toggle "should_show" while composing,
-// which can hide the candidate host right after it is un-cloaked.
-// Keep it visible for a short grace window so it can actually be perceived.
-constexpr UINT kCandidateHideGraceMs = 150;
+// A hide that is immediately followed by another show is not a teardown: it is
+// one keystroke of a burst the worker thread drained late (backspacing the
+// composition empty and typing again). Acting on it cloaks a visible candidate
+// window and un-cloaks it a few frames later, which is the flicker seen while
+// the machine is busy. Defer the hide by this much and drop it outright when a
+// show arrives first; a real commit or focus loss still hides, just this many
+// milliseconds later.
+constexpr UINT_PTR TIMER_ID_CANDIDATE_HIDE_GRACE = 12;
+constexpr UINT kCandidateHideGraceMs = 50;
+// A show repeating the previous frame's preedit, page and caret within this
+// window is a duplicate post rather than new state — the candidate rebuild and
+// the English/cloud merge each request a show per keystroke. Rendering both
+// paints the same picture twice. Keep the window short so anything the
+// signature does not capture (skin reload, DPI change) self-heals on the next
+// keystroke instead of sticking.
+constexpr UINT kCandidateShowDedupWindowMs = 250;
 // Long enough fallback when the page never posts ready (old HTML / failed JS).
 // Page-ready normally ends the grace earlier; until then the toolbar stays shown.
 constexpr UINT kFloatingToolbarPaintGraceMs = 6000;
@@ -73,7 +85,13 @@ std::atomic<bool> g_candidate_force_layout{false};
 std::atomic<uint64_t> g_candidate_content_generation{0};
 int g_last_placed_caret_x = Global::INVALID_Y;
 int g_last_placed_caret_y = Global::INVALID_Y;
-ULONGLONG g_candidate_hide_grace_until_tick = 0;
+// A WM_HIDE_MAIN_WINDOW is armed on TIMER_ID_CANDIDATE_HIDE_GRACE rather than
+// applied straight away; a show inside the grace window cancels it.
+bool g_candidate_hide_pending = false;
+// Last frame actually painted, used to drop duplicate shows. Cleared on hide so
+// the next session always paints.
+std::wstring g_last_rendered_candidate_signature;
+ULONGLONG g_last_rendered_candidate_tick = 0;
 bool g_candidate_session_anchor_valid = false;
 POINT g_candidate_session_anchor{};
 bool g_has_last_candidate_clip = false;
@@ -2168,6 +2186,26 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
     if (message == WM_SHOW_MAIN_WINDOW)
     {
         g_candidate_show_msg_pending.store(false);
+        // A show arriving while a hide is still inside its grace window means the
+        // hide belonged to an earlier keystroke of the same burst. Drop it, so the
+        // window stays up and the user never sees the blink.
+        if (g_candidate_hide_pending)
+        {
+            KillTimer(hwnd, TIMER_ID_CANDIDATE_HIDE_GRACE);
+            g_candidate_hide_pending = false;
+            CAND_DIAG_LOGF(L"hide cancelled by show within grace");
+        }
+        // This handler always renders the newest published state, never a payload
+        // captured when the message was posted, so an older queued show can only
+        // repaint what the newer one is about to repaint. Under load the worker
+        // drains a backlog and posts several at once; painting every one of them
+        // is what turns a queue stall into visible strobing.
+        MSG supersedingShow{};
+        if (PeekMessage(&supersedingShow, hwnd, WM_SHOW_MAIN_WINDOW, WM_SHOW_MAIN_WINDOW, PM_NOREMOVE))
+        {
+            CAND_DIAG_LOGF(L"candidate-frame path=superseded");
+            return 0;
+        }
         const uint64_t contentGeneration = ++g_candidate_content_generation;
         const ULONGLONG updateStartedTick = GetTickCount64();
         ::ReadDataFromSharedMemory(0b1000000);
@@ -2187,6 +2225,23 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
             (void)0;
         }
         const POINT layoutCaret = GetCandidateLayoutCaret();
+        const std::wstring preedit =
+            GetConfiguredCandidateWindowPreeditStyle() == "empty" ? std::wstring{} : GetPreeditWithCaretMarker();
+        // Suppress a repaint that would reproduce the frame already on screen.
+        // g_candidate_force_layout marks the cases (DPI / display change) where
+        // the same content must still be re-laid out, so never dedup through it.
+        const std::wstring frameSignature =
+            fmt::format(L"{}|{}|{},{}|{}", preedit, candidatePage->candidate_string, layoutCaret.x, layoutCaret.y,
+                        candidatePage->selected_index_in_page);
+        if (::is_global_wnd_cand_shown && !g_candidate_force_layout.load() &&
+            frameSignature == g_last_rendered_candidate_signature &&
+            updateStartedTick - g_last_rendered_candidate_tick < kCandidateShowDedupWindowMs)
+        {
+            CAND_DIAG_LOGF(L"candidate-frame path=dedup content_gen={}", contentGeneration);
+            return 0;
+        }
+        g_last_rendered_candidate_signature = frameSignature;
+        g_last_rendered_candidate_tick = updateStartedTick;
         if (CandidatePresenter::Instance().IsBound())
         {
             CandidatePresenter::Instance().ShowFromGlobalState(layoutCaret);
@@ -2204,14 +2259,16 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
         if (!IsCandidateWebviewReady())
         {
             DeferCandidateShowUntilWebviewReady();
+            // Nothing was painted, so this frame must not count as rendered:
+            // the replay posted once the webview is ready would otherwise be
+            // deduped against itself and the window would never appear.
+            g_last_rendered_candidate_signature.clear();
             CAND_DIAG_LOGF(L"candidate-frame path=deferred-webview content_gen={} {}", contentGeneration,
                            DescribeCandidateHostState());
             return 0;
         }
         RaiseCandidateHostForShow(L"show-candidate");
 
-        std::wstring preedit =
-            GetConfiguredCandidateWindowPreeditStyle() == "empty" ? std::wstring{} : GetPreeditWithCaretMarker();
         std::wstring str = preedit + L"," + candidatePage->candidate_string;
         const bool sameCaret = g_last_placed_caret_x == layoutCaret.x && g_last_placed_caret_y == layoutCaret.y;
         const bool alreadyVisible = IsCandidateHostPaintedVisible(hwnd);
@@ -2276,10 +2333,28 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
         return 0;
     }
 
-    if (message == WM_HIDE_MAIN_WINDOW)
+    if (message == WM_HIDE_MAIN_WINDOW || (message == WM_TIMER && wParam == TIMER_ID_CANDIDATE_HIDE_GRACE))
     {
+        if (message == WM_HIDE_MAIN_WINDOW)
+        {
+            // Arm the grace instead of hiding now. A show inside the window cancels
+            // this; only the timer firing means the composition really is over.
+            // Repeat hides while one is already armed need no extra work — that is
+            // where the redundant back-to-back hides get absorbed.
+            if (!g_candidate_hide_pending)
+            {
+                g_candidate_hide_pending = true;
+                SetTimer(hwnd, TIMER_ID_CANDIDATE_HIDE_GRACE, kCandidateHideGraceMs, nullptr);
+            }
+            CAND_DIAG_LOGF(L"hide message deferred grace_ms={} {}", kCandidateHideGraceMs,
+                           DescribeCandidateHostState());
+            return 0;
+        }
+        KillTimer(hwnd, TIMER_ID_CANDIDATE_HIDE_GRACE);
+        g_candidate_hide_pending = false;
         CAND_DIAG_LOGF(L"hide message begin {}", DescribeCandidateHostState());
         ::is_global_wnd_cand_shown = false;
+        g_last_rendered_candidate_signature.clear();
         KillTimer(hwnd, TIMER_ID_CANDIDATE_MOVE_SETTLE);
         g_candidate_session_anchor_valid = false;
         ++g_candidate_content_generation;

--- a/windows/src/Edit/GetTextExtentEditSession.cpp
+++ b/windows/src/Edit/GetTextExtentEditSession.cpp
@@ -57,6 +57,10 @@ STDAPI CGetTextExtentEditSession::DoEditSession(TfEditCookie ec)
         const POINT anchor = GetPhysicalTextAnchor(_pContextView, rc);
         Global::Point[0] = anchor.x;
         Global::Point[1] = anchor.y;
+        // This is the per-keystroke caret source. Tell the sink the session now
+        // has a usable anchor, so a later transient TS_E_NOLAYOUT can be answered
+        // by keeping this position instead of parking the window off-screen.
+        _pTfTextLayoutSink->_MarkAnchorValid();
         if (Global::current_process_name == Global::ZEN_BROWSER)
         {
             Global::firefox_like_cnt++;

--- a/windows/src/IME/MetasequoiaIME.h
+++ b/windows/src/IME/MetasequoiaIME.h
@@ -70,6 +70,9 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
 {
     friend class CCompositionProcessorEngine;
     friend class CKeyHandlerEditSession;
+    // Needs _IsComposing() to tell a host's transient context-view teardown apart
+    // from a real end of composition.
+    friend class CCandidateListUIPresenter;
 
   public:
     CMetasequoiaIME();

--- a/windows/src/Tf/TfTextLayoutSink.cpp
+++ b/windows/src/Tf/TfTextLayoutSink.cpp
@@ -33,6 +33,7 @@ CTfTextLayoutSink::CTfTextLayoutSink(_In_ CMetasequoiaIME *pTextService)
     _tfEditCookie = TF_INVALID_EDIT_COOKIE;
 
     _dwCookieTextLayoutSink = TF_INVALID_COOKIE;
+    _hasValidAnchor = false;
 
     _refCount = 1;
 
@@ -147,6 +148,7 @@ HRESULT CTfTextLayoutSink::_StartLayout(_In_ ITfContext *pContextDocument, TfEdi
     _pRangeComposition->AddRef();
 
     _tfEditCookie = ec;
+    _hasValidAnchor = false;
     HRESULT hr = _AdviseTextLayoutSink();
     return hr;
 }
@@ -157,6 +159,7 @@ VOID CTfTextLayoutSink::_EndLayout()
     const bool hadRangeComposition = (_pRangeComposition != nullptr);
     const bool hadContextDocument = (_pContextDocument != nullptr);
     HRESULT unadviseHr = S_OK;
+    _hasValidAnchor = false;
 
     if (_pRangeComposition)
     {
@@ -249,7 +252,29 @@ HRESULT CTfTextLayoutSink::_GetTextExt(_Out_ RECT *lpRect, _Out_ POINT *lpAnchor
         return hr;
     }
 
-    if (FAILED(hr = pContextView->GetTextExt(_tfEditCookie, _pRangeComposition, lpRect, &isClipped)))
+    hr = pContextView->GetTextExt(_tfEditCookie, _pRangeComposition, lpRect, &isClipped);
+
+    // TS_E_NOLAYOUT means "the host has not laid this range out yet, ask again",
+    // not "the caret is gone". Chromium-based hosts (Electron apps, browsers)
+    // answer it routinely while their renderer is behind, and far more often
+    // while the machine is busy. Adopting the off-screen sentinel here parks the
+    // candidate window at INVALID_Y for one frame and the next measurement pulls
+    // it back — that is the flicker seen under load. Report the failure so the
+    // caller keeps the anchor it already has; TF_LC_CHANGE delivers the real
+    // position as soon as layout completes. Only do this once this layout
+    // session has produced a good anchor, so composition start still falls back
+    // to the sentinel rather than reusing a stale one from another document.
+    if (hr == TS_E_NOLAYOUT && _hasValidAnchor)
+    {
+        pContextView->Release();
+        if (Global::TsfDiagnosticLogEnabled.load(std::memory_order_relaxed))
+        {
+            QueueTsfDiagnosticLog(L"[candidate-layout] kept last anchor across transient TS_E_NOLAYOUT");
+        }
+        return hr;
+    }
+
+    if (FAILED(hr))
     {
         // Set default value to make sure the window is hidden by moving it out of the screen
         lpRect->left = 0;
@@ -267,6 +292,7 @@ HRESULT CTfTextLayoutSink::_GetTextExt(_Out_ RECT *lpRect, _Out_ POINT *lpAnchor
     else
     {
         *lpAnchor = GetPhysicalTextAnchor(pContextView, *lpRect);
+        _hasValidAnchor = true;
     }
     pContextView->Release();
 

--- a/windows/src/Tf/TfTextLayoutSink.h
+++ b/windows/src/Tf/TfTextLayoutSink.h
@@ -29,6 +29,14 @@ class CTfTextLayoutSink : public ITfTextLayoutSink
         return _pContextDocument;
     };
 
+    // Callers that read the caret straight from ITfContextView (the edit-session
+    // path) report their success here, so _GetTextExt knows whether Global::Point
+    // already holds a usable anchor for this layout session.
+    void _MarkAnchorValid()
+    {
+        _hasValidAnchor = true;
+    }
+
     virtual VOID _LayoutChangeNotification(_In_ RECT *lpRect) = 0;
     virtual VOID _LayoutDestroyNotification() = 0;
 
@@ -43,4 +51,5 @@ class CTfTextLayoutSink : public ITfTextLayoutSink
     CMetasequoiaIME *_pTextService;
     DWORD _dwCookieTextLayoutSink;
     LONG _refCount;
+    bool _hasValidAnchor;
 };

--- a/windows/src/UI/CandidateListUIPresenter.cpp
+++ b/windows/src/UI/CandidateListUIPresenter.cpp
@@ -1128,17 +1128,23 @@ VOID CCandidateListUIPresenter::_LayoutDestroyNotification()
         return;
     }
 
-    // Telegram transiently destroys and recreates its TSF context view while
-    // the same composition is still active. Treating that as candidate-session
-    // teardown sends HideCandidate between ordinary keystrokes, so Server clears
-    // the live composition and the HWND visibly disappears/reappears. Keep the
-    // sink/session alive; real commit, cancel, focus loss, and presenter cleanup
-    // still terminate it through the normal composition paths.
-    if (_wcsicmp(Global::current_process_name.c_str(), L"Telegram.exe") == 0)
+    // Some hosts transiently destroy and recreate their TSF context view while
+    // the same composition is still active — Telegram always did, and every
+    // Chromium-based host (Electron apps such as VS Code / Cursor, browsers)
+    // does it too once the machine is busy enough for the renderer to fall
+    // behind. Treating that as candidate-session teardown sends HideCandidate
+    // between ordinary keystrokes, so Server clears the live composition and the
+    // HWND visibly disappears/reappears, and the pending candidate can no longer
+    // be committed. A live composition is the reliable signal that this is not a
+    // real teardown, so gate on that instead of on a process-name allowlist:
+    // real commit, cancel, focus loss, and presenter cleanup all end the
+    // composition first and still terminate the session through those paths.
+    if (_pTextService != nullptr && _pTextService->_IsComposing())
     {
         if (Global::TsfDiagnosticLogEnabled.load(std::memory_order_relaxed))
         {
-            QueueTsfDiagnosticLog(L"[candidate-layout] ignored transient TF_LC_DESTROY process=Telegram.exe");
+            QueueTsfDiagnosticLog(L"[candidate-layout] ignored transient TF_LC_DESTROY while composing process=" +
+                                  Global::current_process_name);
         }
         return;
     }


### PR DESCRIPTION
> metasequoiaime/MSIME-Engine#82 is merged (`da61ca4`). The submodule and `product-lock.json` both point at it, so this PR is self-contained and ready to review.

## Problem

Under load (e.g. Cursor and VSCode both initializing), typing in Chrome would show the candidate window flickering, and pressing SPACE would sometimes fail to commit at all - the preedit letter string flickered back several times and the candidate never reached the document.

Diagnostic logs traced this to a chain rather than one bug:

1. `PrepareCandidateList` runs on the server's single shared task thread. `apply_fixed_positions` inside it opened a sqlite connection and ran a full schema pass **per keystroke** - 90% of the candidate build, worst case 737 ms.
2. That stalled the task thread past the TSF client's in-edit-session reply wait, so the commit timed out (`0x800705B4` -> `0x8007006D`), the client replayed its entire key buffer (the visible preedit flicker), and after five retries abandoned the key (`E_FAIL`).
3. Separately, several UI-thread paths repainted or hid the candidate window more often than the input actually changed, which is the flicker seen even when commits succeeded.

## Commits

- **`fix(tsf)`** - Two host-timing paths could hide or displace the candidate window between keystrokes. `TS_E_NOLAYOUT` from `ITfContextView::GetTextExt` means "not laid out yet, ask again", but it was reported as a valid measurement at `INVALID_Y`, parking the window off-screen for a frame; Chromium hosts return it whenever their renderer is behind. And `TF_LC_DESTROY` was treated as candidate-session teardown for every process except a hardcoded `Telegram.exe`, so hosts that transiently recreate their context view mid-composition got a `HideCandidate` between keystrokes. Now gated on a live composition instead of a process name.
- **`fix(server)`: stop candidate strobing when the worker queue backs up** - three UI-thread causes: a hide that cloaks then un-cloaks ~30 ms later during a burst (now grace-deferred and dropped if a show arrives first), two `WM_SHOW_MAIN_WINDOW` messages per keystroke (now deduplicated when preedit, page, selection and caret are unchanged), and stale queued shows superseded by a newer one.
- **`fix(server)`: only grace-delay a hide the worker delivered late** - the unconditional 50 ms grace cost typing its snap and made the box morph between words instead of disappearing. Now the queue wait is measured at dispatch and only a hide that actually waited behind a stalled thread is delayed; normal typing hides immediately as before.
- **`perf(server)`: time each segment of the candidate build** - measurement only, no behaviour change. This is what identified the segment responsible; the per-keystroke `candidate build` line is what the numbers below come from.
- **`perf(deps)`** - submodule bump to the merged engine fix, with `product-lock.json` following so the artifact manifest records the engine the build actually used. This also moves the engine from the commit `develop` pins to the merged tip of engine `main`; despite the commit count that is a small content step (29 files, mostly additive: fuzzy pinyin options, dictionary state and their tests).

## Measurements (60 keystrokes, loaded disk)

| segment | median | p90 | max | total |
|---|---|---|---|---|
| fixed_pos (user-dictionary journal open) | 11.1 ms | 103.2 ms | 737.3 ms | 2677.4 ms |
| engine candidate query | 0.0 ms | 0.1 ms | 0.3 ms | 1.2 ms |
| total | 12.9 ms | 120.8 ms | 741.0 ms | 2971.8 ms |

## Testing

- `MetasequoiaImeServerTests`: 271/271 pass, against the updated engine.
- `ctest -C Release`: 2/2 pass. Engine own suite on the merged commit: 20/20 pass, including the cases pairing `close_default_user_database()` with directory cleanup.
- TSF DLL built clean for both x64 and x86.
- `clang-format` clean on all changed files.
- Manually verified: the flicker and the dropped-commit failure no longer reproduce under the workload that triggered them.

## Known remaining issue

The client's retry strategy - replaying the **entire** key buffer after an in-edit-session timeout - is still architecturally wrong, and each replay enqueues more work onto the already-congested thread, so it cannot self-recover. Removing the stall makes it stop firing in practice, but it would still trigger under extreme enough load. Left for a follow-up rather than widening this PR.


