### PR TITLE
fix(installer): 保留升级时的自定义翻译配置

### DIFF
--- a/installer/default_config/config.default.toml
+++ b/installer/default_config/config.default.toml
@@ -60,6 +60,17 @@ enabled = true
 secret_id = "<YOUR_TENCENT_SECRET_ID>"
 secret_key = "<YOUR_TENCENT_SECRET_KEY>"
 region = "ap-guangzhou"
+# 候选词翻译/背单词目标语种：en / fr / ja / es / ru / de / ko
+target_language = "en"
+
+#
+# 自定义 DeepLX 兼容翻译服务。endpoint 必须填写完整的 POST 接口地址。
+# api_key 留空时不发送 Authorization 请求头。
+#
+[custom_translation]
+enabled = false
+endpoint = ""
+api_key = ""
 
 [frequency_adjustment]
 # disabled / pin / halve / linear / promote

--- a/server/tests/src/test_config_template_merge.cpp
+++ b/server/tests/src/test_config_template_merge.cpp
@@ -2,6 +2,8 @@
 #include "config/ime_config.h"
 #include "tests/includes/test_framework.h"
 #include <type_traits>
+#include <fstream>
+#include <iterator>
 
 TEST_CASE(font_fallback_upgrade_preserves_legacy_fonts_and_order)
 {
@@ -154,4 +156,28 @@ TEST_CASE(configured_voice_input_is_handed_out_as_a_snapshot)
 
     const VoiceInputConfig snapshot = GetConfiguredVoiceInput();
     REQUIRE_EQ(snapshot.commit_mode, VoiceInputConfig().commit_mode);
+}
+
+// 读取安装器真正分发的模板，防止开发配置齐全、安装模板漏项导致升级后丢失设置。
+TEST_CASE(shipped_translation_settings_survive_template_upgrade)
+{
+    std::ifstream input(MSIME_DEFAULT_CONFIG_PATH, std::ios::binary);
+    REQUIRE(static_cast<bool>(input));
+    const std::string installed((std::istreambuf_iterator<char>(input)), {});
+    const std::string configured =
+        "[custom_translation]\nenabled = true\nendpoint = \"https://translation.example/translate\"\n"
+        "api_key = \"test-translation-key\"\n[tencent_tmt]\ntarget_language = \"ja\"\n";
+    const std::string legacy_template = "[tencent_tmt]\nenabled = true\n";
+
+    // 同时覆盖旧版本缺少这些字段，以及新版本已经包含这些字段的升级。
+    for (const auto &baseline : {legacy_template, installed})
+    {
+        const auto merged = toml::parse(MergeConfigIntoTemplate(installed, configured, baseline));
+        REQUIRE(merged["custom_translation"]["enabled"].value_or(false));
+        REQUIRE_EQ(merged["custom_translation"]["endpoint"].value_or(std::string()),
+                   std::string("https://translation.example/translate"));
+        REQUIRE_EQ(merged["custom_translation"]["api_key"].value_or(std::string()),
+                   std::string("test-translation-key"));
+        REQUIRE_EQ(merged["tencent_tmt"]["target_language"].value_or(std::string()), std::string("ja"));
+    }
 }


### PR DESCRIPTION
安装模板缺少 `[custom_translation]` 和 `tencent_tmt.target_language`。设置页可以写入这些字段，但下一次安装模板更新时，`MergeConfigIntoTemplate` 会删除模板中不存在的字段，导致自定义翻译服务选择、地址、密钥及目标语言丢失。

补齐与 Server 开发配置一致的默认值，并添加读取真实安装模板的回归测试，覆盖从缺少字段的旧模板升级和后续模板升级。

关联 #262。此次修复针对可以从当前代码复现的配置升级丢失路径，未把原报告中所有即时切换失败场景视为已验证解决。

验证：
- Windows 11 / MSVC 19.44：直接编译生产 `ime_config.cpp`，使用两个锁定版本的头文件依赖，运行 `test_config_template_merge.cpp`，12 项通过。隔离测试程序对未使用的宿主依赖采用调用即终止的替身，没有模拟配置合并函数。
- 相同生产合并函数配合原安装模板复现失败；修复模板通过。
- Python 3.11 `tomllib` 验证 TOML 可解析，新增默认值与 Server 一致。
- `git diff --check` 通过。

未执行完整 Server 构建、安装升级或 WebView2 设置窗口交互验证；完整构建与测试由 PR CI 继续检查。
