### PR TITLE
fix(ui): collapse text selections before moving the caret

### DIFF
--- a/ui/src/tsf/TextEditor.cpp
+++ b/ui/src/tsf/TextEditor.cpp
@@ -300,7 +300,7 @@ std::wstring CTextEditor::GetSelectedText() const
 void CTextEditor::MoveSelectionNext()
 {
     UINT nTextLength = GetTextLength();
-    if (_nSelEnd < nTextLength)
+    if (_nSelStart == _nSelEnd && _nSelEnd < nTextLength)
         _nSelEnd++;
 
     _nSelStart = _nSelEnd;
@@ -316,7 +316,7 @@ void CTextEditor::MoveSelectionNext()
 
 void CTextEditor::MoveSelectionPrev()
 {
-    if (_nSelStart > 0)
+    if (_nSelStart == _nSelEnd && _nSelStart > 0)
         _nSelStart--;
 
     _nSelEnd = _nSelStart;

--- a/ui/tests/CMakeLists.txt
+++ b/ui/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(${TEST_EXECUTABLE_NAME}
     src/test_fonts.cpp
     src/test_layout.cpp
     src/test_font_fallback.cpp
+    src/test_text_selection.cpp
     includes/test_framework.h
 )
 

--- a/ui/tests/src/test_text_selection.cpp
+++ b/ui/tests/src/test_text_selection.cpp
@@ -1,0 +1,74 @@
+#include "tests/includes/test_framework.h"
+
+#include "src/tsf/TextEditor.h"
+#include "src/tsf/TsfTextServices.h"
+
+namespace
+{
+class EditorFixture
+{
+  public:
+    EditorFixture()
+    {
+        REQUIRE(SUCCEEDED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED)));
+        REQUIRE(InitializeTsfTextServices(GetModuleHandleW(nullptr)));
+        editor.SetWnd(nullptr);
+        REQUIRE(editor.InitTSF());
+        REQUIRE(editor.InsertAtSelection(L"ABCDE"));
+    }
+
+    ~EditorFixture()
+    {
+        editor.UninitTSF();
+        UninitializeTsfTextServices();
+        CoUninitialize();
+    }
+
+    CTextEditor editor;
+};
+} // namespace
+
+TEST_CASE(text_selection_right_collapses_to_the_selected_range_end)
+{
+    EditorFixture fixture;
+    fixture.editor.MoveSelection(1, 3);
+    fixture.editor.MoveSelectionNext();
+
+    REQUIRE(fixture.editor.GetSelectionStart() == 3);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 3);
+}
+
+TEST_CASE(text_selection_left_collapses_to_the_selected_range_start)
+{
+    EditorFixture fixture;
+    fixture.editor.MoveSelection(1, 3);
+    fixture.editor.MoveSelectionPrev();
+
+    REQUIRE(fixture.editor.GetSelectionStart() == 1);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 1);
+}
+
+TEST_CASE(text_selection_arrows_move_an_unselected_caret)
+{
+    EditorFixture fixture;
+    fixture.editor.MoveSelection(2, 2);
+    fixture.editor.MoveSelectionNext();
+    REQUIRE(fixture.editor.GetSelectionStart() == 3);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 3);
+    fixture.editor.MoveSelectionPrev();
+    REQUIRE(fixture.editor.GetSelectionStart() == 2);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 2);
+}
+
+TEST_CASE(text_selection_arrows_stay_at_text_boundaries)
+{
+    EditorFixture fixture;
+    fixture.editor.MoveSelection(0, 0);
+    fixture.editor.MoveSelectionPrev();
+    REQUIRE(fixture.editor.GetSelectionStart() == 0);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 0);
+    fixture.editor.MoveSelection(5, 5);
+    fixture.editor.MoveSelectionNext();
+    REQUIRE(fixture.editor.GetSelectionStart() == 5);
+    REQUIRE(fixture.editor.GetSelectionEnd() == 5);
+}


### PR DESCRIPTION
## Problem and root cause

In the native TextBox, Left/Right after selecting text should collapse to that selection's start/end. `CTextEditor::MoveSelectionPrev/Next` first decremented/incremented the endpoint even when a selection existed, moving one character too far.

Reproduction with `ABCDE`, selection `[1, 3)` (`BC`): Right moved to 4 instead of 3; Left moved to 0 instead of 1. The normal non-Shift TextBox handlers call these methods directly.

## Change

Only advance the endpoint when the selection is already collapsed. Two condition changes, preserving existing boundary handling and Shift-selection logic.

Add four native tests using a real `CTextEditor` and TSF context: collapse right, collapse left, movement without a selection, and both text boundaries. No visible window or mock editor is needed.

## Validation

- Windows 11 build 28000, x64 Release.
- Before the fix: collapse-left and collapse-right tests failed; ordinary movement and boundary tests passed.
- After the fix: all four tests passed.
- Official `cmake --build ui/build-release --config Release --target msimeui-tests` and `ctest --test-dir ui/build-release -C Release --output-on-failure` passed. The combined local validation tree also contained a separate retained-DPI fix; all 27 UI tests passed.
- UI boundary check, changed-line clang-format 18.1.8 check, and `git diff --check` passed.

This changes selection collapse only; UTF-16 character navigation and other editor behavior are outside this PR.
