### PR TITLE
release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,10 +186,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Stamp the version resource
         shell: pwsh
@@ -260,10 +273,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Install Boost
         shell: pwsh
@@ -393,10 +419,23 @@ jobs:
       # Some runner instances leave _work owned by SYSTEM while the job itself
       # runs as `runner`. checkout still succeeds, so the first plain git call
       # is what exits 128 on dubious ownership, minutes into the job.
+      #
+      # The self-hosted jobs are separate runner instances on one machine, so
+      # they share C:\Users\runner\.gitconfig and reach this step in the same
+      # second. Whoever loses that race gets "could not lock config file". Read
+      # the list back before each attempt so a peer's write counts as success.
       - name: Trust the runner workspace
         shell: pwsh
         run: |
-          git config --global --add safe.directory ($env:GITHUB_WORKSPACE -replace '\\', '/')
+          $workspace = $env:GITHUB_WORKSPACE -replace '\\', '/'
+          foreach ($attempt in 1..10) {
+              $trusted = git config --global --get-all safe.directory
+              if ($trusted -contains $workspace) { exit 0 }
+              git config --global --add safe.directory $workspace
+              if ($LASTEXITCODE -eq 0) { exit 0 }
+              Start-Sleep -Milliseconds (200 * $attempt)
+          }
+          throw "Could not add $workspace to the global safe.directory list"
 
       - name: Verify the release commit is on main
         shell: bash


### PR DESCRIPTION
把 #284 推上 main，触发下一轮 release run。

## 内容

只有一个代码提交 `d7e7b3f`：修 `release.yml` 里 `Trust the runner workspace` 的并发缺陷。三个自建 job 是同一台机器上的三个 runner 实例，共用 `C:\Users\runner\.gitconfig`，同一秒并发 `git config --global --add` 会有一个抢不到锁，报 `could not lock config file ...: File exists`。上一轮 v0.6.6（[run 34264066059](https://github.com/metasequoiaime/MSIME-Windows/actions/runs/34264066059)）就是这样让 `Build TSF x64` 挂掉、`Package and publish installer` 被 skip 的。

现在改成重试写入，且每次尝试前回读 `safe.directory`，并发同伴已写入即算成功。

## 状态

上一轮 release run 里 `Build Server`、`Build TSF Win32`、`Build settings page` 都已通过，说明先前修的 pipe probe 残留进程和 vcpkg 基线两个问题都站住了。这个 PR 之后，理论上就只剩产出 exe 这一步了。