### PR TITLE
fix(ui): 修复候选列表溢出与换行后的点击区域

### DIFF
--- a/ui/include/msimeui/Controls.h
+++ b/ui/include/msimeui/Controls.h
@@ -599,6 +599,18 @@ class CandidateList : public Visual
         Microsoft::WRL::ComPtr<IDWriteTextLayout> translationLayout;
     };
 
+    // 均使用逻辑单位：bounds 相对列表，文字矩形相对候选项；测量、绘制与命中测试共用。
+    struct ItemGeometry
+    {
+        RectF bounds;
+        RectF label;
+        RectF text;
+        RectF annotation;
+        RectF translation;
+    };
+
+    float MeasureTextHeight(const std::wstring &text, float fontSize, float width) const;
+    ItemGeometry MeasureItem(size_t index, float width) const;
     void InvalidateLayoutCache();
     size_t HitTestItem(const PointF &point) const;
     float EstimateTextWidth(const std::wstring &text, float fontSize) const;
@@ -606,10 +618,10 @@ class CandidateList : public Visual
 
     std::vector<Item> items_;
     std::vector<ItemLayoutCache> layoutCache_;
-    std::vector<float> itemWidths_;
+    std::vector<ItemGeometry> itemGeometry_;
+    float layoutWidth_ = 0.0f;
     Appearance appearance_{};
     Orientation orientation_ = Orientation::Vertical;
-    float itemHeight_ = 40.0f;
     bool focused_ = false;
     bool pressed_ = false;
     bool hoverEnabled_ = true;

--- a/ui/src/Controls.cpp
+++ b/ui/src/Controls.cpp
@@ -2549,7 +2549,7 @@ size_t ListView::HitTestItem(const PointF &point) const
     return index < items_.size() ? index : static_cast<size_t>(-1);
 }
 
-CandidateList::CandidateList(float itemHeight) : itemHeight_(itemHeight)
+CandidateList::CandidateList(float itemHeight)
 {
     appearance_.itemHeight = itemHeight;
 }
@@ -2638,7 +2638,6 @@ const CandidateList::Item *CandidateList::GetItem(size_t index) const
 void CandidateList::SetAppearance(Appearance appearance)
 {
     appearance_ = appearance;
-    itemHeight_ = appearance_.itemHeight;
     InvalidateLayoutCache();
     InvalidateMeasure();
 }
@@ -2692,78 +2691,143 @@ float CandidateList::EstimateTextWidth(const std::wstring &text, float fontSize)
     return std::ceil(metrics.widthIncludingTrailingWhitespace + std::max(overhang.right, 0.0f) + 1.0f);
 }
 
