### PR TITLE
release

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -5,6 +5,7 @@ tsf_dll/
 app_data/
 MetasequoiaIME.ico
 /THIRD_PARTY_NOTICES.txt
+/LICENSE.txt
 
 # Local test certificates (generated on each machine)
 *.cer

--- a/scripts/ci/probe-server.ps1
+++ b/scripts/ci/probe-server.ps1
@@ -25,8 +25,17 @@ foreach ($architecture in @('Win32', 'x64')) {
 }
 # CI owns the process lifetime. The existing marker prevents the watchdog from
 # restarting it after the probe; no DLL is registered and no IME is installed.
+# On a persistent self-hosted runner a Server left behind by an earlier job wins
+# the single-instance mutex, the one started here returns 0 immediately, and the
+# probe silently handshakes with the older build instead. Clear the field first.
+Get-Process -Name 'MetasequoiaImeServer', 'MetasequoiaImeWatchdog' -ErrorAction SilentlyContinue |
+    Stop-Process -Force
 $process = Start-Process -FilePath $binary -ArgumentList '--watchdog-managed --pipe-probe' `
     -WorkingDirectory (Split-Path $binary) -PassThru
+Start-Sleep -Milliseconds 200
+if ($process.HasExited) {
+    throw "Server exited immediately with code $($process.ExitCode); another instance holds the single-instance mutex"
+}
 try {
     foreach ($probe in $probes) {
         & $probe

--- a/scripts/ci/test-server.ps1
+++ b/scripts/ci/test-server.ps1
@@ -13,7 +13,9 @@ if (-not (Test-Path -LiteralPath $helpcodes -PathType Container)) {
     throw "Helpcodes not found at $helpcodes; run git submodule update --init"
 }
 python (Join-Path $automationRoot 'scripts/product_lock.py') verify-contracts $automationRoot
-if ($LASTEXITCODE -ne 0) { throw 'The engine submodule does not match the product lock' }
+# A non-zero exit also covers git or python failing outright, which reads nothing
+# like a contract mismatch. Point at the output instead of naming a cause.
+if ($LASTEXITCODE -ne 0) { throw "verify-contracts exited $LASTEXITCODE; see the output above" }
 python (Join-Path $automationRoot 'scripts/product_lock.py') verify-checkout engine (Join-Path $automationRoot 'vendor/MetasequoiaImeEngine')
 if ($LASTEXITCODE -ne 0) { throw 'The Engine checkout does not match the product lock' }
 python (Join-Path $automationRoot 'scripts/product_lock.py') fetch-dictionaries --staging-root $StagingRoot


### PR DESCRIPTION
Promote the validated develop fixes to main for the next automated release. This promotion keeps the conventional fix commits in the main history so release-please can create the next draft release.

Carries `fix(ci): stop the pipe probe from handshaking with a leftover Server` (#278), which is what blocked the v0.6.3 and v0.6.4 installers. Both runs died in `Build Server` on `probe-server.ps1:33` with a `CharacterSetShortcut` capability mismatch that no code in the tree accounts for: a Server left over on the persistent self-hosted runner held the single-instance mutex, the freshly built one exited straight out of the guard, and the probe handshook with the older build instead. `ci.yml` never saw it because its Server job runs on a fresh `windows-2025` image.

Note that #278 passing CI does not by itself demonstrate the fix; only a release run on the self-hosted runner exercises the path that failed.