### PR TITLE
fix(server): D2D 候选窗主题修复与 RDP 会话缩放跟随

### DIFF
--- a/server/src/utils/window_utils.cpp
+++ b/server/src/utils/window_utils.cpp
@@ -110,6 +110,24 @@ FLOAT GetScaleForPoint(POINT pt)
     return ScaleFromMonitor(MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST));
 }
 
+ResolvedCandidateScale ResolveCandidateScaleForCaret(POINT caret)
+{
+    // SM_REMOTESESSION is only set inside a real remote session; console and
+    // local logons never see it, so the local path is byte-for-byte unchanged.
+    // GetDpiForWindow returns 0 for an invalid/absent foreground HWND, which
+    // drops to the monitor path instead of trusting a bogus 0 scale.
+    if (GetSystemMetrics(SM_REMOTESESSION))
+    {
+        const UINT dpi = GetDpiForWindow(GetForegroundWindow());
+        if (dpi != 0)
+        {
+            return {static_cast<FLOAT>(dpi) / static_cast<FLOAT>(USER_DEFAULT_SCREEN_DPI),
+                    CandidateScaleSource::RdpForeground};
+        }
+    }
+    return {GetScaleForPoint(caret), CandidateScaleSource::Monitor};
+}
+
 HalfScreenDipLimits QueryHalfScreenDipLimitsForPoint(POINT pt)
 {
     HalfScreenDipLimits limits{};

--- a/server/src/utils/window_utils.h
+++ b/server/src/utils/window_utils.h
@@ -10,6 +10,34 @@ FLOAT GetForegroundWindowScale();
 // Prefer the monitor that contains the caret / composition anchor. Foreground
 // HWND can disagree with the caret on Office extended-display setups.
 FLOAT GetScaleForPoint(POINT pt);
+
+// Where the candidate scale came from — diagnostic logging must be able to
+// tell the RDP foreground path apart from the plain monitor path.
+enum class CandidateScaleSource
+{
+    Monitor,       // caret's monitor DPI (local sessions, and RDP fallback)
+    RdpForeground, // foreground window DPI inside an RDP session
+};
+
+struct ResolvedCandidateScale
+{
+    FLOAT scale = 0.0f;
+    CandidateScaleSource source = CandidateScaleSource::Monitor;
+};
+
+// Candidate window scale authority. RDP syncs the client's display scaling
+// into the session's monitor DPI metadata (150% client -> 144), while the
+// focused application in the session usually still renders at 96 DPI, so the
+// monitor metadata is unreliable there and GetDpiForWindow(foreground) is the
+// best proxy for what the user actually sees:
+//   - DPI-unaware / System Aware host -> virtualized 96, matches the app;
+//   - PMv2 and correctly following -> current monitor DPI, matches the app;
+//   - PMv2 but not following (pathological) -> mismatch, cannot be detected
+//     via public APIs; documented as a known residue, not probed.
+// Local sessions keep the caret-monitor convention (mixed-DPI multi-monitor
+// setups depend on it). Falls back to the monitor path when the foreground
+// window is gone (lock screen, focus switch) so behavior matches pre-fix.
+ResolvedCandidateScale ResolveCandidateScaleForCaret(POINT caret);
 // Candidate placement uses that monitor's work area to avoid taskbars/app bars.
 MonitorCoordinates GetMonitorCoordinatesFromPoint(POINT pt);
 

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -146,6 +146,17 @@ struct CandSkinTokens
     float borderWidth = 1.5f;
     float containerPad = 5.0f;
     bool showSelectedBar = true;
+    // Row corner radius, selected-row text colors and context-menu palette.
+    // Defaults are fluent dark; the fluent light branch and per-skin branches
+    // override. rowTextSelected/rowLabelSelected alpha 0 keeps the normal
+    // colors (bar-style selection, like the fluent CSS).
+    float itemRadius = 4.0f;
+    D2D1_COLOR_F rowTextSelected = D2D1::ColorF(0, 0.0f);
+    D2D1_COLOR_F rowLabelSelected = D2D1::ColorF(0, 0.0f);
+    D2D1_COLOR_F menuFill = D2D1::ColorF(0x2D2D2D);
+    D2D1_COLOR_F menuBorder = ParseCssColor("#9b9b9b2e", D2D1::ColorF(0x3A3A3A, 0.18f));
+    D2D1_COLOR_F menuText = D2D1::ColorF(0xE9E8E8);
+    D2D1_COLOR_F menuHover = ColorFromRgb(0x414141);
 };
 
 void ApplyPackageColors(const CandidateSkinCatalog::CandidateColors &colors, CandSkinTokens &tokens)