+float CandidateList::MeasureTextHeight(const std::wstring &text, float fontSize, float width) const
+{
+    if (text.empty())
+        return 0.0f;
+    const Theme &theme = ThemeManager::GetCurrent();
+    const auto &family = appearance_.fontFamily.empty() ? theme.textInputFontFamily : appearance_.fontFamily;
+    const auto layout =
+        CreateCachedTextLayout(GetSharedDWriteFactory(), family, text, fontSize, DWRITE_FONT_WEIGHT_NORMAL, width,
+                               65536.0f, DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_PARAGRAPH_ALIGNMENT_NEAR,
+                               DWRITE_WORD_WRAPPING_WRAP, appearance_.fallbackFontFamilies);
+    DWRITE_TEXT_METRICS metrics{};
+    if (layout && SUCCEEDED(layout->GetMetrics(&metrics)))
+        return std::ceil(metrics.height);
+    return std::ceil(EstimateTextWidth(text, fontSize) / width) * fontSize * 1.25f;
+}
+
+CandidateList::ItemGeometry CandidateList::MeasureItem(size_t index, float width) const
+{
+    const auto &item = items_[index];
+    ItemGeometry geometry;
+    const float labelX = appearance_.contentPadLeft + appearance_.textPadLeft;
+    const float labelW = std::max(EstimateTextWidth(item.label, appearance_.labelFontSize), 9.0f);
+    const float textX = labelX + labelW + appearance_.labelGap;
+    const float contentWidth = std::max(width - textX - appearance_.contentPadRight, 1.0f);
+    const float textW = std::min(std::max(EstimateTextWidth(item.text, appearance_.fontSize), 8.0f), contentWidth);
+    const float textH = std::max(appearance_.itemHeight, MeasureTextHeight(item.text, appearance_.fontSize, textW));
+    geometry.label = {labelX, 0.0f, labelW, appearance_.itemHeight};
+    geometry.text = {textX, 0.0f, textW, textH};
+    float height = textH;
+    float lineEnd = textW;
+
+    // 短字段保持原有并排方式；空间不足时让辅助码和翻译完整换行。
+    if (!item.annotation.empty())
+    {
+        const float annotationW =
+            std::min(EstimateTextWidth(item.annotation, appearance_.annotationFontSize), contentWidth);
+        const bool inlineAnnotation = lineEnd + 4.0f + annotationW <= contentWidth;
+        const float annotationH = std::max(
+            appearance_.itemHeight, MeasureTextHeight(item.annotation, appearance_.annotationFontSize, annotationW));
+        geometry.annotation = {textX + (inlineAnnotation ? lineEnd + 4.0f : 0.0f), inlineAnnotation ? 0.0f : height,
+                               annotationW, annotationH};
+        height = std::max(height, geometry.annotation.y + annotationH);
+        lineEnd = geometry.annotation.x - textX + annotationW;
+    }
+    if (!item.translation.empty())
+    {
+        const float fontSize = appearance_.fontSize * 0.78f;
+        const float gap = appearance_.fontSize * 0.65f;
+        const float naturalTranslationWidth = EstimateTextWidth(item.translation, fontSize);
+        const float translationW = std::min(naturalTranslationWidth, contentWidth);
+        const bool inlineTranslation = orientation_ == Orientation::Vertical && geometry.annotation.y == 0.0f &&
+                                       lineEnd + gap + translationW <= contentWidth;
+        const float translationH =
+            inlineTranslation
+                ? textH
+                : (naturalTranslationWidth <= contentWidth
+                       ? fontSize * 1.25f
+                       : std::max(fontSize * 1.25f, MeasureTextHeight(item.translation, fontSize, translationW)));
+        geometry.translation = {textX + (inlineTranslation ? lineEnd + gap : 0.0f), inlineTranslation ? 0.0f : height,
+                                translationW, translationH};
+        height = std::max(height, geometry.translation.y + translationH);
+    }
+    geometry.bounds = {0.0f, 0.0f, width, height};
+    return geometry;
+}
+
 RectF CandidateList::ItemRect(size_t index) const
 {
-    if (index >= items_.size())
-    {
+    if (index >= itemGeometry_.size())
         return {};
-    }
-    const float gap = appearance_.itemGap;
-    if (orientation_ == Orientation::Horizontal)
-    {
-        float x = bounds_.x;
-        for (size_t i = 0; i < index; ++i)
-        {
-            x += (i < itemWidths_.size() ? itemWidths_[i] : 48.0f) + gap;
-        }
-        const float width = index < itemWidths_.size() ? itemWidths_[index] : 48.0f;
-        return {x, bounds_.y, width, itemHeight_};
-    }
-    const float itemY = bounds_.y + (itemHeight_ + gap) * static_cast<float>(index);
-    return {bounds_.x, itemY, bounds_.width, itemHeight_};
+    RectF rect = itemGeometry_[index].bounds;
+    rect.x += bounds_.x;
+    rect.y += bounds_.y;
+    return rect;
 }
 
 SizeF CandidateList::Measure(const SizeF &availableSize)
 {
-    itemWidths_.resize(items_.size());
-    itemHeight_ = appearance_.itemHeight;
+    // 宽度变化也会改变每段文字的高度，不能继续使用上一轮的文字布局缓存。
+    InvalidateLayoutCache();
+    itemGeometry_.clear();
+    const float availableWidth = std::max(availableSize.width, 1.0f);
     const float gap = appearance_.itemGap;
-    if (orientation_ == Orientation::Horizontal)
-    {
-        float width = 0.0f;
-        for (size_t i = 0; i < items_.size(); ++i)
-        {
-            const float textWidth = EstimateTextWidth(items_[i].text, appearance_.fontSize) + 6.0f +
-                                    EstimateTextWidth(items_[i].annotation, appearance_.annotationFontSize);
-            const float translationWidth = EstimateTextWidth(items_[i].translation, appearance_.fontSize * 0.78f);
-            const float itemWidth = appearance_.contentPadLeft + appearance_.textPadLeft +
-                                    EstimateTextWidth(items_[i].label, appearance_.labelFontSize) +
-                                    appearance_.labelGap + std::max(textWidth, translationWidth) +
-                                    appearance_.contentPadRight;
-            if (!items_[i].translation.empty())
-                itemHeight_ = appearance_.itemHeight + appearance_.fontSize * 0.78f * 1.25f;
-            itemWidths_[i] = itemWidth;
-            width += itemWidth;
-            if (i + 1 < items_.size())
-            {
-                width += gap;
-            }
-        }
-        return {(std::min)(width, availableSize.width), (std::min)(itemHeight_, availableSize.height)};
-    }
-
+    const bool horizontal = orientation_ == Orientation::Horizontal;
+    std::vector<float> widths;
     float maxWidth = 80.0f;
     for (const auto &item : items_)
     {
-        const float rowWidth =
-            appearance_.contentPadLeft + appearance_.textPadLeft +
-            EstimateTextWidth(item.label, appearance_.labelFontSize) + appearance_.labelGap +
-            EstimateTextWidth(item.text, appearance_.fontSize) + 6.0f +
-            EstimateTextWidth(item.annotation, appearance_.annotationFontSize) +
-            (item.translation.empty()
-                 ? 0.0f
-                 : appearance_.fontSize * 0.65f + EstimateTextWidth(item.translation, appearance_.fontSize * 0.78f)) +
-            appearance_.contentPadRight;
-        maxWidth = (std::max)(maxWidth, rowWidth);
+        const float textWidth = EstimateTextWidth(item.text, appearance_.fontSize) + 6.0f +
+                                EstimateTextWidth(item.annotation, appearance_.annotationFontSize);
+        const float translationWidth = EstimateTextWidth(item.translation, appearance_.fontSize * 0.78f);
+        const float contentWidth =
+            horizontal
+                ? std::max(textWidth, translationWidth)
+                : textWidth + (item.translation.empty() ? 0.0f : appearance_.fontSize * 0.65f + translationWidth);
+        const float width = appearance_.contentPadLeft + appearance_.textPadLeft +
+                            std::max(EstimateTextWidth(item.label, appearance_.labelFontSize), 9.0f) +
+                            appearance_.labelGap + contentWidth + appearance_.contentPadRight;
+        widths.push_back(std::min(width, availableWidth));
+        maxWidth = std::max(maxWidth, width);
     }
-    const float gapCount = items_.empty() ? 0.0f : static_cast<float>(items_.size() - 1);
-    const float height =
-        items_.empty() ? itemHeight_ : itemHeight_ * static_cast<float>(items_.size()) + gap * gapCount;
-    return {(std::min)(maxWidth, availableSize.width), (std::min)(height, availableSize.height)};
+    const float verticalWidth = std::min(maxWidth, availableWidth);
+    float x = 0.0f;
+    float y = 0.0f;
+    float rowHeight = 0.0f;
+    float measuredWidth = horizontal ? 0.0f : verticalWidth;
+    for (size_t i = 0; i < items_.size(); ++i)
+    {
+        auto geometry = MeasureItem(i, horizontal ? widths[i] : verticalWidth);
+        if (horizontal && x > 0.0f && x + geometry.bounds.width > availableWidth)
+        {
+            y += rowHeight + gap;
+            x = 0.0f;
+            rowHeight = 0.0f;
+        }
+        geometry.bounds.x = x;
+        geometry.bounds.y = y;
+        itemGeometry_.push_back(geometry);
+        measuredWidth = std::max(measuredWidth, x + geometry.bounds.width);
+        rowHeight = std::max(rowHeight, geometry.bounds.height);
+        if (horizontal)
+            x += geometry.bounds.width + gap;
+        else if (i + 1 < items_.size())
+        {
+            y += geometry.bounds.height + gap;
+            rowHeight = 0.0f;
+        }
+    }
+    layoutWidth_ = measuredWidth;
+    const float height = items_.empty() ? appearance_.itemHeight : y + rowHeight;
+    return {measuredWidth, std::min(height, availableSize.height)};
 }
 
 void CandidateList::Arrange(const RectF &finalRect)
 {
+    if (std::abs(finalRect.width - layoutWidth_) > 0.5f)
+        Measure({finalRect.width, std::numeric_limits<float>::max()});
     bounds_ = finalRect;
 }
 
