### PR TITLE
fix(server,ui): D2D 渲染主题明暗模式与皮肤样式对齐 WebView2

### DIFF
--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -146,6 +146,17 @@ struct CandSkinTokens
     float borderWidth = 1.5f;
     float containerPad = 5.0f;
     bool showSelectedBar = true;
+    // Row corner radius, selected-row text colors and context-menu palette.
+    // Defaults are fluent dark; the fluent light branch and per-skin branches
+    // override. rowTextSelected/rowLabelSelected alpha 0 keeps the normal
+    // colors (bar-style selection, like the fluent CSS).
+    float itemRadius = 4.0f;
+    D2D1_COLOR_F rowTextSelected = D2D1::ColorF(0, 0.0f);
+    D2D1_COLOR_F rowLabelSelected = D2D1::ColorF(0, 0.0f);
+    D2D1_COLOR_F menuFill = D2D1::ColorF(0x2D2D2D);
+    D2D1_COLOR_F menuBorder = ParseCssColor("#9b9b9b2e", D2D1::ColorF(0x3A3A3A, 0.18f));
+    D2D1_COLOR_F menuText = D2D1::ColorF(0xE9E8E8);
+    D2D1_COLOR_F menuHover = ColorFromRgb(0x414141);
 };
 
 void ApplyPackageColors(const CandidateSkinCatalog::CandidateColors &colors, CandSkinTokens &tokens)
@@ -331,46 +342,125 @@ void CandidatePresenter::ApplySkin()
         tokens.number = D2D1::ColorF(26.0f / 255.0f, 26.0f / 255.0f, 26.0f / 255.0f, 0.55f);
         tokens.selected = ColorFromRgb(0xE8E8E8);
         tokens.hover = ColorFromRgb(0xECECEC);
+        tokens.menuFill = ColorFromRgb(0xFFFFFF);
+        tokens.menuBorder = D2D1::ColorF(0, 0.12f);
+        tokens.menuText = ColorFromRgb(0x1A1A1A);
+        tokens.menuHover = ColorFromRgb(0xECECEC);
     }
+    // Built-in skin palettes mirror ui-html/webview2/candwnd/skins/<skin>/;
+    // the WebView2 CSS is the reference for both the light and dark values.
     if (skinId == "wechat")
     {
-        tokens.surface = candLight ? ColorFromRgb(0xF7F7F7) : ColorFromRgb(0x151515);
-        tokens.border = ColorFromRgb(0x292929);
         tokens.borderWidth = 1.0f;
         tokens.radius = 5.0f;
+        tokens.containerPad = 2.0f;
         tokens.accent = ColorFromRgb(0x07C160);
         tokens.selected = ColorFromRgb(0x07C160);
-        tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.32f);
         tokens.showSelectedBar = false;
