### PR TITLE
fix(windows): 修复 Word 中 Shift 切换中英文失效

### DIFF
--- a/installer/msime_setup.iss
+++ b/installer/msime_setup.iss
@@ -361,9 +361,11 @@ var
   AppDataPath: String;
   ResultCode: Integer;
 begin
-  { Elevated setup writes {localappdata} as high integrity. Medium-IL Server
-    and Settings cannot replace those files. Users who never rewrote config.toml
-    at the real path (the non-ASCII path bug) keep that leftover and cannot save. }
+  // Elevated setup writes {localappdata} as high integrity. Medium-IL Server
+  // and Settings cannot replace those files. Users who never rewrote config.toml
+  // at the real path (the non-ASCII path bug) keep that leftover and cannot save.
+  // Note: brace comments do not nest in Inno Setup, so a constant like the one
+  // above would close a { } comment early -- keep these as line comments.
   AppDataPath := ExpandConstant('{localappdata}\metasequoiaime');
   ForceDirectories(AppDataPath);
   Exec(

--- a/windows/src/IME/MetasequoiaIME.cpp
+++ b/windows/src/IME/MetasequoiaIME.cpp
@@ -459,16 +459,16 @@ CMetasequoiaIME::CMetasequoiaIME()
     _shiftHotkeyArmed = false;
     _ctrlHotkeyArmed = false;
     _modifierHotkeyExpire = {};
-    _minttyKeyboardHook = nullptr;
-    _minttyShiftDownMask = 0;
-    _minttyShiftArmed = false;
-    _minttyShiftSequence = 0;
-    _minttyShiftHandledSequence = 0;
-    _minttyShiftFocusGeneration = 0;
-    _minttyShiftExpireTick = 0;
+    _bareShiftHook = nullptr;
+    _bareShiftDownMask = 0;
+    _bareShiftArmed = false;
+    _bareShiftSequence = 0;
+    _bareShiftHandledSequence = 0;
+    _bareShiftFocusGeneration = 0;
+    _bareShiftExpireTick = 0;
 }
 
-thread_local CMetasequoiaIME *CMetasequoiaIME::_minttyKeyboardHookOwner = nullptr;
+thread_local CMetasequoiaIME *CMetasequoiaIME::_bareShiftHookOwner = nullptr;
 
 //+---------------------------------------------------------------------------
 //