@@ -331,46 +342,125 @@ void CandidatePresenter::ApplySkin()
         tokens.number = D2D1::ColorF(26.0f / 255.0f, 26.0f / 255.0f, 26.0f / 255.0f, 0.55f);
         tokens.selected = ColorFromRgb(0xE8E8E8);
         tokens.hover = ColorFromRgb(0xECECEC);
+        tokens.menuFill = ColorFromRgb(0xFFFFFF);
+        tokens.menuBorder = D2D1::ColorF(0, 0.12f);
+        tokens.menuText = ColorFromRgb(0x1A1A1A);
+        tokens.menuHover = ColorFromRgb(0xECECEC);
     }
+    // Built-in skin palettes mirror ui-html/webview2/candwnd/skins/<skin>/;
+    // the WebView2 CSS is the reference for both the light and dark values.
     if (skinId == "wechat")
     {
-        tokens.surface = candLight ? ColorFromRgb(0xF7F7F7) : ColorFromRgb(0x151515);
-        tokens.border = ColorFromRgb(0x292929);
         tokens.borderWidth = 1.0f;
         tokens.radius = 5.0f;
+        tokens.containerPad = 2.0f;
         tokens.accent = ColorFromRgb(0x07C160);
         tokens.selected = ColorFromRgb(0x07C160);
-        tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.32f);
         tokens.showSelectedBar = false;
-        tokens.text = ColorFromRgb(0xB7B7B7);
-        tokens.number = ColorFromRgb(0x858585);
+        tokens.rowTextSelected = ColorFromRgb(0xFFFFFF);
+        tokens.rowLabelSelected = ColorFromRgb(0xFFFFFF);
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xF7F7F7);
+            tokens.border = ColorFromRgb(0xDEDEDE);
+            tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.14f);
+            tokens.text = ColorFromRgb(0x333333);
+            tokens.number = ColorFromRgb(0x757575);
+            tokens.menuFill = ColorFromRgb(0xFFFFFF);
+            tokens.menuBorder = ColorFromRgb(0xD9D9D9);
+            tokens.menuText = ColorFromRgb(0x333333);
+            tokens.menuHover = ColorFromRgb(0xEEEEEE);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x151515);
+            tokens.border = ColorFromRgb(0x292929);
+            tokens.hover = D2D1::ColorF(7.0f / 255.0f, 193.0f / 255.0f, 96.0f / 255.0f, 0.32f);
+            tokens.text = ColorFromRgb(0xB7B7B7);
+            tokens.number = ColorFromRgb(0x858585);
+            tokens.menuFill = ColorFromRgb(0x1F1F1F);
+            tokens.menuBorder = ColorFromRgb(0x343434);
+            tokens.menuText = ColorFromRgb(0xD0D0D0);
+            tokens.menuHover = ColorFromRgb(0x2A2A2A);
+        }
     }
     else if (skinId == "willow_green")
     {
-        tokens.surface = ColorFromRgb(0x2D2F2E);
         tokens.borderWidth = 0.0f;
         tokens.radius = 9.0f;
         tokens.containerPad = 0.0f;
-        tokens.accent = ColorFromRgb(0x65C98D);
-        tokens.selected = ColorFromRgb(0x65C98D);
-        tokens.hover = D2D1::ColorF(101.0f / 255.0f, 201.0f / 255.0f, 141.0f / 255.0f, 0.22f);
-        tokens.text = ColorFromRgb(0xD8DBD8);
-        tokens.number = ColorFromRgb(0xA6ABA7);
+        // CSS 把行圆角设为 0、靠容器 clip-path 裁出窗口圆角，但 D2D 端 Card
+        // 不裁剪子控件，行圆角 0 会让绿色选中块盖掉窗口圆角。有意偏离 CSS：
+        // 沿用对齐前的 4px 行圆角（视觉上等效圆角窗口，用户拍板的选择）。
+        tokens.itemRadius = 4.0f;
         tokens.showSelectedBar = false;
+        tokens.rowTextSelected = ColorFromRgb(0xFFFFFF);
+        tokens.rowLabelSelected = ColorFromRgb(0xFFFFFF);
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xF4F5F3);
+            tokens.accent = ColorFromRgb(0x58B980);
+            tokens.selected = ColorFromRgb(0x58B980);
+            tokens.hover = D2D1::ColorF(88.0f / 255.0f, 185.0f / 255.0f, 128.0f / 255.0f, 0.16f);
+            tokens.text = ColorFromRgb(0x343936);
+            tokens.number = ColorFromRgb(0x686F6A);
+            tokens.menuFill = ColorFromRgb(0xFBFCFA);
+            tokens.menuBorder = ColorFromRgb(0xD8DED9);
+            tokens.menuText = ColorFromRgb(0x343936);
+            tokens.menuHover = ColorFromRgb(0xE9EEEA);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x2D2F2E);
+            tokens.accent = ColorFromRgb(0x65C98D);
+            tokens.selected = ColorFromRgb(0x65C98D);
+            tokens.hover = D2D1::ColorF(101.0f / 255.0f, 201.0f / 255.0f, 141.0f / 255.0f, 0.22f);
+            tokens.text = ColorFromRgb(0xD8DBD8);
+            tokens.number = ColorFromRgb(0xA6ABA7);
+            tokens.menuFill = ColorFromRgb(0x343635);
+            tokens.menuBorder = ColorFromRgb(0x454845);
+            tokens.menuText = ColorFromRgb(0xE0E2DF);
+            tokens.menuHover = ColorFromRgb(0x414441);
+        }
     }
     else if (skinId == "graphite")
     {
-        tokens.surface = ColorFromRgb(0x1C1F23);
-        tokens.border = ColorFromRgb(0x30353B);
         tokens.borderWidth = 1.0f;
         tokens.radius = 3.0f;
         tokens.containerPad = 5.0f;
-        tokens.accent = ColorFromRgb(0x8993A0);
+        tokens.itemRadius = 2.0f;
         tokens.selected = D2D1::ColorF(0, 0.0f);
-        tokens.hover = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.055f);
-        tokens.text = ColorFromRgb(0xAEB6C2);
-        tokens.number = ColorFromRgb(0x707987);
         tokens.showSelectedBar = false;