-        tokens.text = ColorFromRgb(0xB7B7B7);
-        tokens.number = ColorFromRgb(0x858585);
+        tokens.rowTextSelected = ColorFromRgb(0xFFFFFF);
+        tokens.rowLabelSelected = ColorFromRgb(0xFFFFFF);
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xF7F7F7);
+            tokens.border = ColorFromRgb(0xDEDEDE);
+            tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.14f);
+            tokens.text = ColorFromRgb(0x333333);
+            tokens.number = ColorFromRgb(0x757575);
+            tokens.menuFill = ColorFromRgb(0xFFFFFF);
+            tokens.menuBorder = ColorFromRgb(0xD9D9D9);
+            tokens.menuText = ColorFromRgb(0x333333);
+            tokens.menuHover = ColorFromRgb(0xEEEEEE);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x151515);
+            tokens.border = ColorFromRgb(0x292929);
+            tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.32f);
+            tokens.text = ColorFromRgb(0xB7B7B7);
+            tokens.number = ColorFromRgb(0x858585);
+            tokens.menuFill = ColorFromRgb(0x1F1F1F);
+            tokens.menuBorder = ColorFromRgb(0x343434);
+            tokens.menuText = ColorFromRgb(0xD0D0D0);
+            tokens.menuHover = ColorFromRgb(0x2A2A2A);
+        }
     }
     else if (skinId == "willow_green")
     {
-        tokens.surface = ColorFromRgb(0x2D2F2E);
         tokens.borderWidth = 0.0f;
         tokens.radius = 9.0f;
         tokens.containerPad = 0.0f;
-        tokens.accent = ColorFromRgb(0x65C98D);
-        tokens.selected = ColorFromRgb(0x65C98D);
-        tokens.hover = D2D1::ColorF(101.0f / 255.0f, 201.0f / 255.0f, 141.0f / 255.0f, 0.22f);
-        tokens.text = ColorFromRgb(0xD8DBD8);
-        tokens.number = ColorFromRgb(0xA6ABA7);
+        // CSS 把行圆角设为 0、靠容器 clip-path 裁出窗口圆角，但 D2D 端 Card
+        // 不裁剪子控件，行圆角 0 会让绿色选中块盖掉窗口圆角。有意偏离 CSS：
+        // 沿用对齐前的 4px 行圆角（视觉上等效圆角窗口，用户拍板的选择）。
+        tokens.itemRadius = 4.0f;
         tokens.showSelectedBar = false;
+        tokens.rowTextSelected = ColorFromRgb(0xFFFFFF);
+        tokens.rowLabelSelected = ColorFromRgb(0xFFFFFF);
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xF4F5F3);
+            tokens.accent = ColorFromRgb(0x58B980);
+            tokens.selected = ColorFromRgb(0x58B980);
+            tokens.hover = D2D1::ColorF(88.0f / 255.0f, 185.0f / 255.0f, 128.0f / 255.0f, 0.16f);
+            tokens.text = ColorFromRgb(0x343936);
+            tokens.number = ColorFromRgb(0x686F6A);
+            tokens.menuFill = ColorFromRgb(0xFBFCFA);
+            tokens.menuBorder = ColorFromRgb(0xD8DED9);
+            tokens.menuText = ColorFromRgb(0x343936);
+            tokens.menuHover = ColorFromRgb(0xE9EEEA);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x2D2F2E);
+            tokens.accent = ColorFromRgb(0x65C98D);
+            tokens.selected = ColorFromRgb(0x65C98D);
+            tokens.hover = D2D1::ColorF(101.0f / 255.0f, 201.0f / 255.0f, 141.0f / 255.0f, 0.22f);
+            tokens.text = ColorFromRgb(0xD8DBD8);
+            tokens.number = ColorFromRgb(0xA6ABA7);
+            tokens.menuFill = ColorFromRgb(0x343635);
+            tokens.menuBorder = ColorFromRgb(0x454845);
+            tokens.menuText = ColorFromRgb(0xE0E2DF);
+            tokens.menuHover = ColorFromRgb(0x414441);
+        }
     }
     else if (skinId == "graphite")
     {
-        tokens.surface = ColorFromRgb(0x1C1F23);
-        tokens.border = ColorFromRgb(0x30353B);
         tokens.borderWidth = 1.0f;
         tokens.radius = 3.0f;
         tokens.containerPad = 5.0f;
-        tokens.accent = ColorFromRgb(0x8993A0);
+        tokens.itemRadius = 2.0f;
         tokens.selected = D2D1::ColorF(0, 0.0f);
-        tokens.hover = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.055f);
-        tokens.text = ColorFromRgb(0xAEB6C2);
-        tokens.number = ColorFromRgb(0x707987);
         tokens.showSelectedBar = false;
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xFBFBFC);
+            tokens.border = ColorFromRgb(0xE2E5E9);
+            tokens.accent = ColorFromRgb(0x5F6B7A);
+            tokens.hover = D2D1::ColorF(31.0f / 255.0f, 41.0f / 255.0f, 55.0f / 255.0f, 0.055f);
+            tokens.text = ColorFromRgb(0x586476);
+            tokens.number = ColorFromRgb(0x8993A1);
+            tokens.rowTextSelected = ColorFromRgb(0x111827);
+            tokens.rowLabelSelected = ColorFromRgb(0x111827);
+            tokens.menuFill = ColorFromRgb(0xFFFFFF);
+            tokens.menuBorder = ColorFromRgb(0xDFE3E8);
+            tokens.menuText = ColorFromRgb(0x374151);
+            tokens.menuHover = ColorFromRgb(0xF1F3F5);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x1C1F23);
+            tokens.border = ColorFromRgb(0x30353B);
+            tokens.accent = ColorFromRgb(0x8993A0);
+            tokens.hover = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.055f);
+            tokens.text = ColorFromRgb(0xAEB6C2);
+            tokens.number = ColorFromRgb(0x707987);
+            tokens.rowTextSelected = ColorFromRgb(0xF1F3F5);
+            tokens.rowLabelSelected = ColorFromRgb(0xF1F3F5);
+            tokens.menuFill = ColorFromRgb(0x23272C);
+            tokens.menuBorder = ColorFromRgb(0x3A4047);
+            tokens.menuText = ColorFromRgb(0xC7CDD5);
+            tokens.menuHover = ColorFromRgb(0x30353B);
+        }
     }
 
     const std::wstring skinsRoot = AssetRoot() + L"\\skins";
