### PR TITLE
fix(ci): unblock packaging on the self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,14 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+
       - name: Stamp the version resource
         shell: pwsh
         run: |
@@ -248,6 +256,14 @@ jobs:
           ref: ${{ needs.prepare.outputs.target_sha }}
           submodules: recursive
           persist-credentials: false
+
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
 
       - name: Install Boost
         shell: pwsh
@@ -373,6 +389,14 @@ jobs:
           ref: ${{ needs.prepare.outputs.target_sha }}
           submodules: true
           persist-credentials: false
+
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
 
       - name: Verify the release commit is on main
         shell: bash

--- a/server/vcpkg.json
+++ b/server/vcpkg.json
@@ -1,4 +1,5 @@
 {
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "fmt",
     "curl",

--- a/windows/vcpkg.json
+++ b/windows/vcpkg.json
@@ -1,4 +1,5 @@
 {
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "fmt",
     "utfcpp"


### PR DESCRIPTION
接在 #278 之后。#278 修好了 `Build Server`（v0.6.5 的 run 里它三轮来第一次通过），随后暴露出两个各自独立的问题，把 `package` job 挡在门外。

## 1. runner 2 的 git 属主

`package` 挂在 `Verify the release commit is on main`：

```
fatal: detected dubious ownership in repository at
  'E:/actions-runners/metasequoiaime/2/_work/MSIME-Windows/MSIME-Windows'
  owned by:      NT AUTHORITY/SYSTEM (S-1-5-18)
  current user:  WIN-RUNNER/runner
exit code 128
```

`actions/checkout` 不受影响，所以直到第一条普通 git 调用才炸。只有被调度到 runner 实例 2 的 job 会遇到 —— 重跑两次都落在它上面。三个自建 runner 的 job 各加一步把工作区标为 safe。

这是给机器配置打的补丁，runner 2 的目录属主本身仍然不对，建议另行修正。

## 2. vcpkg 清单没有 builtin-baseline

两个清单都没钉基线，vcpkg 于是按 registry 的 HEAD 解析，每次构建都依赖一次对 github.com 的实时 fetch。fetch 一降级，port 就直接消失：

```
Fetching registry information from https://github.com/microsoft/vcpkg (HEAD)...
fmt does not exist
utfcpp does not exist
```

`Build TSF x64` 因此在**同一台** `msime-windows-3` 上两次失败、两次成功 —— 典型的未钉 registry 表现。两个清单都钉到 `04a9d8e5`，也就是 `vcpkg-lock.json` 里已经记录为解析成功的那个提交。

注意这会固定依赖的版本解析结果，需要 CI 跑一轮确认。