### PR TITLE
fix(ci): stop the pipe probe from handshaking with a leftover Server

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -5,6 +5,7 @@ tsf_dll/
 app_data/
 MetasequoiaIME.ico
 /THIRD_PARTY_NOTICES.txt
+/LICENSE.txt
 
 # Local test certificates (generated on each machine)
 *.cer

--- a/scripts/ci/probe-server.ps1
+++ b/scripts/ci/probe-server.ps1
@@ -25,8 +25,17 @@ foreach ($architecture in @('Win32', 'x64')) {
 }
 # CI owns the process lifetime. The existing marker prevents the watchdog from
 # restarting it after the probe; no DLL is registered and no IME is installed.
+# On a persistent self-hosted runner a Server left behind by an earlier job wins
+# the single-instance mutex, the one started here returns 0 immediately, and the
+# probe silently handshakes with the older build instead. Clear the field first.
+Get-Process -Name 'MetasequoiaImeServer', 'MetasequoiaImeWatchdog' -ErrorAction SilentlyContinue |
+    Stop-Process -Force
 $process = Start-Process -FilePath $binary -ArgumentList '--watchdog-managed --pipe-probe' `
     -WorkingDirectory (Split-Path $binary) -PassThru
+Start-Sleep -Milliseconds 200
+if ($process.HasExited) {
+    throw "Server exited immediately with code $($process.ExitCode); another instance holds the single-instance mutex"
+}
 try {
     foreach ($probe in $probes) {
         & $probe

--- a/scripts/ci/test-server.ps1
+++ b/scripts/ci/test-server.ps1
@@ -13,7 +13,9 @@ if (-not (Test-Path -LiteralPath $helpcodes -PathType Container)) {
     throw "Helpcodes not found at $helpcodes; run git submodule update --init"
 }
 python (Join-Path $automationRoot 'scripts/product_lock.py') verify-contracts $automationRoot
-if ($LASTEXITCODE -ne 0) { throw 'The engine submodule does not match the product lock' }
+# A non-zero exit also covers git or python failing outright, which reads nothing
+# like a contract mismatch. Point at the output instead of naming a cause.
+if ($LASTEXITCODE -ne 0) { throw "verify-contracts exited $LASTEXITCODE; see the output above" }
 python (Join-Path $automationRoot 'scripts/product_lock.py') verify-checkout engine (Join-Path $automationRoot 'vendor/MetasequoiaImeEngine')
 if ($LASTEXITCODE -ne 0) { throw 'The Engine checkout does not match the product lock' }
 python (Join-Path $automationRoot 'scripts/product_lock.py') fetch-dictionaries --staging-root $StagingRoot


### PR DESCRIPTION
## 问题

v0.6.3 和 v0.6.4 两次 Release 都没有产出安装包。两次 `Build Server` 都挂在同一处：

```
Character-set shortcut capability was not negotiated correctly
Native pipe probe failed: ...\msime-pipe-probe-Win32\Release\msime-ipc-probe.exe
scripts/ci/probe-server.ps1:33
```

但源码两侧都是对的 —— `ipc.cpp` 广播 `Capabilities | CharacterSetShortcut`，probe 请求它，引擎契约测试也覆盖了这条路径。而 PR CI 上同一个脚本每次都绿。

## 根因

`ci.yml` 的 server job 跑在 `windows-2025`（每次全新镜像），`release.yml` 的 server job 跑在自建持久 runner。只有 release 这条路会在 job 之间留下活着的 `MetasequoiaImeServer.exe`。

残留进程占着 `Local\MetasequoiaImeServer_SingleInstance`，于是 `probe-server.ps1` 启动的那个 Server 在 `main.cpp:92-96` 的守卫里直接 `return 0`。脚本不检查这一点，管道又确实是通的（旧进程在监听），probe 就和**旧构建**完成了握手。

probe 1–4 不要求 `CharacterSetShortcut` 所以全过；probe 5 要求，而早于 6ff1cff 的 Server 从不广播它 —— 于是失败在一个树里任何代码都解释不了的能力协商上。`finally` 里 `$process.HasExited` 已是 true，残留进程连清理都躲过了。

时间戳佐证：probe 链接完成到失败只隔 0.5s（v0.6.3 是 0.7s），冷启动加载词库的 Server 不可能在这个窗口内应答完 5 轮三管道握手。

## 改动

- `probe-server.ps1`：启动前清掉已有的 Server / Watchdog；启动后确认自己起的进程没有自行退出，否则明确报错。
- `test-server.ps1`：不再把 `verify-contracts` 的任何非零退出都说成 lock 不一致。同一批 run 里 runner 上的 git dubious-ownership 失败就被报成了 `The engine submodule does not match the product lock`，而 lock 完全正确，白白带偏了排查方向。
- `installer/.gitignore`：忽略 `Prepare-PackageFiles.ps1` 每次本地打包都会生成的 `installer/LICENSE.txt`。