@@ -410,7 +500,6 @@ void CandidatePresenter::ApplySkin()
     appearance.fontSize = fontSize;
     appearance.labelFontSize = fontSize * 0.8f;
     appearance.annotationFontSize = fontSize;
-    appearance.cornerRadius = 4.0f;
     appearance.contentPadLeft = 0.0f;
     appearance.contentPadRight = 0.0f;
     appearance.textPadLeft = 5.0f;
@@ -419,16 +508,19 @@ void CandidatePresenter::ApplySkin()
     appearance.selectedBarHeight = fontSize * 0.85f;
     appearance.showSelectedBar = tokens.showSelectedBar;
     appearance.selectedBarColor = tokens.accent;
+    appearance.cornerRadius = tokens.itemRadius;
     appearance.textColor = theme.textPrimary;
     appearance.labelColor = tokens.number;
     appearance.annotationColor = theme.textPrimary;
     appearance.rowFillSelected = tokens.selected;
     appearance.rowFillHover = tokens.hover;
     appearance.rowFillPressed = tokens.selected;
-    impl_->menuFill = candLight ? ColorFromRgb(0xFFFFFF) : ColorFromRgb(0x2D2D2D);
-    impl_->menuBorder = tokens.border;
-    impl_->menuText = theme.textPrimary;
-    impl_->menuHover = tokens.hover;
+    appearance.rowTextSelected = tokens.rowTextSelected;
+    appearance.rowLabelSelected = tokens.rowLabelSelected;
+    impl_->menuFill = tokens.menuFill;
+    impl_->menuBorder = tokens.menuBorder;
+    impl_->menuText = tokens.menuText;
+    impl_->menuHover = tokens.menuHover;
     impl_->list->SetAppearance(appearance);
     impl_->list->SetOrientation(GetConfiguredCandidateWindowLayout() == "horizontal"
                                     ? msimeui::CandidateList::Orientation::Horizontal

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -303,10 +303,16 @@ void CandidatePresenter::ApplySkin()
         return;
     }
     const std::string skinId = GetConfiguredCandidateSkin();
+    // Resolve the effective light/dark mode before the cache check: with
+    // theme_cand = "follow" the raw setting is unchanged when theme_mode or
+    // the Windows theme flips, but the resolved colors are what we render
+    // with, so the resolved mode must participate in the fingerprint.
+    const bool candLight = ResolveConfiguredTheme(GetConfiguredThemeCand()) == "light";
     std::ostringstream fingerprint;
-    fingerprint << skinId << '|' << GetConfiguredThemeCand() << '|' << GetConfiguredCandidateFont() << '|'
-                << GetConfiguredCandidateFontSize() << '|' << GetConfiguredCandidateWindowPreeditFontSize() << '|'
-                << GetConfiguredCandidateWindowLayout() << '|' << GetConfiguredCandidateTextColor();
+    fingerprint << skinId << '|' << GetConfiguredThemeCand() << '|' << (candLight ? 'L' : 'D') << '|'
+                << GetConfiguredCandidateFont() << '|' << GetConfiguredCandidateFontSize() << '|'
+                << GetConfiguredCandidateWindowPreeditFontSize() << '|' << GetConfiguredCandidateWindowLayout() << '|'
+                << GetConfiguredCandidateTextColor();
     fingerprint << '|' << GetConfiguredCandidateEnglishFont();
     for (const auto &font : GetConfiguredCandidateFallbackFonts())
         fingerprint << '|' << font.size() << ':' << font;