@@ -2771,7 +2835,7 @@ void CandidateList::Render(DeviceResources &deviceResources)
 {
     ID2D1RenderTarget *target = deviceResources.GetRenderTarget();
     IDWriteFactory *factory = deviceResources.GetDWriteFactory();
-    if (!target || !factory)
+    if (!target || !factory || itemGeometry_.size() != items_.size())
     {
         return;
     }
@@ -2813,29 +2877,16 @@ void CandidateList::Render(DeviceResources &deviceResources)
         }
 
         const float translationFontSize = appearance_.fontSize * 0.78f;
-        const float translationGap = appearance_.fontSize * 0.65f;
-        const float labelX = itemRect.x + appearance_.contentPadLeft + appearance_.textPadLeft;
-        const float labelW = (std::max)(EstimateTextWidth(items_[index].label, appearance_.labelFontSize), 9.0f);
-        const float textX = labelX + labelW + appearance_.labelGap;
-        const float textW = (std::max)(EstimateTextWidth(items_[index].text, appearance_.fontSize), 8.0f);
-        const float annotationX = textX + textW + (items_[index].annotation.empty() ? 0.0f : 4.0f);
-        const float annotationW = items_[index].annotation.empty()
-                                      ? 0.0f
-                                      : EstimateTextWidth(items_[index].annotation, appearance_.annotationFontSize);
-        const bool horizontal = orientation_ == Orientation::Horizontal;
-        const float textHeight = horizontal ? appearance_.itemHeight : itemRect.height;
-        const float translationX =
-            horizontal ? textX
-                       : annotationX + annotationW + (items_[index].translation.empty() ? 0.0f : translationGap);
-        const float translationW = items_[index].translation.empty()
-                                       ? 0.0f
-                                       : EstimateTextWidth(items_[index].translation, translationFontSize);
-        const RectF labelRect = {labelX, itemRect.y, labelW, textHeight};
-        const RectF textRect = {textX, itemRect.y, textW, textHeight};
-        const RectF annotationRect = {annotationX, itemRect.y, std::max(annotationW, 1.0f), textHeight};
-        const RectF translationRect = {translationX, itemRect.y + (horizontal ? textHeight : 0.0f),
-                                       std::max(translationW, 1.0f),
-                                       horizontal ? itemRect.height - textHeight : itemRect.height};
+        const auto &geometry = itemGeometry_[index];
+        const auto absolute = [&](RectF rect) {
+            rect.x += itemRect.x;
+            rect.y += itemRect.y;
+            return rect;
+        };
+        const RectF labelRect = absolute(geometry.label);
+        const RectF textRect = absolute(geometry.text);
+        const RectF annotationRect = absolute(geometry.annotation);
+        const RectF translationRect = absolute(geometry.translation);
 
         auto &cache = layoutCache_[index];
         if (cache.fontFamily != fontFamily || cache.labelWidth != labelRect.width)
