### PR TITLE
fix(windows): commit highlighted candidates with numpad punctuation

### DIFF
--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -707,11 +707,14 @@ bool IsCommitWithHighlightedCandidatePunctuationInCandidateMode(UINT keycode, WC
         L'^',  //
         L'&',  //
         L'*',  //
+        L'-',  // Numpad arithmetic keys are not candidate paging keys.
+        L'+',  //
         L'(',  //
         L')',  //
         L'[',  //
         L']',  //
         L'\\', //
+        L'/',  //
         L';',  //
         L':',  //
         L'\'', //

--- a/windows/src/Composition/CompositionProcessorEngine.cpp
+++ b/windows/src/Composition/CompositionProcessorEngine.cpp
@@ -585,8 +585,6 @@ bool IsCommitWithHighlightedCandidatePunctuationInCandidateMode(UINT uCode, WCHA
     case VK_NEXT:
     case VK_OEM_MINUS:
     case VK_OEM_PLUS:
-    case VK_SUBTRACT:
-    case VK_ADD:
     case VK_HOME:
     case VK_END:
     case VK_TAB:

--- a/windows/src/Global/Globals.cpp
+++ b/windows/src/Global/Globals.cpp
@@ -298,6 +298,7 @@ extern const std::unordered_set<WCHAR> CommitWithHighlightedCandPunc = {
     L'[',  //
     L']',  //
     L'\\', //
+    L'/',  //
     L';',  //
     L':',  //
     L'\'', //

--- a/windows/src/Key/KeyEventSink.cpp
+++ b/windows/src/Key/KeyEventSink.cpp
@@ -2247,17 +2247,17 @@ CMetasequoiaIME::KeyDownDispatchResult CMetasequoiaIME::_DispatchKeyDown(
             const bool shouldFinalizeHighlightedCandidateWithPunctuation =
                 _candidateMode != CANDIDATE_NONE && _pCandidateListUIPresenter &&
                 Global::CommitWithHighlightedCandPunc.count(wch) > 0;
-            // Numpad '.' (VK_DECIMAL) keeps ASCII '.' in Chinese punctuation mode.
-            if (code == VK_DECIMAL)
-            {
-                punctuationCommitText = L".";
-            }
-            else if (shouldFinalizeHighlightedCandidateWithPunctuation)
+            if (shouldFinalizeHighlightedCandidateWithPunctuation)
             {
                 // Empty means the edit session must consume this request's
                 // candidate reply and append the punctuation derived from wch
                 // (including smart-punctuation against the candidate text).
                 punctuationCommitText.clear();
+            }
+            else if (code == VK_DECIMAL)
+            {
+                // Numpad '.' stays ASCII, including after a candidate.
+                punctuationCommitText = L".";
             }
             else if (CCompositionProcessorEngine::IsSmartAsciiPunctuationKey(wch) &&
                      Global::SmartPunctuationEnabled.load(std::memory_order_relaxed))

--- a/windows/src/Key/KeyHandler.cpp
+++ b/windows/src/Key/KeyHandler.cpp
@@ -1186,7 +1186,14 @@ HRESULT CMetasequoiaIME::_HandleCompositionPunctuation(TfEditCookie ec, _In_ ITf
                 const std::wstring candidate(receivedData->candidate_string);
                 const WCHAR preceding =
                     candidate.empty() ? _GetPrecedingCharForSmartPunctuation(ec, pContext) : candidate.back();
-                punctuationStr = candidate + _ResolveSmartPunctuation(wch, preceding);
+                if (code == VK_DECIMAL || wch == L'/' || wch == L'-' || wch == L'+')
+                {
+                    punctuationStr = candidate + (code == VK_DECIMAL ? L'.' : wch);
+                }
+                else
+                {
+                    punctuationStr = candidate + _ResolveSmartPunctuation(wch, preceding);
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem and root cause

Fixes #298.

Numpad punctuation was split across inconsistent paths:

- `/` was missing from the TSF and Server candidate-commit sets.
- Numpad `-` and `+` were excluded like main-keyboard paging keys, while the Server only treats the OEM keys as paging.
- Decimal prefetched `.` before considering an active candidate, so the edit session skipped that candidate's reply.

## Change

Keep the existing request/reply and edit-session flow. Recognize the numpad arithmetic keys, consume the highlighted-candidate reply before appending punctuation, and preserve ASCII `/`, `-`, `+`, and decimal `.`. The unmapped arithmetic characters must not pass through the Chinese punctuation lookup, which returns an empty string for them. Main-keyboard paging and the existing `*` mapping are unchanged. No protocol or architecture change.

## Validation

- Before the fix: Windows 11 build 28000, Notepad, locally built v0.6.2. With the candidate `那` highlighted after `n`, numpad divide committed only `/`, decimal committed only `.`, while multiply committed `那*`.
- Release x64 and x86 TSF builds passed; `ctest --test-dir windows/build64-release -C Release --output-on-failure` and the corresponding `build32-release` run both passed 2/2 tests.
- Current Server sources compiled and linked. Local OpenCC dictionary generation could not read filesystem-encrypted input; the build used public prebuilt dictionaries from the identical pinned OpenCC commit, without changing build/source files.
- `ctest --test-dir server/build-release -C Release --output-on-failure`: 283 Server tests and 34 shared WebView contract fixtures passed, with isolated public dictionaries verified against `product-lock.json`.
- UI boundary check and changed-line clang-format 18.1.8 check passed. Product-level Python discovery was attempted but is incomplete locally because Bash/PyYAML and the `python3` command are unavailable.

Post-fix installed-host validation is still pending; compilation and existing tests do not assert final TSF committed text. No new production helper or mock COM stack was introduced solely for this small change.

- [ ] Installed x64 host: candidate + each of numpad `/ - + . *`, in both punctuation modes.
- [ ] Main-keyboard paging, ordinary candidate selection, and empty-composition input.
