### PR TITLE
fix(server): preserve selected prefix when committing generated candidates

### DIFF
--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -4218,6 +4218,8 @@ void ProcessSelectionKey(UINT keycode, uint64_t client_id, uint64_t activation_e
             curWordItem.source == CandidateSource::QuickPhrase || curWordItem.source == CandidateSource::Emoji ||
             curWordItem.source == CandidateSource::Kaomoji || curWordItem.source == CandidateSource::Generated)
         {
+            Global::candidate_ui.selected_text =
+                string_to_wstring(CandidateTextForOutput(GlobalIme::composition.creating_word.word + curWord));
             if (curWordItem.source == CandidateSource::EnglishDictionary && isNeedUpdateWeight)
             {
                 const auto &frequency = GetConfiguredFrequencyAdjustment();


### PR DESCRIPTION
## Summary

Fixes #261.

`Generated` candidates include lattice-generated sentences, but `ProcessSelectionKey` commits them through the special-candidate early-return branch. That branch cleared the composition after copying only the selected candidate, discarding `creating_word.word`.

Prepend the already-selected word before clearing this branch, using the existing output conversion. This is a two-line change; it preserves the existing ranking/learning and special-mode cleanup behavior.

## Validation

- x64 Release Server build passed.
- Server CTest: 2/2 passed, using the public dictionaries pinned by `product-lock.json` in an isolated test data directory.
- Local native regression harness linked the current Server objects and called the real `ProcessSelectionKey`, without starting the Server, installing it, or opening a host application. With an isolated SQLite dictionary containing 西 / 你好 / 中国 and no Google model, input `xi'ni'hao'zhong'guo`, select 西, then select the engine-generated 你好中国. Before: 你好中国 (failure). After: 西你好中国 (pass). The minimal dictionary makes the Generated route deterministic; this is not a claim about the default first candidate with every installed dictionary.
- 48 extended native cases passed: simplified/traditional output, with/without a prefix, Space/number selection, and Generated/English/QuickPhrase/Emoji/Kaomoji routes. Generated sentence cases use the real engine; the remaining special-candidate cases supply candidate items to the actual selection handler.
- Changed lines checked with clang-format 18.1.8; `git diff --check` passed.

No TSF DLL or protocol changes. Interactive host validation was not performed for this patch. Local OpenCC dictionaries came from the matching public resource package because the local transparent-encryption environment prevents its text-to-dictionary build helper from reading source dictionaries.