+        if (candLight)
+        {
+            tokens.surface = ColorFromRgb(0xFBFBFC);
+            tokens.border = ColorFromRgb(0xE2E5E9);
+            tokens.accent = ColorFromRgb(0x5F6B7A);
+            tokens.hover = D2D1::ColorF(31.0f / 255.0f, 41.0f / 255.0f, 55.0f / 255.0f, 0.055f);
+            tokens.text = ColorFromRgb(0x586476);
+            tokens.number = ColorFromRgb(0x8993A1);
+            tokens.rowTextSelected = ColorFromRgb(0x111827);
+            tokens.rowLabelSelected = ColorFromRgb(0x111827);
+            tokens.menuFill = ColorFromRgb(0xFFFFFF);
+            tokens.menuBorder = ColorFromRgb(0xDFE3E8);
+            tokens.menuText = ColorFromRgb(0x374151);
+            tokens.menuHover = ColorFromRgb(0xF1F3F5);
+        }
+        else
+        {
+            tokens.surface = ColorFromRgb(0x1C1F23);
+            tokens.border = ColorFromRgb(0x30353B);
+            tokens.accent = ColorFromRgb(0x8993A0);
+            tokens.hover = D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.055f);
+            tokens.text = ColorFromRgb(0xAEB6C2);
+            tokens.number = ColorFromRgb(0x707987);
+            tokens.rowTextSelected = ColorFromRgb(0xF1F3F5);
+            tokens.rowLabelSelected = ColorFromRgb(0xF1F3F5);
+            tokens.menuFill = ColorFromRgb(0x23272C);
+            tokens.menuBorder = ColorFromRgb(0x3A4047);
+            tokens.menuText = ColorFromRgb(0xC7CDD5);
+            tokens.menuHover = ColorFromRgb(0x30353B);
+        }
     }
 
     const std::wstring skinsRoot = AssetRoot() + L"\\skins";
@@ -410,7 +500,6 @@ void CandidatePresenter::ApplySkin()
     appearance.fontSize = fontSize;
     appearance.labelFontSize = fontSize * 0.8f;
     appearance.annotationFontSize = fontSize;
-    appearance.cornerRadius = 4.0f;
     appearance.contentPadLeft = 0.0f;
     appearance.contentPadRight = 0.0f;
     appearance.textPadLeft = 5.0f;
