### PR TITLE
fix(ci): stop the self-hosted jobs racing on the global git config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,10 +186,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Stamp the version resource
         shell: pwsh
@@ -260,10 +273,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Install Boost
         shell: pwsh
@@ -393,10 +419,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Verify the release commit is on main
         shell: bash


### PR DESCRIPTION
## 问题

v0.6.6 的 release run（[34264066059](https://github.com/metasequoiaime/MSIME-Windows/actions/runs/34264066059)）在 `Build TSF x64` 挂掉，`Package and publish installer` 因此被 skip，仍然没有产出 exe。

失败的是 #281 里我自己加的 `Trust the runner workspace`：

```
error: could not lock config file C:/Users/runner/.gitconfig: File exists
##[error]Process completed with exit code 1.
```

三个自建 job 是同一台机器上的三个 runner 实例，共用 `C:\Users\runner\.gitconfig`：

| job | runner | Trust 步骤 | 时刻 |
| --- | --- | --- | --- |
| Build Server | msime-windows | success | 18:51:05 |
| Build TSF Win32 | msime-windows-3 | success | 18:51:05 |
| Build TSF x64 | msime-windows-2 | **failure** | 18:51:05 |

同一秒三个 `git config --global --add`，两个抢到锁，第三个失败。`actions/checkout` 做同样的事却不受影响，因为它写之前把 `HOME` 临时指到了 job 私有的 `_temp` 目录。

## 改动

重试写入，并在每次尝试前回读 `safe.directory`——如果并发的同伴已经把这个路径写进去了，直接算成功。

## 验证

在沙盒 `HOME` 下用独立 pwsh 进程跑过四种情形：

- 首次写入 → `added`，exit 0
- 幂等重跑 → `skip: already trusted`，exit 0
- 锁被长期占住 + 新路径 → 重试 13.2s 后明确报错，exit 1
- 锁被占住但对手已写好该路径 → 立即 `skip`，exit 0

CI 验不到这一步（这三个 job 只存在于 `release.yml`，而 `ci.yml` 跑 GitHub 托管机器），只能由下一轮 release run 检验。