### PR TITLE
perf(ci): cache the Server MSVC build with sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,11 @@ jobs:
     needs: lock
     runs-on: windows-2025
     timeout-minutes: 90
+    # sccache caches individual MSVC compiles across runs so an incremental change recompiles only
+    # what it touched instead of the whole server + engine tree. It needs SCCACHE_GHA_ENABLED for
+    # every step that shells out to the compiler (configure probes it too, not just build).
+    env:
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Check out source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -147,6 +152,12 @@ jobs:
         uses: ./.github/actions/vcpkg-cache
         with:
           scope: server-x64-windows-and-static-md
+      # The Visual Studio generator finds MSVC on its own; Ninja does not, so put cl.exe on PATH
+      # before configuring. Defaults to the x64 host/target, matching the build below.
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install Boost
         shell: pwsh
         run: ./scripts/ci/install-boost.ps1
@@ -157,12 +168,19 @@ jobs:
           path: ${{ steps.vcpkg-cache.outputs.path }}
           key: ${{ steps.vcpkg-cache.outputs.key }}-boost
       # 刻意不叫 build：CMakeLists.txt 曾经写死 ${CMAKE_SOURCE_DIR}/build/vcpkg_installed，换任何别的名字都会链接失败。构建到别处才能保证这条不会悄悄退回去。
+      #
+      # Ninja Multi-Config instead of the Visual Studio generator: sccache plugs in through
+      # CMAKE_<LANG>_COMPILER_LAUNCHER, which CMake honours only for the Ninja and Makefile
+      # generators. "Multi-Config" keeps the --config Release / bin/Release layout the later steps
+      # (check-server-binaries.ps1, ctest -C Release) already depend on.
       - name: Configure
         shell: pwsh
         run: >
-          cmake -S server -B server/build-release -A x64
+          cmake -S server -B server/build-release -G "Ninja Multi-Config"
           -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
           -DVCPKG_TARGET_TRIPLET=x64-windows
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
       - name: Save dependency binaries before compiling
         if: steps.vcpkg-cache.outputs.matched-key != format('{0}-complete', steps.vcpkg-cache.outputs.key)
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -172,6 +190,10 @@ jobs:
       - name: Build
         shell: pwsh
         run: cmake --build server/build-release --config Release --parallel
+      - name: Report sccache hit rate
+        if: always()
+        shell: pwsh
+        run: sccache --show-stats
       - name: Check the Release binaries and symbols
         shell: pwsh
         run: ./scripts/ci/check-server-binaries.ps1 -BuildDir server/build-release/bin/Release

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,9 +10,15 @@ project(${PROJECT_NAME} VERSION 1.0)
 
 # Release binaries need usable symbols for crash diagnosis. Keep the PDB beside each executable so
 # the release job can validate and publish it without changing the binary's install layout.
+#
+# The debug info is embedded in each object (/Z7) rather than written to a compile-time PDB (/Zi).
+# The two produce the same final .pdb once the linker's /DEBUG runs over them, but sccache -- the CI
+# compiler cache -- can only cache an MSVC compile whose debug info lives in the object. With /Zi it
+# treats every translation unit as uncacheable and the cache sits at a 0% hit rate. /Z7 keeps the
+# beside-the-executable PDB the release job expects while letting that cache actually work.
 if(MSVC)
-    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "ProgramDatabase")
-    add_compile_options("$<$<CONFIG:Release>:/Zi>")
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "Embedded")
+    add_compile_options("$<$<CONFIG:Release>:/Z7>")
     add_link_options("$<$<CONFIG:Release>:/DEBUG>")
 endif()
 


### PR DESCRIPTION
## 背景

流水线的长板是 **Server** job（上次成功运行 ~9m27s，是唯一超过 4 分钟的 job）。分步耗时：

| 步骤 | 耗时 |
|---|---|
| Checkout（recursive 子模块） | 29s |
| Restore deps / Install Boost | ~30s |
| Configure | 59s |
| **Build（编译 server + engine）** | **6m37s** |
| Test with the product's exact data（词库集成测试） | 43s |

瓶颈是编译，不是词库测试。本 PR 给 Server 的 MSVC 编译接入 **sccache**，让增量改动只重编受影响的翻译单元，而不是整棵 server + engine 树。

## 改动

- **`.github/workflows/ci.yml`（仅 Server job）**
  - 接入 `mozilla-actions/sccache-action`，设 `SCCACHE_GHA_ENABLED=true`（configure 也会探测编译器，故放在 job env）。
  - Configure 从 Visual Studio 生成器切到 **Ninja Multi-Config**——sccache 的 `CMAKE_<LANG>_COMPILER_LAUNCHER` 只被 Ninja/Makefile 生成器识别。用 Multi-Config 是为了保留 `--config Release` / `bin/Release` 布局，`check-server-binaries.ps1` 和 `ctest -C Release` 不用改。
  - 加一步 `ilammy/msvc-dev-cmd` 设置 MSVC 环境，因为 Ninja 不像 VS 生成器会自动找到 `cl.exe`。
  - Build 后加 `sccache --show-stats`，方便直接从日志看命中率。
- **`server/CMakeLists.txt`**：Release 调试信息从 `/Zi` 改为 `/Z7`。sccache 只缓存调试信息**嵌入 obj**的 MSVC 编译；用 `/Zi`（独立 PDB）会被判为不可缓存，命中率为 0。链接期 `/DEBUG` 仍生成 exe 旁边的 `.pdb`，release job 的符号校验不受影响。
  - ⚠️ 这会影响**所有人的本地 Release 构建**的调试信息格式（`/Z7` 而非 `/Zi`），最终 PDB 等价，但 obj 会稍大。

## 验证

首次运行是冷缓存（会写入），提速要看**第二次及之后**的运行。合并后可从 `Report sccache hit rate` 步骤观察命中率与 Build 耗时下降。

第三方 action 均按仓库惯例 pin 到 commit SHA。