@@ -2843,7 +2894,7 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.labelLayout = CreateCachedTextLayout(
                 factory, fontFamily, items_[index].label, appearance_.labelFontSize, DWRITE_FONT_WEIGHT_NORMAL,
                 std::max(labelRect.width, 1.0f), std::max(labelRect.height, 1.0f), DWRITE_TEXT_ALIGNMENT_LEADING,
-                DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_NO_WRAP, appearance_.fallbackFontFamilies);
+                DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_WRAP, appearance_.fallbackFontFamilies);
             cache.labelWidth = labelRect.width;
             cache.fontFamily = fontFamily;
         }
@@ -2852,7 +2903,7 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.textLayout = CreateCachedTextLayout(
                 factory, fontFamily, items_[index].text, appearance_.fontSize, DWRITE_FONT_WEIGHT_NORMAL,
                 std::max(textRect.width, 1.0f), std::max(textRect.height, 1.0f), DWRITE_TEXT_ALIGNMENT_LEADING,
-                DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_NO_WRAP, appearance_.fallbackFontFamilies);
+                DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_WRAP, appearance_.fallbackFontFamilies);
             cache.textWidth = textRect.width;
             cache.fontFamily = fontFamily;
         }
@@ -2861,7 +2912,7 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.annotationLayout = CreateCachedTextLayout(
                 factory, fontFamily, items_[index].annotation, appearance_.annotationFontSize,
                 DWRITE_FONT_WEIGHT_NORMAL, std::max(annotationRect.width, 1.0f), std::max(annotationRect.height, 1.0f),
-                DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_NO_WRAP,
+                DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_WRAP,
                 appearance_.fallbackFontFamilies);
             cache.annotationWidth = annotationRect.width;
             cache.fontFamily = fontFamily;
