### PR TITLE
fix(server): 候选窗右侧截断——去重的 show 不再让待应用的裁剪区失效

### DIFF
--- a/server/src/utils/webview_utils.cpp
+++ b/server/src/utils/webview_utils.cpp
@@ -7,8 +7,8 @@
 #include "utils/common_utils.h"
 #include <boost/json.hpp>
 
-#undef DIAG_LOGF
-#define DIAG_LOGF(...) ((void)0)
+// ui-measure tracing was compiled out, which hid whether the reported card width
+// matches what the DOM actually paints. Keep it on the global diagnostic switch.
 
 namespace json = boost::json;
 
@@ -89,9 +89,15 @@ void GetCandidateCardSize(ComPtr<ICoreWebView2> webview, const wchar_t *boxId, c
             if (box) {{
                 box.style.maxWidth = maxW + "px";
                 box.style.maxHeight = maxH + "px";
-                box.style.width = "fit-content";
+                // max-content + the maxWidth cap above is the skin's own clamp: the
+                // used width shrinks to the content but never exceeds maxW, and the
+                // content re-wraps inside it. These inline styles outlive the measure
+                // and become the painted layout, so they must wrap exactly where the
+                // skin wraps. Never pin white-space to nowrap here -- that is what let
+                // the card outgrow maxW and get sliced mid-candidate by overflow-x.
+                box.style.width = "max-content";
                 box.style.boxSizing = "border-box";
-                box.style.whiteSpace = "nowrap";
+                box.style.removeProperty("white-space");
                 box.style.overflowX = "hidden";
                 box.style.overflowY = "auto";
             }}
@@ -112,7 +118,13 @@ void GetCandidateCardSize(ComPtr<ICoreWebView2> webview, const wchar_t *boxId, c
             var height = Math.min(
                 maxH,
                 Math.max(rect.height, target.offsetHeight || 0) + 1);
-            return JSON.stringify({{width: width, height: height}});
+            // Diagnostic breakdown: if sw/cw exceed the reported width, the painted
+            // card is wider than what the native region will be built from.
+            return JSON.stringify({{width: width, height: height,
+                rw: rect.width, ow: target.offsetWidth || 0,
+                sw: target.scrollWidth || 0, cw: target.clientWidth || 0,
+                rh: rect.height, oh: target.offsetHeight || 0,
+                sh: target.scrollHeight || 0, mw: maxW}});
         }})();
     )",
                                       boxId, parentId, maxWidthDip, maxHeightDip);
@@ -127,10 +139,12 @@ void GetCandidateCardSize(ComPtr<ICoreWebView2> webview, const wchar_t *boxId, c
             {
                 size = ParseDivSize(result);
             }
+            // The payload is numbers only (no candidate text), so it is safe to log
+            // verbatim and it is the only view of measured-vs-painted width.
             DIAG_LOGF(L"ui-measure box={} parent={} max_dip=({:.1f},{:.1f}) callback_hr={:#x} "
-                      L"result_chars={} measured_dip=({:.2f},{:.2f})",
-                      boxId, parentId, maxWidthDip, maxHeightDip, static_cast<unsigned>(errorCode),
-                      result ? wcslen(result) : 0, size.first, size.second);
+                      L"measured_dip=({:.2f},{:.2f}) raw={}",
+                      boxId, parentId, maxWidthDip, maxHeightDip, static_cast<unsigned>(errorCode), size.first,
+                      size.second, result ? result : L"<null>");
             callback(size);
             return S_OK;
         }).Get());

--- a/server/src/webview2/windows_webview2.cpp
+++ b/server/src/webview2/windows_webview2.cpp
@@ -1932,17 +1932,20 @@ window.ApplyCandidateFrame = function (payload) {
     }
     void container.offsetWidth;
     const rect = container.getBoundingClientRect();
+    // scrollWidth must be part of this: rect/offsetWidth report the clipped box
+    // once .container{overflow-x:hidden} bites, so without it the native region
+    // is built from a width narrower than what is actually painted.
     return {
-      width: Math.max(rect.width, container.offsetWidth || 0) + 1,
-      height: Math.max(rect.height, container.offsetHeight || 0) + 1
+      width: Math.max(rect.width, container.offsetWidth || 0, container.scrollWidth || 0) + 1,
+      height: Math.max(rect.height, container.offsetHeight || 0) + 1,
+      rw: rect.width, ow: container.offsetWidth || 0,
+      sw: container.scrollWidth || 0, cw: container.clientWidth || 0
     };
 };
