### PR TITLE
fix(ipc): distinguish definite local fallback

### DIFF
--- a/windows/src/IPC/Ipc.h
+++ b/windows/src/IPC/Ipc.h
@@ -17,6 +17,13 @@ enum class KeyEventSendResult
     DeliveryAmbiguous,
 };
 
+// Only a write that definitely did not reach Server may be handed to a local
+// fallback. DeliveryAmbiguous must go through the existing epoch recovery path.
+inline bool IsDefinitelyNotSent(KeyEventSendResult result) noexcept
+{
+    return result == KeyEventSendResult::DefinitelyNotSent;
+}
+
 int InitIpc();
 int InitNamedpipe();
 int ConnectToAllNamedpipe();


### PR DESCRIPTION
Add a pure IPC predicate documenting that only DefinitelyNotSent permits local fallback; DeliveryAmbiguous remains on the existing epoch recovery path. No protocol layout or runtime behavior changes. Windows build unavailable on this host; CI remains disabled.