### PR TITLE
release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,14 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+
       - name: Stamp the version resource
         shell: pwsh
         run: |
@@ -248,6 +256,14 @@ jobs:
           ref: ${{ needs.prepare.outputs.target_sha }}
           submodules: recursive
           persist-credentials: false
+
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
 
       - name: Install Boost
         shell: pwsh
@@ -373,6 +389,14 @@ jobs:
           ref: ${{ needs.prepare.outputs.target_sha }}
           submodules: true
           persist-credentials: false
+
+      # Some runner instances leave _work owned by SYSTEM while the job itself
+      # runs as `runner`. checkout still succeeds, so the first plain git call
+      # is what exits 128 on dubious ownership, minutes into the job.
+      - name: Trust the runner workspace
+        shell: pwsh
+        run: |
+          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
 
       - name: Verify the release commit is on main
         shell: bash

--- a/server/vcpkg.json
+++ b/server/vcpkg.json
@@ -1,4 +1,5 @@
 {
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "fmt",
     "curl",

--- a/windows/vcpkg.json
+++ b/windows/vcpkg.json
@@ -1,4 +1,5 @@
 {
+  "builtin-baseline": "04a9d8e5212d01ee1dd9478eadd9caade4f8b0d4",
   "dependencies": [
     "fmt",
     "utfcpp"


### PR DESCRIPTION
Promote the validated develop fixes to main for the next automated release. This promotion keeps the conventional fix commits in the main history so release-please can create the next draft release.

Carries `fix(ci): unblock packaging on the self-hosted runners` (#281), the second half of getting an installer built again. #278 already fixed `Build Server`, which passed for the first time in the v0.6.5 run; `package` then failed on git dubious ownership on runner instance 2, and `Build TSF x64` kept failing at random because neither vcpkg manifest pinned a baseline.

The vcpkg baseline is exercised by CI: the Server, Windows x64 and Windows Win32 jobs all installed and built against `04a9d8e5` on this branch. The `safe.directory` half is not — those steps exist only in `release.yml`, and `ci.yml` runs on GitHub-hosted images that never hit the ownership check. Only a release run can confirm it.