@@ -419,16 +508,19 @@ void CandidatePresenter::ApplySkin()
     appearance.selectedBarHeight = fontSize * 0.85f;
     appearance.showSelectedBar = tokens.showSelectedBar;
     appearance.selectedBarColor = tokens.accent;
+    appearance.cornerRadius = tokens.itemRadius;
     appearance.textColor = theme.textPrimary;
     appearance.labelColor = tokens.number;
     appearance.annotationColor = theme.textPrimary;
     appearance.rowFillSelected = tokens.selected;
     appearance.rowFillHover = tokens.hover;
     appearance.rowFillPressed = tokens.selected;
-    impl_->menuFill = candLight ? ColorFromRgb(0xFFFFFF) : ColorFromRgb(0x2D2D2D);
-    impl_->menuBorder = tokens.border;
-    impl_->menuText = theme.textPrimary;
-    impl_->menuHover = tokens.hover;
+    appearance.rowTextSelected = tokens.rowTextSelected;
+    appearance.rowLabelSelected = tokens.rowLabelSelected;
+    impl_->menuFill = tokens.menuFill;
+    impl_->menuBorder = tokens.menuBorder;
+    impl_->menuText = tokens.menuText;
+    impl_->menuHover = tokens.menuHover;
     impl_->list->SetAppearance(appearance);
     impl_->list->SetOrientation(GetConfiguredCandidateWindowLayout() == "horizontal"
                                     ? msimeui::CandidateList::Orientation::Horizontal

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -67,6 +67,23 @@ int AlignHostPixels(int value)
     return ((value + kBucket - 1) / kBucket) * kBucket;
 }
 
+// Recompute half-screen DIP limits against `scale` when it differs from the
+// monitor-derived scale, so clamping and window sizing stay on one scale
+// (mirrors the webview path's rasterization-scale composition).
+HalfScreenDipLimits ApplyScaleToHalfScreenLimits(POINT pt, FLOAT scale)
+{
+    HalfScreenDipLimits limits = QueryHalfScreenDipLimitsForPoint(pt);
+    if (scale > 0.0f)
+    {
+        const double monitorWidthPx = static_cast<double>((std::max)(1, limits.monitor.right - limits.monitor.left));
+        const double monitorHeightPx = static_cast<double>((std::max)(1, limits.monitor.bottom - limits.monitor.top));
+        limits.scale = scale;
+        limits.maxWidthDip = (monitorWidthPx * 0.5) / static_cast<double>(scale);
+        limits.maxHeightDip = (monitorHeightPx * 0.5) / static_cast<double>(scale);
+    }
+    return limits;
+}
+
 D2D1_COLOR_F ParseCssColor(const std::string &text, D2D1_COLOR_F fallback)
 {
     std::string value = TrimCopy(text);
@@ -848,14 +865,23 @@ void CandidatePresenter::RestoreHostAfterMenu()
     impl_->hostExpandedForMenu = false;
 }
 