@@ -316,8 +322,6 @@ void CandidatePresenter::ApplySkin()
         return;
     }
     lastSkinFingerprint_ = skinKey;
-
-    const bool candLight = ResolveConfiguredTheme(GetConfiguredThemeCand()) == "light";
     CandSkinTokens tokens;
     if (candLight)
     {

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -126,6 +126,15 @@ POINT GetCandidateLayoutCaret()
     return g_candidate_session_anchor;
 }
 
+// WM_SETTINGCHANGE lParam points to "ImmersiveColorSet" when the user flips
+// the Windows app light/dark theme. Only meaningful for the D2D presenters:
+// they own their colors, while WebView2 pages restyle themselves.
+bool IsSystemLightDarkToggle(UINT message, LPARAM lParam)
+{
+    return message == WM_SETTINGCHANGE && lParam != 0 && UseD2dSmallWindowUi() &&
+           lstrcmpiW(reinterpret_cast<LPCWSTR>(lParam), L"ImmersiveColorSet") == 0;
+}
+
 struct SuppressCandidateDpiChange
 {
     SuppressCandidateDpiChange()
@@ -2169,6 +2178,17 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
                        DescribeCandidateHostState());
     }
 
+    if (IsSystemLightDarkToggle(message, lParam))
+    {
+        // A visible candidate window must flip immediately; a hidden one
+        // re-resolves its theme on the next ShowFromGlobalState via the
+        // ApplySkin fingerprint.
+        if (::is_global_wnd_cand_shown && CandidatePresenter::Instance().IsBound())
+        {
+            CandidatePresenter::Instance().ShowFromGlobalState(GetCandidateLayoutCaret());
+        }
+    }
+
     if (message == WM_IMEACTIVATE)
     {
         g_is_ime_active = true;
@@ -3604,6 +3624,13 @@ LRESULT CALLBACK WndProcSettingsWindow(HWND hwnd, UINT message, WPARAM wParam, L
 
 LRESULT CALLBACK WndProcFtbWindow(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+    // The floating toolbar is persistent, so it cannot rely on being re-themed
+    // on the next show (unlike the tray menu, which re-themes on every open).
+    if (IsSystemLightDarkToggle(message, lParam) && FloatingToolbarPresenter::Instance().IsBound())
+    {
+        FloatingToolbarPresenter::Instance().ApplyTheme();
+    }
+
     if (message == WM_NCHITTEST && FloatingToolbarPresenter::Instance().IsBound())
     {
         POINT client{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};

--- a/ui/include/msimeui/Controls.h
+++ b/ui/include/msimeui/Controls.h
@@ -540,6 +540,12 @@ class CandidateList : public Visual
         D2D1_COLOR_F rowFillHover = D2D1::ColorF(0x343434);
         D2D1_COLOR_F rowFillPressed = D2D1::ColorF(0x353535);
         D2D1_COLOR_F rowFillSelected = D2D1::ColorF(0x3E3E3E, 0.725f);
+        // Text/label colors for the selected (and pressed) row. Alpha 0 keeps
+        // the normal textColor/labelColor; skins that fill the selected row
+        // with an opaque accent set these to the contrasting color (e.g. white
+        // on the WeChat green first row).
+        D2D1_COLOR_F rowTextSelected = D2D1::ColorF(0, 0.0f);
+        D2D1_COLOR_F rowLabelSelected = D2D1::ColorF(0, 0.0f);
         D2D1_COLOR_F selectedBarColor = D2D1::ColorF(0x6B69D6);
         D2D1_COLOR_F labelColor = D2D1::ColorF(0xE9E8E8, 0.616f);
         D2D1_COLOR_F textColor = D2D1::ColorF(0xE9E8E8);

--- a/ui/src/Controls.cpp
+++ b/ui/src/Controls.cpp
@@ -2877,8 +2877,14 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.fontFamily = fontFamily;
         }
 
-        ID2D1SolidColorBrush *labelBrush = deviceResources.GetSolidColorBrush(appearance_.labelColor);
-        ID2D1SolidColorBrush *textBrush = deviceResources.GetSolidColorBrush(appearance_.textColor);
+        const bool highlighted = selected || pressed;
+        const D2D1_COLOR_F &labelColor = highlighted && appearance_.rowLabelSelected.a > 0.001f
+                                             ? appearance_.rowLabelSelected
+                                             : appearance_.labelColor;
+        const D2D1_COLOR_F &textColor =
+            highlighted && appearance_.rowTextSelected.a > 0.001f ? appearance_.rowTextSelected : appearance_.textColor;
+        ID2D1SolidColorBrush *labelBrush = deviceResources.GetSolidColorBrush(labelColor);
+        ID2D1SolidColorBrush *textBrush = deviceResources.GetSolidColorBrush(textColor);
         ID2D1SolidColorBrush *annotationBrush = deviceResources.GetSolidColorBrush(appearance_.annotationColor);
         D2D1_COLOR_F translationColor = appearance_.annotationColor;
         translationColor.a *= 0.62f;


### PR DESCRIPTION
## 问题

D2D 模式下（`ui_backend = "d2d"`）主题明暗表现异常：

1. `theme_cand = follow`（默认）时改「主题模式」或系统明暗切换，候选窗停留在首次渲染的主题（多为暗色）——浮动工具栏/托盘菜单正常，唯独候选窗卡死。
2. 非 fluent 皮肤（wechat / willow_green / graphite）在 light 模式下依旧是深色窗口。
3. 选中行、右键菜单、条目圆角、容器留白等样式与 WebView2 渲染存在多处不一致。

## 根因

- **指纹缓存穿透失败**：`CandidatePresenter::ApplySkin()` 的指纹只含 `theme_cand` 原始值，`follow` 之下解析后的明暗结果（依赖 `theme_mode` + 注册表 `AppsUseLightTheme`）不参与缓存判定，且解析发生在 early-return 之后。
- **无系统明暗刷新路径**：`theme_mode = system` 时 D2D 宿主窗口对 `WM_SETTINGCHANGE` 只打日志。
- **配色奇偶差**：`ApplySkin` 里只有 fluent 实现了完整明暗双配色，wechat 只条件了 surface，willow_green/graphite 整块写死暗色。

## 改动

### 实时刷新（8fdb310）

- `candLight` 解析提前并入 ApplySkin 指纹（`'L'/'D'`）。
- 新增 `IsSystemLightDarkToggle`（`WM_SETTINGCHANGE` + `ImmersiveColorSet`，D2D 门控）：候选窗可见即重绘；常驻的浮动工具栏即时 `ApplyTheme`；托盘菜单每次打开已先 `ApplyTheme`，无需接线。

### light 配色 + 样式对齐（63751f0 / efc2dd9 / 5e18ae8）

以 `ui-html/webview2/candwnd/skins/<skin>/*_light.css` 为权威参照：

- wechat / willow_green / graphite 补齐 light 配色（surface/border/text/number/hover/accent 逐项对齐，dark 值逐字节不变）。
- `ui` 库 `CandidateList::Appearance` 新增 `rowTextSelected` / `rowLabelSelected`（alpha 0 哨兵 = 沿用常规色，既有调用方零改动），支持 wechat/willow「accent 底 + 白字」选中行与 graphite 选中行专属文字色。
- 条目圆角（willow 0 / graphite 2）、wechat 容器留白（padding: 2px）、右键菜单底色/边框/文字/hover 逐皮肤对齐。

## 验证

- Server Release 构建 + `MetasequoiaImeServerTests` 278/278 通过；`scripts/format.sh` 干净。
- 本机 light 安装包（TSF x64/x86 + Server + 设置页）真机验证：`theme_mode` 三态切换、系统深浅切换实时刷新、各皮肤 light/dark 均正确。
- WebView2 路径逻辑未动，无回归面。

## 风险与回滚

- 纯 server/ui 渲染层行为修正，无配置、IPC、契约变更；回滚 revert 各 commit 即可。
- 已知差异保持不变：D2D 无 CSS 阴影/边框发光；fluent 无彩条时选中行底色为半透明填充。