@@ -2871,7 +2922,7 @@ void CandidateList::Render(DeviceResources &deviceResources)
             cache.translationLayout = CreateCachedTextLayout(
                 factory, fontFamily, items_[index].translation, translationFontSize, DWRITE_FONT_WEIGHT_NORMAL,
                 std::max(translationRect.width, 1.0f), std::max(translationRect.height, 1.0f),
-                DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_NO_WRAP,
+                DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_PARAGRAPH_ALIGNMENT_CENTER, DWRITE_WORD_WRAPPING_WRAP,
                 appearance_.fallbackFontFamilies);
             cache.translationWidth = translationRect.width;
             cache.fontFamily = fontFamily;

--- a/ui/tests/src/test_layout.cpp
+++ b/ui/tests/src/test_layout.cpp
@@ -273,3 +273,96 @@ TEST_CASE(vertical_candidate_translation_stays_on_the_same_line)
     REQUIRE_NEAR(vertical.height, 28.0f);
     REQUIRE(vertical.width > horizontal.width);
 }
+
+TEST_CASE(horizontal_candidates_wrap_and_keep_their_click_indices_at_each_dpi)
+{
+    Window window(L"candidate-wrap-test", L"", 1000, 1000);
+    CandidateList list(28.0f);
+    list.Attach(&window);
+    list.SetOrientation(CandidateList::Orientation::Horizontal);
+    list.SetItems({{L"1", L"候选文字", L"", L""}});
+    const float width = list.MeasureInLayout({1000.0f, 1000.0f}).width + 1.0f;
+    list.SetItems({{L"1", L"候选文字", L"", L""},
+                   {L"2", L"候选文字", L"", L""},
+                   {L"3", L"候选文字", L"", L""},
+                   {L"4", L"候选文字", L"", L""},
+                   {L"5", L"候选文字", L"", L""},
+                   {L"6", L"候选文字", L"", L""}});
+    const SizeF wrapped = list.MeasureInLayout({width, 1000.0f});
+    REQUIRE_NEAR(wrapped.height, 6.0f * 28.0f + 5.0f * 2.0f);
+    list.ArrangeInLayout({10.0f, 20.0f, width, wrapped.height});
+    size_t activated = 99;
+    list.SetOnItemActivated([&](size_t index) { activated = index; });
+    for (float dpi : {96.0f, 120.0f, 144.0f, 192.0f})
+    {
+        window.SetDpiOverride(dpi);
+        for (size_t i = 0; i < 6; ++i)
+        {
+            const POINT point{static_cast<LONG>(DipsToPixels(30.0f, dpi)),
+                              static_cast<LONG>(DipsToPixels(34.0f + i * 30.0f, dpi))};
+            REQUIRE(list.OnMouseDown(point, MK_LBUTTON));
+            REQUIRE(list.OnMouseUp(point, 0));
+            REQUIRE(activated == i);
+        }
+    }
+    // 可用宽度恢复后必须重新排成一行，不保留上一轮的换行高度。
+    REQUIRE_NEAR(list.MeasureInLayout({2000.0f, 1000.0f}).height, 28.0f);
+}
+
+TEST_CASE(long_candidate_text_wraps_and_the_following_candidate_remains_clickable)
+{
+    Window window(L"long-candidate-test", L"", 1000, 1000);
+    CandidateList list(28.0f);
+    list.Attach(&window);
+    for (auto orientation : {CandidateList::Orientation::Horizontal, CandidateList::Orientation::Vertical})
+    {
+        list.SetOrientation(orientation);
+        list.SetItems({{L"1", std::wstring(60, L'字'), L"(aux)", L"translation"}});
+        const SizeF first = list.MeasureInLayout({140.0f, 2000.0f});
+        REQUIRE(first.height > 56.0f);
+        REQUIRE(first.width <= 140.0f);
+        list.SetItems({{L"1", std::wstring(60, L'字'), L"(aux)", L"translation"}, {L"2", L"下一个", L"", L""}});
+        const SizeF all = list.MeasureInLayout({140.0f, 2000.0f});
+        REQUIRE(all.height >= first.height + 30.0f);
+        list.ArrangeInLayout({0.0f, 0.0f, all.width, all.height});
+        size_t activated = 99;
+        list.SetOnItemActivated([&](size_t index) { activated = index; });
+        const POINT point{20, static_cast<LONG>(all.height - 14.0f)};
+        REQUIRE(list.OnMouseDown(point, MK_LBUTTON));
+        REQUIRE(list.OnMouseUp(point, 0));
+        REQUIRE(activated == 1);
+    }
+}
+
+TEST_CASE(long_annotation_and_translation_increase_candidate_height)
+{
+    CandidateList list(28.0f);
+    for (auto orientation : {CandidateList::Orientation::Horizontal, CandidateList::Orientation::Vertical})
+    {
+        list.SetOrientation(orientation);
+        list.SetItems({{L"1", L"short", L"", L""}});
+        const SizeF plain = list.MeasureInLayout({140.0f, 2000.0f});
+        list.SetItems({{L"1", L"short", std::wstring(60, L'a'), std::wstring(100, L'b')}});
+        const SizeF annotated = list.MeasureInLayout({140.0f, 2000.0f});
+        REQUIRE(annotated.height > plain.height * 3.0f);
+        REQUIRE(annotated.width <= 140.0f);
+    }
+}
+
+TEST_CASE(candidate_arrangement_reflows_when_the_final_slot_is_narrower)
+{
+    Window window(L"candidate-arrange-test", L"", 1000, 1000);
+    CandidateList list(28.0f);
+    list.Attach(&window);
+    list.SetOrientation(CandidateList::Orientation::Horizontal);
+    list.SetItems({{L"1", L"candidate", L"", L""}});
+    const float width = list.MeasureInLayout({1000.0f, 1000.0f}).width + 1.0f;
+    list.SetItems({{L"1", L"candidate", L"", L""}, {L"2", L"candidate", L"", L""}});
+    list.MeasureInLayout({1000.0f, 1000.0f});
+    list.Arrange({0.0f, 0.0f, width, 58.0f});
+    size_t activated = 99;
+    list.SetOnItemActivated([&](size_t index) { activated = index; });
+    REQUIRE(list.OnMouseDown({20, 44}, MK_LBUTTON));
+    REQUIRE(list.OnMouseUp({20, 44}, 0));
+    REQUIRE(activated == 1);
+}