-void CandidatePresenter::PlaceAndShow(POINT caret, float widthDip, float heightDip, float cardLeftDip, float cardTopDip)
+void CandidatePresenter::PlaceAndShow(POINT caret, float widthDip, float heightDip, float cardLeftDip, float cardTopDip,
+                                      const ResolvedCandidateScale &resolved)
 {
-    const HalfScreenDipLimits limits = QueryHalfScreenDipLimitsForPoint(caret);
-    FLOAT scale = limits.scale > 0.0f ? limits.scale : GetScaleForPoint(caret);
+    FLOAT scale = resolved.scale;
+    CandidateScaleSource scaleSource = resolved.source;
+    if (scale <= 0.0f)
+    {
+        const ResolvedCandidateScale now = ResolveCandidateScaleForCaret(caret);
+        scale = now.scale;
+        scaleSource = now.source;
+    }
     if (scale <= 0.0f)
     {
         scale = 1.0f;
+        scaleSource = CandidateScaleSource::Monitor;
     }
+    const HalfScreenDipLimits limits = ApplyScaleToHalfScreenLimits(caret, scale);
     widthDip = static_cast<float>(ClampWidthDipToHalfScreen(widthDip, limits));
     heightDip = static_cast<float>(ClampHeightDipToHalfScreen(heightDip, limits));
     lastLayoutWidthDip_ = widthDip;
@@ -910,9 +936,24 @@ void CandidatePresenter::PlaceAndShow(POINT caret, float widthDip, float heightD
         y = monitor.top + 2 - cardTopPx;
     }
     SetWindowPos(hwnd_, HWND_TOPMOST, x, y, widthPx, heightPx, SWP_NOACTIVATE | SWP_SHOWWINDOW);
+    // Rendering must use the same scale the window was just sized with: the ui
+    // override replaces GetDpiForWindow (144 inside RDP) so DIPs map exactly
+    // onto the pixels computed above. Must land before EnsureForComposition —
+    // a freshly created target reads it through DpiForHwnd().
+    const FLOAT dpiOverride = scale * 96.0f;
+    impl_->window->SetDpiOverride(dpiOverride);
+    impl_->resources.SetDpiOverride(dpiOverride);
     impl_->resources.EnsureForComposition(hwnd_);
     Present();
     SetCandidateHostCloaked(false);
+    // Acceptance trace for the RDP candidate-scale fix: which scale authority
+    // won, and the system's own (potentially diverging) DPI values. Coordinates
+    // and DPI only — never user input, per the diagnostic logging red lines.
+    CAND_DIAG_LOGF(L"candidate-d2d place source={} scale={:.3f} hwnd_dpi={} system_dpi={} remote={} caret=({},{}) "
+                   L"size_px=({},{})",
+                   scaleSource == CandidateScaleSource::RdpForeground ? L"rdp-foreground" : L"monitor", scale,
+                   GetDpiForWindow(hwnd_), GetDpiForSystem(), GetSystemMetrics(SM_REMOTESESSION) ? 1 : 0, caret.x,
+                   caret.y, widthPx, heightPx);
 }
 
 void CandidatePresenter::ShowFromGlobalState()
@@ -970,7 +1011,11 @@ void CandidatePresenter::ShowFromGlobalState(POINT caret)
     }
     FillItemsFromUi();
     impl_->list->SetHoverEnabled(hoverArmed_);
-    const HalfScreenDipLimits limits = QueryHalfScreenDipLimitsForPoint(caret);
+    // Resolve the scale once per show and thread it through measure, clamping,
+    // window sizing and rendering DPI — a foreground window changing mid-show
+    // must not split measure (clamped at one scale) from placement (another).
+    const ResolvedCandidateScale scale = ResolveCandidateScaleForCaret(caret);
+    const HalfScreenDipLimits limits = ApplyScaleToHalfScreenLimits(caret, scale.scale);
     const float maxW = limits.maxWidthDip > 1.0 ? static_cast<float>(limits.maxWidthDip) : 480.0f;
     const float maxH = limits.maxHeightDip > 1.0 ? static_cast<float>(limits.maxHeightDip) : 640.0f;
     impl_->root->InvalidateMeasure();
@@ -992,7 +1037,7 @@ void CandidatePresenter::ShowFromGlobalState(POINT caret)
         cardLeftDip = card.x;
         cardTopDip = card.y;
     }
-    PlaceAndShow(caret, widthDip, heightDip, cardLeftDip, cardTopDip);
+    PlaceAndShow(caret, widthDip, heightDip, cardLeftDip, cardTopDip, scale);
     ::is_global_wnd_cand_shown = true;
 }
 

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -303,10 +303,16 @@ void CandidatePresenter::ApplySkin()
         return;
     }
     const std::string skinId = GetConfiguredCandidateSkin();
+    // Resolve the effective light/dark mode before the cache check: with
+    // theme_cand = "follow" the raw setting is unchanged when theme_mode or
+    // the Windows theme flips, but the resolved colors are what we render
+    // with, so the resolved mode must participate in the fingerprint.
+    const bool candLight = ResolveConfiguredTheme(GetConfiguredThemeCand()) == "light";
     std::ostringstream fingerprint;
-    fingerprint << skinId << '|' << GetConfiguredThemeCand() << '|' << GetConfiguredCandidateFont() << '|'
-                << GetConfiguredCandidateFontSize() << '|' << GetConfiguredCandidateWindowPreeditFontSize() << '|'
-                << GetConfiguredCandidateWindowLayout() << '|' << GetConfiguredCandidateTextColor();
+    fingerprint << skinId << '|' << GetConfiguredThemeCand() << '|' << (candLight ? 'L' : 'D') << '|'
+                << GetConfiguredCandidateFont() << '|' << GetConfiguredCandidateFontSize() << '|'
+                << GetConfiguredCandidateWindowPreeditFontSize() << '|' << GetConfiguredCandidateWindowLayout() << '|'
+                << GetConfiguredCandidateTextColor();
     fingerprint << '|' << GetConfiguredCandidateEnglishFont();
     for (const auto &font : GetConfiguredCandidateFallbackFonts())
         fingerprint << '|' << font.size() << ':' << font;
