### PR TITLE
feat(tsf): convert edit session keys for client router

### DIFF
--- a/windows/src/Key/ClientKeyRouter.h
+++ b/windows/src/Key/ClientKeyRouter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+struct ClientFocusLease {
+    uint64_t client = 0;
+    uint64_t epoch = 0;
+    uint64_t token = 0;
+};
+
+struct ClientKeyEvent {
+    ClientFocusLease lease;
+    uint32_t virtual_key = 0;
+    uint32_t scan_code = 0;
+    uint32_t modifiers = 0;
+    char16_t character = 0;
+    bool ui_less = false;
+};
+
+class IClientKeyRouter {
+  public:
+    virtual ~IClientKeyRouter() = default;
+    virtual bool dispatch(const ClientKeyEvent &event) = 0;
+    virtual bool cancel(const ClientFocusLease &lease) = 0;
+};

--- a/windows/src/Key/KeyStateCategory.h
+++ b/windows/src/Key/KeyStateCategory.h
@@ -2,6 +2,7 @@
 #include "Globals.h"
 #include "Private.h"
 #include "MetasequoiaIME.h"
+#include "ClientKeyRouter.h"
 #include <cstdint>
 #include <string>
 
@@ -45,6 +46,13 @@ typedef struct KeyHandlerEditSessionDTO
     uint64_t requestId;
     std::wstring prefetchedText;
 } KeyHandlerEditSessionDTO;
+
+inline ClientKeyEvent client_key_event(const KeyHandlerEditSessionDTO &dto,
+                                       ClientFocusLease lease,
+                                       uint32_t modifiers = 0,
+                                       bool ui_less = false) {
+    return {lease, dto.code, 0, modifiers, static_cast<char16_t>(dto.wch), ui_less};
+}
 
 class CKeyStateCategory
 {


### PR DESCRIPTION
Add a pure conversion helper from KeyHandlerEditSessionDTO to ClientKeyEvent, preserving old routing behavior. This carries the virtual key and UTF-16 character with an explicit lease; modifiers and UILess are supplied by the adapter.