@@ -478,7 +478,7 @@ thread_local CMetasequoiaIME *CMetasequoiaIME::_minttyKeyboardHookOwner = nullpt
 
 CMetasequoiaIME::~CMetasequoiaIME()
 {
-    _UninitMinttyKeyboardHook();
+    _UninitBareShiftKeyboardHook();
     _ClearDeferredKeyDowns();
     // Deactivate normally owns the unbind.  Keep this owner-aware fallback for
     // partial activation failures without allowing a delayed old service
@@ -1423,7 +1423,7 @@ STDAPI CMetasequoiaIME::ActivateEx(ITfThreadMgr *pThreadMgr, TfClientId tfClient
 
     // Apply configured default CN/EN whenever switching back to this IME
     _pCompositionProcessorEngine->InitializeMetasequoiaIMECompartment(pThreadMgr, tfClientId);
-    _InitMinttyKeyboardHook();
+    _InitBareShiftKeyboardHook();
 
     // The first connect timer can run before the engine exists. Re-arm after
     // compartment initialization so an already-focused activation always
@@ -1452,7 +1452,7 @@ ExitError:
 
 STDAPI CMetasequoiaIME::Deactivate()
 {
-    _UninitMinttyKeyboardHook();
+    _UninitBareShiftKeyboardHook();
     Global::HostUiLessMode = false;
     Global::CandidateUiLessMode = false;
     // Send this synchronously before destroying the message window. OnKill can
@@ -2158,8 +2158,8 @@ LRESULT CALLBACK CMetasequoiaIME_WindowProc(HWND hWnd, UINT message, WPARAM wPar
 
     switch (message)
     {
-    case WM_MinttyShiftRelease:
-        pIME->_HandleMinttyShiftRelease(static_cast<UINT>(wParam));
+    case WM_BareShiftRelease:
+        pIME->_HandleHookedBareShiftRelease(static_cast<UINT>(wParam));
         return 0;
 
     case WM_CheckGlobalCompartment: {

--- a/windows/src/IME/MetasequoiaIME.h
+++ b/windows/src/IME/MetasequoiaIME.h
@@ -39,7 +39,7 @@ const DWORD WM_InsertText = WM_USER + 19;
 const DWORD WM_RefreshLanguageBarTheme = WM_USER + 20;
 const DWORD WM_PairedPunctuationMoveLeft = WM_USER + 21;
 const DWORD WM_ReplaceRepeatedSmartPunctuation = WM_USER + 22;
-const DWORD WM_MinttyShiftRelease = WM_USER + 23;
+const DWORD WM_BareShiftRelease = WM_USER + 23;
 const DWORD WM_UpdateVoiceComposition = WM_USER + 24;
 const DWORD WM_CommitVoiceComposition = WM_USER + 25;
 const DWORD WM_CancelVoiceComposition = WM_USER + 26;
@@ -375,16 +375,21 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
     bool _MatchModifierReleaseHotkey(WPARAM wParam, _Out_ GUID *hotkeyGuid);
     bool _QueueInputHotkey(_In_ ITfContext *pContext, REFGUID hotkeyGuid, _Out_ BOOL *pIsEaten);
 
-    // mintty exposes IME composition through the legacy IMM bridge, but some
-    // versions do not forward bare modifier key-up events to ITfKeyEventSink.
-    // Observe only this host thread and feed a missed bare-Shift release back
-    // into the normal deferred hotkey path.
-    void _InitMinttyKeyboardHook();
-    void _UninitMinttyKeyboardHook();
-    void _HandleMinttyShiftRelease(UINT sequence);
-    void _MarkMinttyShiftHandled();
-    static LRESULT CALLBACK _MinttyKeyboardHookProc(int code, WPARAM wParam, LPARAM lParam);
-    static thread_local CMetasequoiaIME *_minttyKeyboardHookOwner;
+    // Not every host completes a bare-Shift release through ITfKeyEventSink:
+    // mintty routes composition over the legacy IMM bridge and drops bare
+    // modifier key-ups, and Word does not deliver them either. Since the
+    // release must be reported uneaten (JetBrains double-Shift depends on
+    // seeing it), OnTestKeyUp cannot rely on a follow-up OnKeyUp. Observe only
+    // this host thread and feed a missed bare-Shift release back into the
+    // normal deferred hotkey path. _MarkBareShiftHandled() latches the presses
+    // the key-event sink already toggled, so hosts that do deliver the release
+    // never toggle twice.
+    void _InitBareShiftKeyboardHook();
+    void _UninitBareShiftKeyboardHook();
+    void _HandleHookedBareShiftRelease(UINT sequence);
+    void _MarkBareShiftHandled();
+    static LRESULT CALLBACK _BareShiftKeyboardHookProc(int code, WPARAM wParam, LPARAM lParam);
+    static thread_local CMetasequoiaIME *_bareShiftHookOwner;
 
     void _StartComposition(_In_ ITfContext *pContext);
     HRESULT _EndComposition(_In_opt_ ITfContext *pContext, _In_opt_ ITfComposition *expectedComposition = nullptr,
@@ -592,13 +597,13 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
     bool _ctrlHotkeyArmed;
     std::chrono::steady_clock::time_point _modifierHotkeyExpire;
 
-    HHOOK _minttyKeyboardHook;
-    BYTE _minttyShiftDownMask;
-    bool _minttyShiftArmed;
-    UINT _minttyShiftSequence;
-    UINT _minttyShiftHandledSequence;
-    uint64_t _minttyShiftFocusGeneration;
-    ULONGLONG _minttyShiftExpireTick;
+    HHOOK _bareShiftHook;
+    BYTE _bareShiftDownMask;
+    bool _bareShiftArmed;
+    UINT _bareShiftSequence;
+    UINT _bareShiftHandledSequence;
+    uint64_t _bareShiftFocusGeneration;
+    ULONGLONG _bareShiftExpireTick;
 
     LONG _refCount;
 

--- a/windows/src/IME/MetasequoiaIME.h
+++ b/windows/src/IME/MetasequoiaIME.h
@@ -375,15 +375,15 @@ class CMetasequoiaIME : public ITfTextInputProcessorEx,
     bool _MatchModifierReleaseHotkey(WPARAM wParam, _Out_ GUID *hotkeyGuid);
     bool _QueueInputHotkey(_In_ ITfContext *pContext, REFGUID hotkeyGuid, _Out_ BOOL *pIsEaten);
 
-    // Not every host completes a bare-Shift release through ITfKeyEventSink:
-    // mintty routes composition over the legacy IMM bridge and drops bare
-    // modifier key-ups, and Word does not deliver them either. Since the
-    // release must be reported uneaten (JetBrains double-Shift depends on
-    // seeing it), OnTestKeyUp cannot rely on a follow-up OnKeyUp. Observe only
-    // this host thread and feed a missed bare-Shift release back into the
-    // normal deferred hotkey path. _MarkBareShiftHandled() latches the presses
-    // the key-event sink already toggled, so hosts that do deliver the release
-    // never toggle twice.
+    // mintty routes composition over the legacy IMM bridge and never offers a
+    // bare modifier key-up to ITfKeyEventSink, so there is no sink event to
+    // hang the toggle on. Observe only this host thread and feed the missed
+    // bare-Shift release back into the normal deferred hotkey path.
+    // _MarkBareShiftHandled() latches the presses the key-event sink already
+    // toggled, so a host that does deliver the release never toggles twice.
+    // Keep this mintty-only: hosts whose problem is a stale GetKeyState()
+    // rather than a missing callback are handled in the sink, and windows/
+    // AGENTS.md asks that hooks in the injected DLL stay the exception.
     void _InitBareShiftKeyboardHook();
     void _UninitBareShiftKeyboardHook();
     void _HandleHookedBareShiftRelease(UINT sequence);

--- a/windows/src/Key/KeyEventSink.cpp
+++ b/windows/src/Key/KeyEventSink.cpp
@@ -270,6 +270,29 @@ bool IsOtherKeyboardKeyDown()
     return false;
 }
 
+// Global::IsShiftKeyDownOnly and friends are derived from GetKeyState(), which
+// reports the modifier state as of the message the calling thread last pulled
+// from its queue.  Hosts that call into ITfKeystrokeMgr outside that dispatch
+// -- Word is the known offender -- can therefore hand us a Shift event whose
+// GetKeyState() snapshot still describes the previous keystroke.  Bare-modifier
+// arming must not depend on that; GetAsyncKeyState() reads the real keyboard.
+bool IsOnlyModifierPhysicallyDown(UINT keptDownVk)
+{
+    static const UINT kModifiers[] = {VK_CONTROL, VK_MENU, VK_SHIFT, VK_LWIN, VK_RWIN};
+    for (const UINT modifier : kModifiers)
+    {
+        if (modifier == keptDownVk)
+        {
+            continue;
+        }
+        if ((GetAsyncKeyState(modifier) & 0x8000) != 0)
+        {
+            return false;
+        }
+    }
+    return (GetAsyncKeyState(keptDownVk) & 0x8000) != 0;
+}
+
 void ClearReleasedShiftModifierState()
 {
     if ((GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0)
@@ -286,7 +309,15 @@ void ClearReleasedShiftModifierState()
 
 void CMetasequoiaIME::_InitBareShiftKeyboardHook()
 {
-    if (_bareShiftHook != nullptr || _bareShiftHookOwner != nullptr)
+    // Restricted to mintty on purpose.  mintty routes composition over the
+    // legacy IMM bridge and never offers a bare modifier key-up to
+    // ITfKeyEventSink at all, so there is no sink event to work with.  Hosts
+    // that merely report a stale GetKeyState() alongside the release (Word) are
+    // handled in the sink instead -- see _MatchModifierReleaseHotkey.  Neither
+    // Weasel nor WindInput installs a keyboard hook for this, and windows/
+    // AGENTS.md asks that hooks in the injected DLL stay the exception.
+    if (_bareShiftHook != nullptr || _bareShiftHookOwner != nullptr ||
+        CompareStringOrdinal(Global::current_process_name.c_str(), -1, L"mintty.exe", -1, TRUE) != CSTR_EQUAL)
     {
         return;
     }
@@ -456,14 +487,14 @@ void CMetasequoiaIME::_TrackModifierHotkeyArming(WPARAM wParam, LPARAM lParam, b
     }
 
     const auto now = std::chrono::steady_clock::now();
-    if (isShift && Global::IsShiftKeyDownOnly)
+    if (isShift && IsOnlyModifierPhysicallyDown(VK_SHIFT))
     {
         _shiftHotkeyArmed = true;
         _ctrlHotkeyArmed = false;
         _modifierHotkeyExpire = now + kModifierHotkeyToggleLimit;
         return;
     }
-    if (isCtrl && Global::IsControlKeyDownOnly)
+    if (isCtrl && IsOnlyModifierPhysicallyDown(VK_CONTROL))
     {
         _ctrlHotkeyArmed = true;
         _shiftHotkeyArmed = false;
@@ -517,7 +548,12 @@ bool CMetasequoiaIME::_MatchModifierReleaseHotkey(WPARAM wParam, _Out_ GUID *hot
     const auto now = std::chrono::steady_clock::now();
     const auto hotkeys = FanyUtils::ReadConfiguredSwitchLanguageHotkeys();
 
-    if (IsShiftVk(code) && _shiftHotkeyArmed && Global::PureShiftKeyUp)
+    // _shiftHotkeyArmed already encodes "this Shift went down alone and nothing
+    // else has been pressed since" -- _TrackModifierHotkeyArming disarms on any
+    // other key-down.  Matching on the released virtual key plus that latch is
+    // enough, and unlike Global::PureShiftKeyUp it does not require the host's
+    // GetKeyState() snapshot to have caught up with the release.
+    if (IsShiftVk(code) && _shiftHotkeyArmed)
     {
         const bool fire = now < _modifierHotkeyExpire && hotkeys.shift;
         _shiftHotkeyArmed = false;
@@ -530,7 +566,7 @@ bool CMetasequoiaIME::_MatchModifierReleaseHotkey(WPARAM wParam, _Out_ GUID *hot
         return false;
     }
 
-    if (IsControlVk(code) && _ctrlHotkeyArmed && Global::IsControlKeyDownOnly)
+    if (IsControlVk(code) && _ctrlHotkeyArmed)
     {
         const bool fire = now < _modifierHotkeyExpire && hotkeys.ctrl;
         _shiftHotkeyArmed = false;
@@ -2315,8 +2351,10 @@ STDAPI CMetasequoiaIME::OnTestKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM 
     {
         // TSF does not call OnKeyUp after a FALSE test result. Claim and
         // queue the bare-Shift toggle here while leaving its release visible.
-        // Hosts that never route the release here (Word, mintty) fall back to
-        // the bare-Shift keyboard hook, which _MarkBareShiftHandled() disarms.
+        // Whichever of TestKeyUp/KeyUp a host offers first wins;
+        // _MatchModifierReleaseHotkey disarms so the other one is a no-op.
+        // mintty offers neither and falls back to the keyboard hook, which
+        // _MarkBareShiftHandled() disarms.
         GUID hotkeyGuid = {};
         BOOL queued = FALSE;
         const bool toggled =

--- a/windows/src/Key/KeyEventSink.cpp
+++ b/windows/src/Key/KeyEventSink.cpp
@@ -284,44 +284,43 @@ void ClearReleasedShiftModifierState()
 }
 } // namespace
 
-void CMetasequoiaIME::_InitMinttyKeyboardHook()
+void CMetasequoiaIME::_InitBareShiftKeyboardHook()
 {
-    if (_minttyKeyboardHook != nullptr || _minttyKeyboardHookOwner != nullptr ||
-        CompareStringOrdinal(Global::current_process_name.c_str(), -1, L"mintty.exe", -1, TRUE) != CSTR_EQUAL)
+    if (_bareShiftHook != nullptr || _bareShiftHookOwner != nullptr)
     {
         return;
     }
 
-    _minttyKeyboardHookOwner = this;
-    _minttyKeyboardHook = SetWindowsHookExW(WH_KEYBOARD, _MinttyKeyboardHookProc, nullptr, GetCurrentThreadId());
-    if (_minttyKeyboardHook == nullptr)
+    _bareShiftHookOwner = this;
+    _bareShiftHook = SetWindowsHookExW(WH_KEYBOARD, _BareShiftKeyboardHookProc, nullptr, GetCurrentThreadId());
+    if (_bareShiftHook == nullptr)
     {
-        _minttyKeyboardHookOwner = nullptr;
+        _bareShiftHookOwner = nullptr;
     }
 }
 
-void CMetasequoiaIME::_UninitMinttyKeyboardHook()
+void CMetasequoiaIME::_UninitBareShiftKeyboardHook()
 {
-    HHOOK hook = _minttyKeyboardHook;
-    _minttyKeyboardHook = nullptr;
-    if (_minttyKeyboardHookOwner == this)
+    HHOOK hook = _bareShiftHook;
+    _bareShiftHook = nullptr;
+    if (_bareShiftHookOwner == this)
     {
-        _minttyKeyboardHookOwner = nullptr;
+        _bareShiftHookOwner = nullptr;
     }
     if (hook != nullptr)
     {
         UnhookWindowsHookEx(hook);
     }
 
-    _minttyShiftDownMask = 0;
-    _minttyShiftArmed = false;
-    _minttyShiftFocusGeneration = 0;
-    _minttyShiftExpireTick = 0;
+    _bareShiftDownMask = 0;
+    _bareShiftArmed = false;
+    _bareShiftFocusGeneration = 0;
+    _bareShiftExpireTick = 0;
 }
 
-LRESULT CALLBACK CMetasequoiaIME::_MinttyKeyboardHookProc(int code, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK CMetasequoiaIME::_BareShiftKeyboardHookProc(int code, WPARAM wParam, LPARAM lParam)
 {
-    CMetasequoiaIME *owner = _minttyKeyboardHookOwner;
+    CMetasequoiaIME *owner = _bareShiftHookOwner;
     if (code == HC_ACTION && owner != nullptr &&
         static_cast<ULONG_PTR>(GetMessageExtraInfo()) != SMART_PUNCTUATION_SENDINPUT_EXTRA_INFO)
     {
@@ -338,57 +337,56 @@ LRESULT CALLBACK CMetasequoiaIME::_MinttyKeyboardHookProc(int code, WPARAM wPara
             {
                 if (!wasDown)
                 {
-                    if (owner->_minttyShiftDownMask == 0)
+                    if (owner->_bareShiftDownMask == 0)
                     {
-                        owner->_minttyShiftArmed = !IsOtherKeyboardKeyDown();
-                        ++owner->_minttyShiftSequence;
-                        if (owner->_minttyShiftSequence == 0)
+                        owner->_bareShiftArmed = !IsOtherKeyboardKeyDown();
+                        ++owner->_bareShiftSequence;
+                        if (owner->_bareShiftSequence == 0)
                         {
-                            ++owner->_minttyShiftSequence;
+                            ++owner->_bareShiftSequence;
                         }
-                        owner->_minttyShiftFocusGeneration = owner->_deferredKeyFocusGeneration;
-                        owner->_minttyShiftExpireTick =
+                        owner->_bareShiftFocusGeneration = owner->_deferredKeyFocusGeneration;
+                        owner->_bareShiftExpireTick =
                             GetTickCount64() + static_cast<ULONGLONG>(kModifierHotkeyToggleLimit.count());
                     }
-                    owner->_minttyShiftDownMask |= shiftBit;
+                    owner->_bareShiftDownMask |= shiftBit;
                 }
             }
             else
             {
-                owner->_minttyShiftDownMask &= static_cast<BYTE>(~shiftBit);
-                if (owner->_minttyShiftDownMask == 0)
+                owner->_bareShiftDownMask &= static_cast<BYTE>(~shiftBit);
+                if (owner->_bareShiftDownMask == 0)
                 {
-                    const bool shouldPost =
-                        owner->_minttyShiftArmed && GetTickCount64() < owner->_minttyShiftExpireTick;
-                    owner->_minttyShiftArmed = false;
+                    const bool shouldPost = owner->_bareShiftArmed && GetTickCount64() < owner->_bareShiftExpireTick;
+                    owner->_bareShiftArmed = false;
                     if (shouldPost && owner->_msgWndHandle != nullptr)
                     {
-                        PostMessage(owner->_msgWndHandle, WM_MinttyShiftRelease, owner->_minttyShiftSequence, 0);
+                        PostMessage(owner->_msgWndHandle, WM_BareShiftRelease, owner->_bareShiftSequence, 0);
                     }
                 }
             }
         }
         else if (!isKeyUp)
         {
-            owner->_minttyShiftArmed = false;
+            owner->_bareShiftArmed = false;
         }
     }
 
-    return CallNextHookEx(owner ? owner->_minttyKeyboardHook : nullptr, code, wParam, lParam);
+    return CallNextHookEx(owner ? owner->_bareShiftHook : nullptr, code, wParam, lParam);
 }
 
-void CMetasequoiaIME::_MarkMinttyShiftHandled()
+void CMetasequoiaIME::_MarkBareShiftHandled()
 {
-    if (_minttyKeyboardHook != nullptr)
+    if (_bareShiftHook != nullptr)
     {
-        _minttyShiftHandledSequence = _minttyShiftSequence;
+        _bareShiftHandledSequence = _bareShiftSequence;
     }
 }
 
-void CMetasequoiaIME::_HandleMinttyShiftRelease(UINT sequence)
+void CMetasequoiaIME::_HandleHookedBareShiftRelease(UINT sequence)
 {
-    if (_minttyKeyboardHook == nullptr || sequence == 0 || sequence != _minttyShiftSequence ||
-        sequence == _minttyShiftHandledSequence || _minttyShiftFocusGeneration != _deferredKeyFocusGeneration ||
+    if (_bareShiftHook == nullptr || sequence == 0 || sequence != _bareShiftSequence ||
+        sequence == _bareShiftHandledSequence || _bareShiftFocusGeneration != _deferredKeyFocusGeneration ||
         !Global::g_connected || _pThreadMgr == nullptr || _pCompositionProcessorEngine == nullptr ||
         (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0 || !FanyUtils::ReadConfiguredSwitchLanguageHotkeys().shift)
     {
@@ -415,9 +413,13 @@ void CMetasequoiaIME::_HandleMinttyShiftRelease(UINT sequence)
     }
 
     BOOL eaten = FALSE;
-    if (_QueueInputHotkey(context, Global::MetasequoiaIMEGuidImeModePreserveKey, &eaten))
+    const bool queued = _QueueInputHotkey(context, Global::MetasequoiaIMEGuidImeModePreserveKey, &eaten);
+    DebugTsfIssue47(L"bare-shift-hook-release", FANY_IME_NO_REQUEST_ID, VK_SHIFT, L'\0', 0, 0, queued ? 1 : 0,
+                    _IsComposing(),
+                    _pCompositionProcessorEngine ? _pCompositionProcessorEngine->GetVirtualKeyLength() : 0, S_OK);
+    if (queued)
     {
-        _minttyShiftHandledSequence = sequence;
+        _bareShiftHandledSequence = sequence;
         _shiftHotkeyArmed = false;
         _ctrlHotkeyArmed = false;
         Global::IsShiftKeyDownOnly = FALSE;
@@ -2313,12 +2315,19 @@ STDAPI CMetasequoiaIME::OnTestKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM 
     {
         // TSF does not call OnKeyUp after a FALSE test result. Claim and
         // queue the bare-Shift toggle here while leaving its release visible.
+        // Hosts that never route the release here (Word, mintty) fall back to
+        // the bare-Shift keyboard hook, which _MarkBareShiftHandled() disarms.
         GUID hotkeyGuid = {};
         BOOL queued = FALSE;
-        if (_MatchModifierReleaseHotkey(wParam, &hotkeyGuid) && _QueueInputHotkey(pContext, hotkeyGuid, &queued))
+        const bool toggled =
+            _MatchModifierReleaseHotkey(wParam, &hotkeyGuid) && _QueueInputHotkey(pContext, hotkeyGuid, &queued);
+        if (toggled)
         {
-            _MarkMinttyShiftHandled();
+            _MarkBareShiftHandled();
         }
+        DebugTsfIssue47(L"bare-shift-testkeyup", FANY_IME_NO_REQUEST_ID, LOWORD(wParam), L'\0', 0, 0, toggled ? 1 : 0,
+                        _IsComposing(),
+                        _pCompositionProcessorEngine ? _pCompositionProcessorEngine->GetVirtualKeyLength() : 0, S_OK);
         ClearReleasedShiftModifierState();
         *pIsEaten = FALSE;
         return S_OK;
@@ -2384,10 +2393,15 @@ STDAPI CMetasequoiaIME::OnKeyUp(ITfContext *pContext, WPARAM wParam, LPARAM lPar
         // Defend against hosts that offer KeyUp without a preceding test.
         GUID hotkeyGuid = {};
         BOOL queued = FALSE;
-        if (_MatchModifierReleaseHotkey(wParam, &hotkeyGuid) && _QueueInputHotkey(pContext, hotkeyGuid, &queued))
+        const bool toggled =
+            _MatchModifierReleaseHotkey(wParam, &hotkeyGuid) && _QueueInputHotkey(pContext, hotkeyGuid, &queued);
+        if (toggled)
         {
-            _MarkMinttyShiftHandled();
+            _MarkBareShiftHandled();
         }
+        DebugTsfIssue47(L"bare-shift-keyup", FANY_IME_NO_REQUEST_ID, LOWORD(wParam), L'\0', 0, 0, toggled ? 1 : 0,
+                        _IsComposing(),
+                        _pCompositionProcessorEngine ? _pCompositionProcessorEngine->GetVirtualKeyLength() : 0, S_OK);
         ClearReleasedShiftModifierState();
         *pIsEaten = FALSE;
         return S_OK;


### PR DESCRIPTION
## 问题

Word 里用 Shift 切换中英文失效，回归自 #? `70930df`（修复 JetBrains 双 Shift）。那次改动为了让 IDEA 能看到 Shift 抬起而不再吃掉它，切换动作被内联进 `OnTestKeyUp`。

对照小狼毫（WeaselTSF）和清风（wind_tsf）的实现后确认，**Word 其实把 Shift 抬起送进 sink 了**；它没送到的是一份新鲜的 `GetKeyState()` 快照。`GetKeyState()` 返回的是「本线程最后一次从消息队列取出的消息」对应的修饰键状态；宿主若不是直接在消息派发里调 `ITfKeystrokeMgr`，抬起回调里读到的可能还是上一个按键的状态。于是 `Global::PureShiftKeyUp`（`Globals.cpp` 里每次调用开头重置为 FALSE，只在 `case VK_SHIFT` 的 `GetKeyState` 为已松开时才置 TRUE）为假，`_MatchModifierReleaseHotkey` 静默不匹配 —— `OnTestKeyUp` / `OnKeyUp` 其实都跑了，只是判定失败。

WeaselTSF `KeyEventSink.cpp` 里有一段注释直接点名 Word 的回调时序不规矩：*"Some sends multiple OnTestKeyDown() for a single key event. (MS WORD 2010 x64)"*。

## 改动

`fix(windows): match bare-Shift release on the arming latch, not GetKeyState`

- `_MatchModifierReleaseHotkey`：去掉 `Global::PureShiftKeyUp` / `IsControlKeyDownOnly` 判定，改为只看「抬起的 vk + `_shiftHotkeyArmed` 闩锁 + 500ms 窗口」。闩锁本身已经表达了「这次 Shift 单独按下、之后没按过别的键」（`_TrackModifierHotkeyArming` 遇到任何其它按键 down 就解除），且匹配成功即自清，所以 TestKeyUp/KeyUp 都到也不会切两次。这与清风的 `_DispatchPendingToggleKeyUp` 是同一个模型。
- `_TrackModifierHotkeyArming`：arm 条件改用 `GetAsyncKeyState`（读真实键盘状态，不受宿主线程消息队列滞后影响）判断「只有该修饰键被按住」。
- 保留 Shift/Ctrl 抬起 `*pIsEaten = FALSE`，JetBrains 双 Shift / 双 Ctrl 行为不变。

`fix(installer): unbreak ISCC compile of EnsureImeUserDataDir comment`

develop 上 `msime_setup.iss` 目前编译不过。Inno Setup 的 `{ }` 注释不能嵌套，注释里的 `{localappdata}` 提前闭合了注释，后半句被当成代码：

```
Error on line 364 ... Column 42: Identifier expected.
Compile aborted.
```

改成 `//` 行注释，并加一行说明避免再踩。

## 关于键盘钩子

初版提交 `0838681` 把原本 mintty 专用的 `WH_KEYBOARD` 线程钩子放开给所有宿主。核对参考实现后撤回了 —— **小狼毫和清风都没有为这个功能装键盘钩子**，`windows/AGENTS.md` 也要求注入型 DLL 里的 hook 保持例外。钩子仍保留给 mintty：那是另一种故障，mintty 走 IMM 桥，根本不把裸修饰键抬起交给 sink，没有事件可匹配。

另外顺带说明：本地曾有一个走 `OnPreservedKey` 的修法，那条路是死的 —— 自 `a4ecf47` 起 `SetupPreserved` 不再调用 `InitPreservedKey`，TSF 从未注册 Shift 的 PreserveKey，该回调永不触发。（小狼毫也把同样的 `PreserveKey(VK_SHIFT, TF_MOD_ON_KEYUP)` 用 `#if 0` 关掉了。）

## 新增日志

key-up 路径此前完全没有埋点，导致诊断日志无法区分「抬起没到达」和「到达但判定失败」。本 PR 加了三个 `[issue47]` stage：`bare-shift-testkeyup`、`bare-shift-keyup`、`bare-shift-hook-release`。

## 验证

- [x] x64 Release 构建 `MetasequoiaImeTsf.dll` 通过，仅既有警告；已 clang-format
- [x] `Compile-Installer.ps1` 编译通过
- [x] **已实测**：Word 中 Shift 切换；回归 JetBrains 双 Shift、mintty、Ctrl 单击切换