@@ -316,8 +322,6 @@ void CandidatePresenter::ApplySkin()
         return;
     }
     lastSkinFingerprint_ = skinKey;
-
-    const bool candLight = ResolveConfiguredTheme(GetConfiguredThemeCand()) == "light";
     CandSkinTokens tokens;
     if (candLight)
     {

--- a/server/src/window/candidate_presenter.h
+++ b/server/src/window/candidate_presenter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils/window_utils.h"
+
 #include <memory>
 #include <string>
 #include <windows.h>
@@ -26,7 +28,11 @@ class CandidatePresenter
     void RebuildScene();
     void ApplySkin();
     void FillItemsFromUi();
-    void PlaceAndShow(POINT caret, float widthDip, float heightDip, float cardLeftDip, float cardTopDip);
+    // `scale` carries the scale resolved once per show in ShowFromGlobalState
+    // so measure, clamping, sizing and rendering all share one source; an
+    // unset (scale == 0) value makes PlaceAndShow resolve it itself.
+    void PlaceAndShow(POINT caret, float widthDip, float heightDip, float cardLeftDip, float cardTopDip,
+                      const ResolvedCandidateScale &scale = {});
     void ArmHoverIfPointerMoved();
     void CommitItem(size_t pageIndex);
     void ShowItemContextMenu(size_t pageIndex, POINT clientPoint);

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -126,6 +126,15 @@ POINT GetCandidateLayoutCaret()
     return g_candidate_session_anchor;
 }
 
+// WM_SETTINGCHANGE lParam points to "ImmersiveColorSet" when the user flips
+// the Windows app light/dark theme. Only meaningful for the D2D presenters:
+// they own their colors, while WebView2 pages restyle themselves.
+bool IsSystemLightDarkToggle(UINT message, LPARAM lParam)
+{
+    return message == WM_SETTINGCHANGE && lParam != 0 && UseD2dSmallWindowUi() &&
+           lstrcmpiW(reinterpret_cast<LPCWSTR>(lParam), L"ImmersiveColorSet") == 0;
+}
+
 struct SuppressCandidateDpiChange
 {
     SuppressCandidateDpiChange()
@@ -2169,6 +2178,17 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
                        DescribeCandidateHostState());
     }
 