### PR DESCRIPTION
D2D 候选列表在测量时把窗口宽度限制到可用空间，但绘制和点击仍按整行的自然宽度计算，导致后面的候选移到窗外。单个长候选、辅助码和翻译也使用不换行的文本布局，会越过候选边界。

本次让候选项与各段文字共用一份逻辑坐标布局：横排空间不足时换到下一行，单个长字段按可用宽度换行，竖排根据实际内容高度推进。绘制、背景和点击区域一起使用该布局，候选顺序、选中索引与业务状态保持原有行为。空间足够时保留短候选的布局，以及横排翻译在第二行、竖排翻译在同行的行为。

关联 #317：修复当前 develop 可复现的 D2D 路径。WebView2 的内置皮肤当前已经有换行样式，本次没有修改或宣称完成它的宿主验证。

验证：
- Windows 11 / MSVC 19.44：`cmake -S ui -B ui/build -G "Visual Studio 17 2022" -A x64`、`cmake --build ui/build --config Release --target msimeui-tests --parallel 4`、`ctest --test-dir ui/build -C Release --output-on-failure` 通过，31 项原生测试全部通过。
- 新增的 4 项测试在原始 develop 上均失败，应用修复后均通过：6 个候选换行和点击索引、横竖排长候选、长辅助码和翻译、最终排列宽度变化。
- 点击测试覆盖 96/120/144/192 DPI；使用真实 Direct2D/DirectWrite 隐藏窗口导出四种 DPI 的渲染图片，检查长中文、长英文、辅助码及后续候选均完整呈现。
- `python ui/scripts/check-boundary.py` 和 `git diff --check` 通过。

未安装输入法，未执行真实 TSF 宿主或跨物理显示器的手工回归。PR CI 继续验证完整产品构建。
