### PR TITLE
fix(settings): 补充字体下拉框的箭头不再显示文本编辑光标

### DIFF
--- a/ui-html/webview2/settings/ime-settings/src/styles/components/dropdown.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/components/dropdown.css
@@ -136,7 +136,8 @@
 }
 
 .font-combobox .arrow,
-.font-combobox .arrow img {
+.font-combobox .arrow img,
+.font-combobox > img {
   cursor: default;
 }
 


### PR DESCRIPTION
## 问题

设置页「候选窗补充字体」的下拉框，鼠标悬浮在右侧箭头上时仍是文本编辑光标；而「候选窗主字体」的下拉框在箭头处是普通指针，两者不一致。

## 原因

主字体的箭头包在 `<div class="arrow">` 容器里，命中了 `.font-combobox .arrow, .font-combobox .arrow img { cursor: default }`；补充字体的箭头是直接挂在按钮上的 `<img>`，选不中，于是 `.font-combobox { cursor: text }` 一路继承到了箭头上。

## 改动

在该规则上补一个 `.font-combobox > img` 选择器，纯样式改动，未改 DOM 结构，现有 appearance 测试不受影响。

## 验证

在设置窗中确认：补充字体下拉框的文本区仍为编辑光标，箭头为普通指针，与主字体一致。