### PR TITLE
fix(installer): 打包写 .iss 用 LF，test-light 还原工作目录

### DIFF
--- a/installer/Prepare-PackageFiles.ps1
+++ b/installer/Prepare-PackageFiles.ps1
@@ -221,7 +221,9 @@ $updatedIss = [regex]::Replace(
     '(?m)^#define\s+MyAppVersion\s+"[^"]+"\s*$',
     "#define MyAppVersion   `"$TargetVersion`""
 )
-$updatedIss = $updatedIss.TrimEnd("`r", "`n") + "`r`n"
+# .gitattributes pins this repo to eol=lf; emit LF so packaging does not leave the file as a
+# CRLF-only diff that git flags as modified while `git diff` shows no textual change.
+$updatedIss = $updatedIss.TrimEnd("`r", "`n") + "`n"
 Set-Content -LiteralPath $targetIss -Value $updatedIss -Encoding utf8NoBOM -NoNewline
 
 # 设置页是已构建的静态资源，同步其“当前版本”展示。

--- a/installer/test-light.ps1
+++ b/installer/test-light.ps1
@@ -7,36 +7,43 @@
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
-Set-Location $PSScriptRoot
 
-$repoRoot = Split-Path -Parent $PSScriptRoot
-$tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
-$serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
-$settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
-
-# All three are directories of this repository now, so a missing one is a broken checkout rather
-# than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
-# lying around would produce an installer you then run on your own machine.
-foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
-    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
-        throw "缺少组件构建入口：$required"
-    }
-}
-
-Push-Location (Join-Path $repoRoot 'windows')
-try { & $tsfCompile } finally { Pop-Location }
-
-Push-Location (Join-Path $repoRoot 'server')
-try { & $serverCompile } finally { Pop-Location }
-
-Push-Location $settingsDir
+# Every build step below uses its own Push-Location and absolute paths ($repoRoot / $PSScriptRoot),
+# so the script never relies on the process cwd. Push/pop it here too, inside try/finally, so the
+# caller's shell is left where it started instead of stranded in installer\ when the script exits.
+Push-Location $PSScriptRoot
 try {
-    pnpm run build
-    if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
-} finally { Pop-Location }
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
+    $serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
+    $settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
 
-& (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -Light -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
-& (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
-& (Join-Path $PSScriptRoot 'Compile-Installer.ps1') -Light
-& (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1') -Light
-& (Join-Path $PSScriptRoot 'Install.ps1') -Light
+    # All three are directories of this repository now, so a missing one is a broken checkout rather
+    # than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
+    # lying around would produce an installer you then run on your own machine.
+    foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
+        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+            throw "缺少组件构建入口：$required"
+        }
+    }
+
+    Push-Location (Join-Path $repoRoot 'windows')
+    try { & $tsfCompile } finally { Pop-Location }
+
+    Push-Location (Join-Path $repoRoot 'server')
+    try { & $serverCompile } finally { Pop-Location }
+
+    Push-Location $settingsDir
+    try {
+        pnpm run build
+        if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+
+    & (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -Light -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
+    & (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
+    & (Join-Path $PSScriptRoot 'Compile-Installer.ps1') -Light
+    & (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1') -Light
+    & (Join-Path $PSScriptRoot 'Install.ps1') -Light
+} finally {
+    Pop-Location
+}

--- a/installer/test.ps1
+++ b/installer/test.ps1
@@ -6,36 +6,43 @@
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
-Set-Location $PSScriptRoot
 
-$repoRoot = Split-Path -Parent $PSScriptRoot
-$tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
-$serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
-$settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
-
-# All three are directories of this repository now, so a missing one is a broken checkout rather
-# than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
-# lying around would produce an installer you then run on your own machine.
-foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
-    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
-        throw "缺少组件构建入口：$required"
-    }
-}
-
-Push-Location (Join-Path $repoRoot 'windows')
-try { & $tsfCompile } finally { Pop-Location }
-
-Push-Location (Join-Path $repoRoot 'server')
-try { & $serverCompile } finally { Pop-Location }
-
-Push-Location $settingsDir
+# Every build step below uses its own Push-Location and absolute paths ($repoRoot / $PSScriptRoot),
+# so the script never relies on the process cwd. Push/pop it here too, inside try/finally, so the
+# caller's shell is left where it started instead of stranded in installer\ when the script exits.
+Push-Location $PSScriptRoot
 try {
-    pnpm run build
-    if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
-} finally { Pop-Location }
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
+    $serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
+    $settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
 
-& (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
-& (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
-& (Join-Path $PSScriptRoot 'Compile-Installer.ps1')
-& (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1')
-& (Join-Path $PSScriptRoot 'Install.ps1')
+    # All three are directories of this repository now, so a missing one is a broken checkout rather
+    # than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
+    # lying around would produce an installer you then run on your own machine.
+    foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
+        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+            throw "缺少组件构建入口：$required"
+        }
+    }
+
+    Push-Location (Join-Path $repoRoot 'windows')
+    try { & $tsfCompile } finally { Pop-Location }
+
+    Push-Location (Join-Path $repoRoot 'server')
+    try { & $serverCompile } finally { Pop-Location }
+
+    Push-Location $settingsDir
+    try {
+        pnpm run build
+        if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+
+    & (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
+    & (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
+    & (Join-Path $PSScriptRoot 'Compile-Installer.ps1')
+    & (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1')
+    & (Join-Path $PSScriptRoot 'Install.ps1')
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
## 问题

在 develop 上执行 `.\installer\test-light.ps1`（或 `.\installer\test.ps1`）后出现两个现象：

1. **`msime_setup.iss` 被 git 标记为已修改，但 `git diff` 看不到文本差异。**
   仓库 `.gitattributes` 为 `* text=auto eol=lf`，文件以 LF 存储/检出。但 `Prepare-PackageFiles.ps1` 回写 `MyAppVersion` 时把末尾换行强制成了 CRLF（`+ "\r\n"`），多出一个 `\r` 字节，于是工作区字节与 LF 规范化后的 blob 不一致 —— git 报 “CRLF will be replaced by LF” 并视为已修改。

2. **脚本结束后，pwsh 的工作目录从项目根目录跑到了 `installer\`。**
   `test.ps1` 与 `test-light.ps1` 顶部的 `Set-Location $PSScriptRoot` 改了进程 cwd 却从不还原。

## 改动

- `Prepare-PackageFiles.ps1`：`.iss` 末尾换行由 `\r\n` 改为 `\n`，与 `eol=lf` 一致。再次打包不再产生幽灵 diff。
- `test.ps1` 与 `test-light.ps1`：主体包进 `Push-Location $PSScriptRoot` + `try { … } finally { Pop-Location }`，即使中途报错也能把 shell 还原到调用前目录（各构建步骤已用绝对路径，不依赖进程 cwd）。

## 验证

- 三个脚本均通过 PowerShell 语法解析。
- 已将此前被弄脏的 `installer/msime_setup.iss` 还原，工作区残留 diff 消失。