### PR TITLE
fix(ui): pass /utf-8 to msimeui-tests on MSVC to prevent C4819 on CP936

### DIFF
--- a/ui/tests/CMakeLists.txt
+++ b/ui/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(${TEST_EXECUTABLE_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(${TEST_EXECUTABLE_NAME} PRIVATE msimeui)
 
 if(MSVC)
-    target_compile_options(${TEST_EXECUTABLE_NAME} PRIVATE /W4 /permissive-)
+    target_compile_options(${TEST_EXECUTABLE_NAME} PRIVATE /W4 /permissive- /utf-8)
 endif()
 
 add_test(NAME ${TEST_EXECUTABLE_NAME} COMMAND ${TEST_EXECUTABLE_NAME})


### PR DESCRIPTION
## Problem and root cause

On Windows hosts running non-UTF-8 system code pages (specifically Simplified Chinese Windows with active ANSI code page 936 / GBK), building the test target `msimeui-tests` with MSVC fails:

```
ui\tests\src\test_fonts.cpp(1,1): warning C4819: 该文件包含不能在当前代码页(936)中表示的字符。请将该文件保存为 Unicode 格式以防止数据丢失
ui\tests\src\test_fonts.cpp(33,78): error C2065: “kCjkWen”: 未声明的标识符
```

Root cause:
1. `.gitattributes` specifies `* text=auto eol=lf`, ensuring checkout uses LF (`0x0A`) line endings.
2. `ui/tests/src/test_fonts.cpp` is encoded in UTF-8 without BOM. Line 11 ends with `// 中\n` (`0xE4 0xB8 0xAD 0x0A`).
3. Under CP936, `0xAD` falls inside the multi-byte lead byte range (`0x81-0xFE`). Without `/utf-8`, MSVC's preprocessor consumes `0x0A` (`\n`) as the trailing byte of a DBCS character.
4. As a result, the single-line comment `//` fails to terminate at the line break, swallowing line 12 (`constexpr wchar_t kCjkWen = 0x6587; // 文`) into the comment and causing `C2065` at line 35.
5. Other modules across the repository (`server/`, `vendor/MetasequoiaImeEngine/`, `vendor/cpp-pinyin/`) already set `/utf-8` for MSVC; `ui/tests/CMakeLists.txt` omitted this option.

## Change

Pass `/utf-8` to `msimeui-tests` compile options on MSVC in `ui/tests/CMakeLists.txt`. This aligns with the rest of the repository and ensures source files are parsed as UTF-8 regardless of the developer's system code page.

## Validation

- Environment: Windows 11 build 26100, x64 Debug, MSVC 19.51.36252.0, active code page 936 (GBK).
- Before the fix:
  `cmake --build ui/build --config Debug --target msimeui-tests` failed with warning `C4819` and error `C2065`.
- After the fix:
  - `cmake --build ui/build --config Debug --target msimeui-tests` succeeded with 0 warnings and 0 errors.
  - `ctest --test-dir ui/build -C Debug --output-on-failure` ran 27/27 tests and all passed (100% pass rate).
  - `git diff --check` passed cleanly.

## 提交前确认

- [x] 我按上面写的方式实际验证过，不是只读代码判断
- [x] 没有在改动、截图或日志里带上 API Key、凭据或真实输入内容
- [x] 如果用了 AI 生成代码，我已自行逐行检查并测试过