-if (!document.getElementById('msime-fast-layout')) {
-  const style = document.createElement('style');
-  style.id = 'msime-fast-layout';
-  style.textContent = '.container,.container .text,.row-wrapper,.cand .text{overflow-wrap:normal!important;word-break:keep-all!important;white-space:nowrap!important;}';
-  document.documentElement.appendChild(style);
-}
+// Do NOT force white-space:nowrap on .container/.row-wrapper here. The skin CSS
+// wraps the inline-block candidates at --msime-max-width-dip; pinning them to a
+// single line makes the card outgrow that cap, and .container's overflow-x:hidden
+// then slices the last candidate mid-glyph instead of flowing it onto a new row.
 )";
 
 std::pair<double, double> g_last_candidate_slot_measured_size{};
@@ -2005,6 +2008,10 @@ void SubmitCandidateSlotScript(ComPtr<ICoreWebView2> webview, const std::wstring
             else if (result)
             {
                 g_last_candidate_slot_measured_size = ParseDivSize(result);
+                // Numbers only (no candidate text): shows painted vs reported width.
+                CAND_WEBVIEW_TRACE_LOGF(L"candidate-slot measured_dip=({:.2f},{:.2f}) raw={}",
+                                        g_last_candidate_slot_measured_size.first,
+                                        g_last_candidate_slot_measured_size.second, result);
             }
             g_candidate_slot_update_inflight = false;
             if (!g_candidate_slot_update_pending.empty())
@@ -2513,11 +2520,10 @@ bool ApplyConfiguredCandidateAppearance()
         L"root.style.removeProperty('--cand-text');"
         L"root.style.removeProperty('--cand-num');"
         L"}"
-        L"if(!document.getElementById('msime-fast-layout')){"
-        L"const s=document.createElement('style');s.id='msime-fast-layout';"
-        L"s.textContent='.container,.container .text,.row-wrapper,.cand "
-        L".text{overflow-wrap:normal!important;word-break:keep-all!important;white-space:nowrap!important;}';"
-        L"root.appendChild(s);}"
+        // Drop any stale nowrap fast-layout sheet so the skin's wrap-at-max-width
+        // rules apply; forcing a single line makes the card overflow the cap and
+        // get clipped by .container{overflow-x:hidden}.
+        L"document.getElementById('msime-fast-layout')?.remove();"
         L"})(" +
         string_to_wstring(cfg.dump()) + L");";
     return SUCCEEDED(webviewCandWnd->ExecuteScript(script.c_str(), nullptr));

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -326,6 +326,13 @@ void RefreshCandidateClipAfterPaint(HWND hwnd, uint64_t contentGeneration, ULONG
     if (!hwnd || !::is_global_wnd_cand_shown || !webviewCandWnd ||
         contentGeneration != g_candidate_content_generation.load())
     {
+        // This return used to be silent, which is why a region frozen across every
+        // content-only update never showed up in the trace: clip-measure-drop only
+        // covers the post-measure guard, so the whole refresh vanished without a
+        // line. Never let the clip path fail quietly again.
+        CAND_DIAG_LOGF(L"candidate-frame clip-refresh-skip content_gen={} current_gen={} shown={} webview={} hwnd={}",
+                       contentGeneration, g_candidate_content_generation.load(), ::is_global_wnd_cand_shown,
+                       webviewCandWnd != nullptr, hwnd != nullptr);
         return;
     }
     const HalfScreenDipLimits limits = QueryWebViewHalfScreenDipLimitsForHwnd(hwnd);
@@ -2258,7 +2265,21 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
             frameSignature == g_last_rendered_candidate_signature &&
             updateStartedTick - g_last_rendered_candidate_tick < kCandidateShowDedupWindowMs)
         {
-            CAND_DIAG_LOGF(L"candidate-frame path=dedup content_gen={}", contentGeneration);
+            // A deduped show paints nothing: the DOM still holds exactly the frame
+            // the in-flight measurement was started for. The unconditional bump at
+            // the top of this handler would nevertheless make that measurement look
+            // stale, and both guards below drop it — so every content-only update
+            // lost its SetWindowRgn refresh and the region stayed frozen at the last
+            // full FineTune's width while the DOM kept changing. That is the
+            // right-edge truncation: a wider later page painted past a stale region.
+            // Hand the generation back (only if nobody bumped it since) so the
+            // pending clip still lands. path=superseded above returns before the
+            // bump for the same reason.
+            uint64_t expectedGeneration = contentGeneration;
+            const bool generationRestored =
+                g_candidate_content_generation.compare_exchange_strong(expectedGeneration, contentGeneration - 1);
+            CAND_DIAG_LOGF(L"candidate-frame path=dedup content_gen={} generation_restored={}", contentGeneration,
+                           generationRestored);
             return 0;
         }
         g_last_rendered_candidate_signature = frameSignature;


### PR DESCRIPTION
## 问题

WebView2 后端下，候选窗右边总是被竖着切一刀，而且多半切在最后一个候选上。之前修过多次（CSS 换行、量测取 max、区域加安全边距），都只压住了症状。

## 根因

`WndProcCandWindow` 里 `g_candidate_content_generation` 在处理函数**最顶部无条件自增**，早于下面的去重判断。IME 每次按键会投递两次 show，所以每次按键的时序是：

| 世代 | 路径 | 结果 |
| --- | --- | --- |
| N | `path=content-only` | `InflateCandWnd` 发出 DOM 更新，回调捕获 gen N |
| N+1 | `path=dedup` | 帧签名相同，什么都没画、什么都没排，但计数器留在 N+1 |
| — | gen N 的 `dom-callback` | 发现 `N != N+1`，直接 return |

于是 `SetWindowRgn` **只会被完整的 FineTune 刷新**，裁剪区一直冻结在上一次 FineTune 量到的宽度。后面的候选页一旦更宽，就画到了过期区域之外——右边缘的硬切；更窄时只是多一块看不见的透明留白。这正好解释了为什么永远是右边、永远是最后一个候选、而且时隐时现。

诊断日志（851 行）里的证据：

- `path=content-only`：18 次
- `dom-callback` 世代不匹配：**18/18**
- `clip-measure-submit` / `clip-measure-apply` / `clip-measure-drop`：**全为 0**
- `ui-region`：7 次，全部来自 `path=full-layout`

同时被数据**排除**的嫌疑：区域算术在 7 个样本里逐一验证正确（`margin=25 → region=(15,0)-(761,125)`，`(25+465.28+17)×1.5=761` ✓）；`client.right=1920` 从不成为约束；量测也没有少报（`sw == cw == ow`，`mw:1280` 远未触顶）。

## 修改

1. **`ime_windows.cpp` — 去重分支把世代还回去**（`compare_exchange_strong`，仅在期间无人自增时生效）。一次去重的 show 什么都没画，DOM 里仍然正是那次在途测量对应的帧，所以那次测量不该被判为过期。上面的 `path=superseded` 出于同样的原因本来就在自增之前返回。
2. **`windows_webview2.cpp` — 去掉 `#msime-fast-layout`**：它给 `.container` / `.row-wrapper` 强加 `white-space:nowrap!important`，让卡片长过 `--msime-max-width-dip` 上限，再被 `overflow-x:hidden` 从字中间切开；并在应用外观时 `?.remove()` 清掉历史残留。这是同一个 bug 的另一半。
3. **量测取 `scrollWidth`**：`.container{overflow-x:hidden}` 生效后 `rect`/`offsetWidth` 报的是被裁过的盒子，不带 `scrollWidth` 就会拿一个比实际绘制更窄的宽度去建区域。
4. **恢复诊断可见性**：`webview_utils.cpp` 里 `ui-measure` 日志曾被 `#define` 成空操作，裁剪路径的 `return` 又是静默的——正是这两处的沉默让「区域从不刷新」在日志里毫无痕迹。现在补上 `clip-refresh-skip` 与量测原始 payload（`rw/ow/sw/cw`）。

> 新增日志只记录数字、坐标与状态，**不含任何用户输入或候选文本**，符合 `candidate_diag_log.h` 里的约定。全部挂在既有的 `diagnostic_log` 开关下。

## 验证

- Release 构建通过（仅 `engine/core/data_path.h` 既有的 C4996 `_wgetenv` 警告）
- Debug 构建 exit 0；`ctest -C Debug` **2/2 通过**（`MetasequoiaImeServerTests` 19.40s，`webview_contract` 0.04s）
- 重新打包安装（`Install.ps1 -Light`）后人工输入验证：不再出现右侧截断

## 已知遗留（不在本 PR 范围）

- 页面侧的 `contentTruncated` 自检对候选面永远不会触发（viewport 2073 DIP vs 可见 1280 DIP），属于死逻辑。
- 宿主尺寸在 1920x1044（工作区）与 1920x1080（整屏）之间交替，因为 `ComputeQuarterScreenHostPixels` 拿到的是两个不同的 monitor rect，导致高度上限在两次 show 之间漂移 24 DIP。
