### PR TITLE
feat(tsf): inject optional client router into ime

### DIFF
--- a/windows/src/IME/MetasequoiaIME.h
+++ b/windows/src/IME/MetasequoiaIME.h
@@ -15,6 +15,7 @@
 class CLangBarItemButton;
 class CCandidateListUIPresenter;
 class CCompositionProcessorEngine;
+class IClientKeyRouter;
 
 const DWORD WM_CheckGlobalCompartment = WM_USER;
 const DWORD WM_ConnectNamedpipe = WM_USER + 1;
@@ -77,6 +78,8 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
   public:
     CMetasequoiaIME();
     ~CMetasequoiaIME();
+    void SetClientKeyRouter(IClientKeyRouter *router) noexcept { _clientKeyRouter = router; }
+    IClientKeyRouter *ClientKeyRouter() const noexcept { return _clientKeyRouter; }
 
     // IUnknown
     STDMETHODIMP QueryInterface(REFIID riid, _Outptr_ void **ppvObj);
@@ -469,6 +472,7 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
     friend LRESULT CALLBACK CMetasequoiaIME_WindowProc(HWND wndHandle, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
   private:
+    IClientKeyRouter *_clientKeyRouter = nullptr; // borrowed; owner outlives IME
     ITfThreadMgr *_pThreadMgr;
     TfClientId _tfClientId;
     DWORD _dwActivateFlags;

--- a/windows/src/Key/ClientKeyRouter.h
+++ b/windows/src/Key/ClientKeyRouter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+struct ClientFocusLease {
+    uint64_t client = 0;
+    uint64_t epoch = 0;
+    uint64_t token = 0;
+};
+
+struct ClientKeyEvent {
+    ClientFocusLease lease;
+    uint32_t virtual_key = 0;
+    uint32_t scan_code = 0;
+    uint32_t modifiers = 0;
+    char16_t character = 0;
+    bool ui_less = false;
+};
+
+class IClientKeyRouter {
+  public:
+    virtual ~IClientKeyRouter() = default;
+    virtual bool dispatch(const ClientKeyEvent &event) = 0;
+    virtual bool cancel(const ClientFocusLease &lease) = 0;
+};

--- a/windows/src/Key/KeyStateCategory.h
+++ b/windows/src/Key/KeyStateCategory.h
@@ -2,6 +2,7 @@
 #include "Globals.h"
 #include "Private.h"
 #include "MetasequoiaIME.h"
+#include "ClientKeyRouter.h"
 #include <cstdint>
 #include <string>
 
@@ -45,6 +46,13 @@ typedef struct KeyHandlerEditSessionDTO
     uint64_t requestId;
     std::wstring prefetchedText;
 } KeyHandlerEditSessionDTO;
+
+inline ClientKeyEvent client_key_event(const KeyHandlerEditSessionDTO &dto,
+                                       ClientFocusLease lease,
+                                       uint32_t modifiers = 0,
+                                       bool ui_less = false) {
+    return {lease, dto.code, 0, modifiers, static_cast<char16_t>(dto.wch), ui_less};
+}
 
 class CKeyStateCategory
 {


### PR DESCRIPTION
Add a borrowed optional client router slot to CMetasequoiaIME. Existing behavior is unchanged when unset; this establishes lifecycle ownership for the next KeyHandler routing slice.