### PR TITLE
issue-288 修复候选窗在光标坐标无效时提前显示的问题

### DIFF
--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -823,6 +823,19 @@ void CandidatePresenter::ShowFromGlobalState(POINT caret)
     {
         return;
     }
+    // A composition can start before the host reports a usable text extent
+    // (first focus, or resuming after a long idle). The caret then arrives as
+    // (0, INVALID_Y), which placement would clamp into the monitor's work area.
+    // Hide even an already-visible host until a real anchor arrives. Preserve
+    // the show request so MoveCandidate / the settle timer can place it later.
+    if (caret.y == Global::INVALID_Y)
+    {
+        CloseContextMenu(false);
+        SetCandidateHostCloaked(true);
+        ::is_global_wnd_cand_shown = true;
+        CAND_DIAG_LOGF(L"candidate-d2d show deferred: no usable caret anchor ({},{})", caret.x, caret.y);
+        return;
+    }
     CloseContextMenu(false);
     ApplySkin();
     std::wstring preedit;

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -2330,7 +2330,10 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
         const bool forceLayout = g_candidate_force_layout.exchange(false);
         const POINT layoutCaret = GetCandidateLayoutCaret();
         const bool sameCaret = g_last_placed_caret_x == layoutCaret.x && g_last_placed_caret_y == layoutCaret.y;
-        if (!forceLayout && !GetConfiguredCandidateWindowFollowCursor())
+        // Position locking applies only after the first usable anchor has been
+        // placed. A deferred show still needs its first valid MoveCandidate.
+        const bool awaitingInitialPlacement = g_last_placed_caret_y == Global::INVALID_Y;
+        if (!forceLayout && !GetConfiguredCandidateWindowFollowCursor() && !awaitingInitialPlacement)
         {
             CAND_DIAG_LOGF(L"candidate-position move-ignored locked_anchor=({},{}) reported=({},{})", layoutCaret.x,
                            layoutCaret.y, Global::Point[0], Global::Point[1]);


### PR DESCRIPTION
## 改动摘要

- 当光标坐标无效时，显式隐藏原生候选窗，并保留待显示状态。后续收到有效坐标后，通过现有的延迟定位流程刷新候选内容并显示窗口，避免无效坐标被修正到屏幕边缘后提前显示。

- 补齐关闭“候选窗跟随光标”时的恢复逻辑：尚未完成首次有效定位时，允许位置更新触发显示；完成定位后继续遵循原有的位置锁定设置。

关联 Issue：[[Bug] Firefox 中触发首次输入或空闲后恢复输入时，候选窗在屏幕左上角闪烁 #288](https://github.com/metasequoiaime/MSIME-Windows/issues/288)

## 如何验证
系统与版本：Windows 11 IoT 企业版 LTSC 24H2（操作系统版本 26100.9168，功能体验包 1000.26100.344.0）。
### 自动化测试

| 测试项 | 命令 | 结果 |
|---|---|---|
| 服务端发布构建 | `cmake --build server/build-release --config Release --parallel 4` | Windows x64 发布构建通过 |
| 测试词库校验 | `python scripts/product_lock.py verify-dictionaries <隔离词库目录>` | 通过，与产品锁一致 |
| 服务端完整测试及网页消息契约 | `ctest --test-dir server/build-release -C Release --output-on-failure --timeout 120` | 服务端 269 项通过；网页消息契约 34 个共享样例通过 |
| 补丁格式检查 | `git diff --check` | 通过 |

### 本机安装验证

| 验证项 | 验证方式 | 结果 |
|---|---|---|
| 窗口访问权限清单 | 注入后读回可执行文件中的清单 | 确认已启用 `uiAccess` |
| 本机测试签名 | `Get-AuthenticodeSignature` | 暂存及安装后的服务端签名均有效 |
| 安装文件一致性 | `Get-FileHash` | 安装文件与签名后的暂存文件摘要一致 |
| 服务端启动 | 启动后检查进程状态 | 新进程启动成功，响应正常 |

### 宿主验证

| 验证项 | 操作方式 | 结果 |
|---|---|---|
| Firefox 首次输入 | 首次点击网页文本框后输入，观察候选窗出现位置 | 通过 |
| Firefox 闲置后恢复输入 | 停止输入后再次触发输入，观察是否在左上角闪现 | 通过 |

https://github.com/user-attachments/assets/335d6e00-688f-4acb-aab9-8080ba2586cc

### 未覆盖
- 未重新执行设置页测试、文本服务通信契约测试或真实服务端管道探针。
- 未构建/验证 x86 版本。

## 跨仓库
否。

## 提交前确认

- [✅] 我按上面写的方式实际验证过，不是只读代码判断
- [✅] 没有在改动、截图或日志里带上 API Key、凭据或真实输入内容
- [✅] 如果用了 AI 生成代码，我已自行逐行检查并测试过