+    if (IsSystemLightDarkToggle(message, lParam))
+    {
+        // A visible candidate window must flip immediately; a hidden one
+        // re-resolves its theme on the next ShowFromGlobalState via the
+        // ApplySkin fingerprint.
+        if (::is_global_wnd_cand_shown && CandidatePresenter::Instance().IsBound())
+        {
+            CandidatePresenter::Instance().ShowFromGlobalState(GetCandidateLayoutCaret());
+        }
+    }
+
     if (message == WM_IMEACTIVATE)
     {
         g_is_ime_active = true;
@@ -3604,6 +3624,13 @@ LRESULT CALLBACK WndProcSettingsWindow(HWND hwnd, UINT message, WPARAM wParam, L
 
 LRESULT CALLBACK WndProcFtbWindow(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+    // The floating toolbar is persistent, so it cannot rely on being re-themed
+    // on the next show (unlike the tray menu, which re-themes on every open).
+    if (IsSystemLightDarkToggle(message, lParam) && FloatingToolbarPresenter::Instance().IsBound())
+    {
+        FloatingToolbarPresenter::Instance().ApplyTheme();
+    }
+
     if (message == WM_NCHITTEST && FloatingToolbarPresenter::Instance().IsBound())
     {
         POINT client{GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};

--- a/ui/include/msimeui/Controls.h
+++ b/ui/include/msimeui/Controls.h
@@ -540,6 +540,12 @@ class CandidateList : public Visual
         D2D1_COLOR_F rowFillHover = D2D1::ColorF(0x343434);
         D2D1_COLOR_F rowFillPressed = D2D1::ColorF(0x353535);
         D2D1_COLOR_F rowFillSelected = D2D1::ColorF(0x3E3E3E, 0.725f);
+        // Text/label colors for the selected (and pressed) row. Alpha 0 keeps
+        // the normal textColor/labelColor; skins that fill the selected row
+        // with an opaque accent set these to the contrasting color (e.g. white
+        // on the WeChat green first row).
+        D2D1_COLOR_F rowTextSelected = D2D1::ColorF(0, 0.0f);
+        D2D1_COLOR_F rowLabelSelected = D2D1::ColorF(0, 0.0f);
         D2D1_COLOR_F selectedBarColor = D2D1::ColorF(0x6B69D6);
         D2D1_COLOR_F labelColor = D2D1::ColorF(0xE9E8E8, 0.616f);
         D2D1_COLOR_F textColor = D2D1::ColorF(0xE9E8E8);

--- a/ui/include/msimeui/DeviceResources.h
+++ b/ui/include/msimeui/DeviceResources.h
@@ -23,6 +23,15 @@ class DeviceResources
     void DiscardTarget();
     HRESULT Present();
 
+    /// Rendering DPI override for windows whose system DPI diverges from the
+    /// content's true scale (e.g. an RDP session syncs the client's display
+    /// scaling into the session's DPI metadata while the focused application
+    /// still renders at 96 DPI). Pass 0 (or any non-positive value) to clear
+    /// the override and fall back to GetDpiForWindow(hwnd). While set, the
+    /// override is the single DPI source so window sizing and rendering stay
+    /// on the same scale; a live render target is re-DPI'd immediately
+    /// because target recreation can be skipped for same-size compositions.
+    void SetDpiOverride(FLOAT dpi);
     ID2D1RenderTarget *GetRenderTarget() const;
     ID2D1DeviceContext *GetDeviceContext() const;
     IDWriteFactory *GetDWriteFactory() const;
@@ -61,6 +70,8 @@ class DeviceResources
     static bool IsSameColor(const D2D1_COLOR_F &lhs, const D2D1_COLOR_F &rhs);
     bool BindCompositionSurface();
     FLOAT DpiForHwnd() const;
+
+    FLOAT dpiOverride_ = 0.0f;
 
     HWND hwnd_ = nullptr;
     UINT pixelWidth_ = 1;

--- a/ui/include/msimeui/Window.h
+++ b/ui/include/msimeui/Window.h
@@ -30,6 +30,12 @@ class Window
     HINSTANCE GetInstance() const;
     Scene *GetScene() const;
     DeviceResources &GetDeviceResources();
+    /// DPI override, mirrored into the window's own DeviceResources. Only for
+    /// cases where the system window DPI diverges from the content's real
+    /// scale (RDP client-scaling sync); see DeviceResources::SetDpiOverride.
+    /// GetDpi() and every pixels<->DIPs conversion (hit testing, drag region,
+    /// layout) honor it while set.
+    void SetDpiOverride(FLOAT dpi);
     float GetDpi() const;
     PointF ClientPixelsToDips(const POINT &point) const;
     SizeF ClientPixelsToDips(const SIZE &size) const;
@@ -64,6 +70,7 @@ class Window
     int height_ = 0;
     HINSTANCE instance_ = nullptr;
     HWND hwnd_ = nullptr;
+    FLOAT dpiOverride_ = 0.0f;
     DeviceResources deviceResources_;
     std::unique_ptr<Scene> scene_;
     Visual *focusedVisual_ = nullptr;

--- a/ui/src/Controls.cpp
+++ b/ui/src/Controls.cpp
@@ -2877,8 +2877,14 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.fontFamily = fontFamily;
         }
 
-        ID2D1SolidColorBrush *labelBrush = deviceResources.GetSolidColorBrush(appearance_.labelColor);
-        ID2D1SolidColorBrush *textBrush = deviceResources.GetSolidColorBrush(appearance_.textColor);
+        const bool highlighted = selected || pressed;
+        const D2D1_COLOR_F &labelColor = highlighted && appearance_.rowLabelSelected.a > 0.001f
+                                             ? appearance_.rowLabelSelected
+                                             : appearance_.labelColor;
+        const D2D1_COLOR_F &textColor =
+            highlighted && appearance_.rowTextSelected.a > 0.001f ? appearance_.rowTextSelected : appearance_.textColor;
+        ID2D1SolidColorBrush *labelBrush = deviceResources.GetSolidColorBrush(labelColor);
+        ID2D1SolidColorBrush *textBrush = deviceResources.GetSolidColorBrush(textColor);
         ID2D1SolidColorBrush *annotationBrush = deviceResources.GetSolidColorBrush(appearance_.annotationColor);
         D2D1_COLOR_F translationColor = appearance_.annotationColor;
         translationColor.a *= 0.62f;

--- a/ui/src/DeviceResources.cpp
+++ b/ui/src/DeviceResources.cpp
@@ -24,12 +24,42 @@ bool DeviceResources::IsSameColor(const D2D1_COLOR_F &lhs, const D2D1_COLOR_F &r
 
 FLOAT DeviceResources::DpiForHwnd() const
 {
+    // The override wins over the system window DPI: window sizing and
+    // rendering must share one scale even when GetDpiForWindow disagrees
+    // with the content's real scale (RDP client-scaling sync).
+    if (dpiOverride_ > 0.0f)
+    {
+        return dpiOverride_;
+    }
     if (!hwnd_)
     {
         return 96.0f;
     }
     const UINT dpi = GetDpiForWindow(hwnd_);
     return dpi > 0 ? static_cast<FLOAT>(dpi) : 96.0f;
+}
+
+void DeviceResources::SetDpiOverride(FLOAT dpi)
+{
+    const FLOAT normalized = dpi > 0.0f ? dpi : 0.0f;
+    if (normalized == dpiOverride_)
+    {
+        return;
+    }
+    dpiOverride_ = normalized;
+    // EnsureForComposition early-returns when the existing swap chain already
+    // covers the requested size, so a live target would keep the stale DPI.
+    // Push the new DPI into live targets right away; freshly created targets
+    // read it through DpiForHwnd() instead.
+    const FLOAT effective = DpiForHwnd();
+    if (hwndRenderTarget_)
+    {
+        hwndRenderTarget_->SetDpi(effective, effective);
+    }
+    if (deviceContext_)
+    {
+        deviceContext_->SetDpi(effective, effective);
+    }
 }
 
 bool DeviceResources::EnsureFactories()

--- a/ui/src/Window.cpp
+++ b/ui/src/Window.cpp
@@ -149,8 +149,26 @@ DeviceResources &Window::GetDeviceResources()
     return deviceResources_;
 }
 
+void Window::SetDpiOverride(FLOAT dpi)
+{
+    const FLOAT normalized = dpi > 0.0f ? dpi : 0.0f;
+    if (normalized == dpiOverride_)
+    {
+        return;
+    }
+    dpiOverride_ = normalized;
+    // The presenter usually drives its own DeviceResources for composition,
+    // but the HwndRenderTarget path (OnPaint) must not keep rendering at the
+    // stale system DPI.
+    deviceResources_.SetDpiOverride(dpi);
+}
+
 float Window::GetDpi() const
 {
+    if (dpiOverride_ > 0.0f)
+    {
+        return dpiOverride_;
+    }
     return hwnd_ ? static_cast<float>(GetDpiForWindow(hwnd_)) : 96.0f;
 }
 


### PR DESCRIPTION
## 概述

本分支基于 #318（`fix/d2d`）之上，包含该 PR 的两个 commit 与本分支的两个新 commit，共四项改动，均围绕 D2D 候选窗的渲染正确性。

> **与 #318 的关系**：仓库以 merge commit 方式合并，两个 PR 无论谁先合并都不会冲突——先合 #318 则本 PR 的 diff 自动缩小为下面后两个 commit；先合本 PR 则 #318 变为空 diff，可直接关闭。

## 变更

### 来自 #318（`fix/d2d`）
- **D2D 候选窗明暗主题跟随设定与系统切换实时刷新**：`ApplySkin` 的指纹缓存只含 `theme_cand` 原始值，follow 模式下改 `theme_mode` 或系统明暗切换时指纹不变，候选窗停留在首次渲染的配色。将 `ResolveConfiguredTheme` 的解析结果并入指纹，并补上 `WM_SETTINGCHANGE(ImmersiveColorSet)` 的实时刷新路径。
- **D2D 内置皮肤补齐 light 配色**：对齐 WebView2 CSS 的 light token。

### 本分支新增
- **feat(ui): DeviceResources 与 Window 支持渲染 DPI 覆写**（`62b4688a`）
- **fix(server): RDP 会话中候选窗缩放跟随宿主应用实际渲染比例**（`753312f3`）：RDP 会话里系统 DPI 与宿主应用实际渲染 DPI 不一致，候选窗按系统 DPI 渲染会偏大或偏小。新增 `window_utils` 读取目标窗口实际渲染比例，经 `candidate_presenter` 下发渲染 DPI 覆写，`ui` 侧由 DeviceResources/Window 应用该覆写。