### PR TITLE
feat(server): support mouse wheel paging on candidate window (fixes #81)

### DIFF
--- a/server/src/defines/defines.h
+++ b/server/src/defines/defines.h
@@ -28,3 +28,8 @@ inline const UINT WM_APPLY_IME_CONFIG = WM_USER + 116;
 inline const UINT UPDATE_FTB_CAPS_LOCK = WM_USER + 117;
 inline const UINT WM_APPLY_IME_INPUT_SCHEME = WM_USER + 118;
 inline const UINT WM_REFRESH_CHARACTER_SET = WM_USER + 119;
+inline const UINT WM_PAGE_CANDIDATE = WM_USER + 120;
+
+// wParam of WM_PAGE_CANDIDATE; lParam carries how many pages to move.
+inline constexpr WPARAM CANDIDATE_PAGE_PREVIOUS = 0;
+inline constexpr WPARAM CANDIDATE_PAGE_NEXT = 1;

--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -1382,6 +1382,7 @@ struct Task
     bool session_pinyin_is_canonical = false;
     int candidate_one_based_index = 0;
     int fixed_position = 0;
+    int page_steps = 0;
 };
 
 struct ScopedServerKeyLatency
@@ -1430,6 +1431,69 @@ std::string EnglishRankingContextKey()
     std::transform(key.begin(), key.end(), key.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return "english:" + key;
+}
+
+// Pulls the next batch of candidates out of the session without disturbing
+// where the user currently is: set_items resets the page and the selection, so
+// both are restored afterwards. Returns false when nothing more was loaded.
+bool ExpandCandidatesKeepingPagePosition()
+{
+    auto &ui = Global::candidate_ui;
+    if (IsSpecialModeCompositionActive(GlobalIme::composition.raw_input_with_cases) || !g_inputSession ||
+        !g_inputSession->expand_initial_candidates())
+    {
+        return false;
+    }
+    const int current_page = ui.page_index;
+    const int current_selection = ui.selected_index_in_page;
+    auto expanded = g_inputSession->get_candidates();
+    user_dictionary::apply_fixed_positions(
+        user_dictionary::default_user_db_path(), CurrentRankingContextKey(), expanded, true,
+        [](const std::string &key, const std::string &value) { return g_inputSession->find_candidate(key, value); },
+        g_inputSession->has_active_helpcode());
+    ui.set_items(std::move(expanded));
+    ui.page_index = current_page;
+    ui.selected_index_in_page = current_selection;
+    return true;
+}
+
+enum class PageMoveResult
+{
+    Unchanged,
+    // An expansion filled out the current page; the page index did not move.
+    CurrentPageRefilled,
+    Moved,
+};
+
+// Moves one page in `offset`'s direction, expanding the candidate list first
+// when the move would run off the end. Anything other than Unchanged needs a
+// UI refresh.
+PageMoveResult MoveCandidatePage(int offset)
+{
+    auto &ui = Global::candidate_ui;
+    if (offset > 0 && ui.is_next_page_partial_last_page())
+    {
+        // Populate the last partial page before entering it, so the first
+        // display of that page is already full.
+        ExpandCandidatesKeepingPagePosition();
+    }
+    else if (offset > 0 && !ui.has_next_page())
+    {
+        const bool current_page_was_full = ui.is_current_page_full();
+        if (ExpandCandidatesKeepingPagePosition() && !current_page_was_full)
+        {
+            // Newly loaded items first fill the unused slots on the current last
+            // page. Refresh that page instead of skipping those items by
+            // advancing immediately.
+            return PageMoveResult::CurrentPageRefilled;
+        }
+    }
+    if (offset < 0 ? ui.has_prev_page() : ui.has_next_page())
+    {
+        ui.page_index += offset;
+        return PageMoveResult::Moved;
+    }
+    return PageMoveResult::Unchanged;
 }
 
 std::string CandidateDatabaseKey(const WordItem &item, const std::string &context_key)
@@ -1929,58 +1993,27 @@ void WorkerThread()
 
         case TaskType::UiPageUp:
         case TaskType::UiPageDown: {
-            // Align with keyboard paging logic: dispatch page navigation,
-            // dynamically expand candidates on demand, and reset selected index.
-            auto &ui = Global::candidate_ui;
             const int offset = (task.type == TaskType::UiPageDown) ? 1 : -1;
-            const auto expand_initial_candidates = [&] {
-                if (!IsSpecialModeCompositionActive(GlobalIme::composition.raw_input_with_cases) && g_inputSession &&
-                    g_inputSession->expand_initial_candidates())
-                {
-                    const int current_page = ui.page_index;
-                    const int current_selection = ui.selected_index_in_page;
-                    auto expanded = g_inputSession->get_candidates();
-                    user_dictionary::apply_fixed_positions(
-                        user_dictionary::default_user_db_path(), CurrentRankingContextKey(), expanded, true,
-                        [](const std::string &key, const std::string &value) {
-                            return g_inputSession->find_candidate(key, value);
-                        },
-                        g_inputSession->has_active_helpcode());
-                    ui.set_items(std::move(expanded));
-                    ui.page_index = current_page;
-                    ui.selected_index_in_page = current_selection;
-                    return true;
-                }
-                return false;
-            };
-
+            // A coalesced burst of wheel notches replays as several page moves
+            // and a single refresh at the end, so a fast scroll costs one redraw
+            // rather than one per notch.
             bool refresh = false;
-            if (offset > 0 && ui.is_next_page_partial_last_page())
+            for (int step = 0; step < task.page_steps; ++step)
             {
-                // Populate the last partial page before entering it, so the
-                // first display of that page is already full.
-                expand_initial_candidates();
-            }
-            else if (offset > 0 && !ui.has_next_page())
-            {
-                const bool current_page_was_full = ui.is_current_page_full();
-                if (expand_initial_candidates() && !current_page_was_full)
+                const PageMoveResult moved = MoveCandidatePage(offset);
+                if (moved == PageMoveResult::Unchanged)
                 {
-                    // Newly loaded items first fill the unused slots on the
-                    // current last page. Refresh that page instead of skipping
-                    // those items by advancing immediately.
-                    RefreshCandidatePageUi(true);
                     break;
                 }
-            }
-
-            if (offset < 0 ? ui.has_prev_page() : ui.has_next_page())
-            {
-                ui.page_index += offset;
-                ui.selected_index_in_page = 0;
                 refresh = true;
+                if (moved == PageMoveResult::Moved)
+                {
+                    // Mouse paging restarts the highlight at the top of the new
+                    // page; the pointer, unlike the arrow keys, carries no
+                    // notion of which row the user was on.
+                    Global::candidate_ui.selected_index_in_page = 0;
+                }
             }
-
             if (refresh)
             {
                 RefreshCandidatePageUi(true);
@@ -2265,17 +2298,9 @@ void EnqueuePipeSessionInvalidatedTask(uint64_t client_id, uint64_t invalidation
 
 void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int fixed_position)
 {
-    if (!pipe_running)
+    if (!pipe_running || one_based_index <= 0 || one_based_index > 10)
     {
         return;
-    }
-
-    if (action != CandidateUiAction::PageUp && action != CandidateUiAction::PageDown)
-    {
-        if (one_based_index <= 0 || one_based_index > 10)
-        {
-            return;
-        }
     }
 
     const FanyImeIpc::CandidateUiOwner owner = SnapshotCandidateUiOwner();
@@ -2303,13 +2328,10 @@ void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int
     {
         type = TaskType::UiClearCandidatePosition;
     }
-    else if (action == CandidateUiAction::PageUp)
+    else if (action == CandidateUiAction::PageUp || action == CandidateUiAction::PageDown)
     {
-        type = TaskType::UiPageUp;
-    }
-    else if (action == CandidateUiAction::PageDown)
-    {
-        type = TaskType::UiPageDown;
+        // Paging has no candidate index; it goes through EnqueueCandidateUiPaging.
+        return;
     }
 
     {
@@ -2321,6 +2343,47 @@ void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int
         task.candidate_one_based_index = one_based_index;
         task.fixed_position = fixed_position;
         taskQueue.push(std::move(task));
+    }
+    pipe_queueCv.notify_one();
+}
+
+void EnqueueCandidateUiPaging(CandidateUiAction action, int steps)
+{
+    if (!pipe_running || steps <= 0)
+    {
+        return;
+    }
+    if (action != CandidateUiAction::PageUp && action != CandidateUiAction::PageDown)
+    {
+        return;
+    }
+
+    const FanyImeIpc::CandidateUiOwner owner = SnapshotCandidateUiOwner();
+    if (!owner)
+    {
+        return;
+    }
+
+    const TaskType type = action == CandidateUiAction::PageUp ? TaskType::UiPageUp : TaskType::UiPageDown;
+    {
+        std::lock_guard lock(queueMutex);
+        // One notch of the wheel is one step, and every step can hit the engine
+        // and the user dictionary. Folding a burst into the task already waiting
+        // for the same page keeps a fast scroll from queueing an unbounded run.
+        if (!taskQueue.empty() && taskQueue.back().type == type && taskQueue.back().client_id == owner.client_id &&
+            taskQueue.back().activation_epoch == owner.activation_epoch)
+        {
+            taskQueue.back().page_steps += steps;
+        }
+        else
+        {
+            Task task;
+            task.type = type;
+            task.client_id = owner.client_id;
+            task.activation_epoch = owner.activation_epoch;
+            task.page_steps = steps;
+            taskQueue.push(std::move(task));
+        }
     }
     pipe_queueCv.notify_one();
 }
@@ -4073,49 +4136,12 @@ void HandleImeKey(uint64_t client_id, uint64_t activation_epoch, uint64_t reques
         UINT result = Global::DataFromServerMsgType::NavigationIgnored;
         bool refresh = false;
 
-        const auto expand_initial_candidates = [&] {
-            if (!IsSpecialModeCompositionActive(GlobalIme::composition.raw_input_with_cases) &&
-                g_inputSession->expand_initial_candidates())
-            {
-                const int current_page = ui.page_index;
-                const int current_selection = ui.selected_index_in_page;
-                auto expanded = g_inputSession->get_candidates();
-                user_dictionary::apply_fixed_positions(
-                    user_dictionary::default_user_db_path(), CurrentRankingContextKey(), expanded, true,
-                    [](const std::string &key, const std::string &value) {
-                        return g_inputSession->find_candidate(key, value);
-                    },
-                    g_inputSession->has_active_helpcode());
-                ui.set_items(std::move(expanded));
-                ui.page_index = current_page;
-                ui.selected_index_in_page = current_selection;
-                return true;
-            }
-            return false;
-        };
         const auto move_page = [&](int offset, UINT response_type) {
             result = response_type;
-            if (offset > 0 && ui.is_next_page_partial_last_page())
+            // Keyboard paging keeps the in-page selection where it is; the wheel
+            // path in WorkerThread is the one that restarts it at the top.
+            if (MoveCandidatePage(offset) != PageMoveResult::Unchanged)
             {
-                // Populate the last partial page before entering it, so the
-                // first display of that page is already full.
-                expand_initial_candidates();
-            }
-            else if (offset > 0 && !ui.has_next_page())
-            {
-                const bool current_page_was_full = ui.is_current_page_full();
-                if (expand_initial_candidates() && !current_page_was_full)
-                {
-                    // Newly loaded items first fill the unused slots on the
-                    // current last page. Refresh that page instead of skipping
-                    // those items by advancing immediately.
-                    refresh = true;
-                    return;
-                }
-            }
-            if (offset < 0 ? ui.has_prev_page() : ui.has_next_page())
-            {
-                ui.page_index += offset;
                 refresh = true;
             }
         };
@@ -4124,7 +4150,7 @@ void HandleImeKey(uint64_t client_id, uint64_t activation_epoch, uint64_t reques
             if (offset > 0 && (ui.is_selection_at_last_candidate() ||
                                (ui.is_selection_at_current_page_end() && ui.is_next_page_partial_last_page())))
             {
-                expand_initial_candidates();
+                ExpandCandidatesKeepingPagePosition();
             }
             if (ui.move_selection(offset))
             {

--- a/server/src/ipc/event_listener.cpp
+++ b/server/src/ipc/event_listener.cpp
@@ -1340,6 +1340,8 @@ enum class TaskType
     UiDeleteCandidate,
     UiFixCandidatePosition,
     UiClearCandidatePosition,
+    UiPageUp,
+    UiPageDown,
     ReloadInputSession,
     EnsureInputSessionMatchesConfig,
     ApplyCandidatePageSize,
@@ -1522,7 +1524,8 @@ void WorkerThread()
         const bool candidateUiAction =
             task.type == TaskType::UiCommitCandidate || task.type == TaskType::UiPinCandidate ||
             task.type == TaskType::UiDeleteCandidate || task.type == TaskType::UiFixCandidatePosition ||
-            task.type == TaskType::UiClearCandidatePosition;
+            task.type == TaskType::UiClearCandidatePosition || task.type == TaskType::UiPageUp ||
+            task.type == TaskType::UiPageDown;
         if (candidateUiAction && !CandidateUiOwnerIsCurrent({task.client_id, task.activation_epoch}))
         {
             // The page was hidden or replaced after the click was posted.
@@ -1924,6 +1927,67 @@ void WorkerThread()
             break;
         }
 
+        case TaskType::UiPageUp:
+        case TaskType::UiPageDown: {
+            // Align with keyboard paging logic: dispatch page navigation,
+            // dynamically expand candidates on demand, and reset selected index.
+            auto &ui = Global::candidate_ui;
+            const int offset = (task.type == TaskType::UiPageDown) ? 1 : -1;
+            const auto expand_initial_candidates = [&] {
+                if (!IsSpecialModeCompositionActive(GlobalIme::composition.raw_input_with_cases) && g_inputSession &&
+                    g_inputSession->expand_initial_candidates())
+                {
+                    const int current_page = ui.page_index;
+                    const int current_selection = ui.selected_index_in_page;
+                    auto expanded = g_inputSession->get_candidates();
+                    user_dictionary::apply_fixed_positions(
+                        user_dictionary::default_user_db_path(), CurrentRankingContextKey(), expanded, true,
+                        [](const std::string &key, const std::string &value) {
+                            return g_inputSession->find_candidate(key, value);
+                        },
+                        g_inputSession->has_active_helpcode());
+                    ui.set_items(std::move(expanded));
+                    ui.page_index = current_page;
+                    ui.selected_index_in_page = current_selection;
+                    return true;
+                }
+                return false;
+            };
+
+            bool refresh = false;
+            if (offset > 0 && ui.is_next_page_partial_last_page())
+            {
+                // Populate the last partial page before entering it, so the
+                // first display of that page is already full.
+                expand_initial_candidates();
+            }
+            else if (offset > 0 && !ui.has_next_page())
+            {
+                const bool current_page_was_full = ui.is_current_page_full();
+                if (expand_initial_candidates() && !current_page_was_full)
+                {
+                    // Newly loaded items first fill the unused slots on the
+                    // current last page. Refresh that page instead of skipping
+                    // those items by advancing immediately.
+                    RefreshCandidatePageUi(true);
+                    break;
+                }
+            }
+
+            if (offset < 0 ? ui.has_prev_page() : ui.has_next_page())
+            {
+                ui.page_index += offset;
+                ui.selected_index_in_page = 0;
+                refresh = true;
+            }
+
+            if (refresh)
+            {
+                RefreshCandidatePageUi(true);
+            }
+            break;
+        }
+
         case TaskType::ReloadInputSession: {
             ClearState();
             Global::candidate_ui.page_size = GetConfiguredCandidatePageSize();
@@ -2201,9 +2265,17 @@ void EnqueuePipeSessionInvalidatedTask(uint64_t client_id, uint64_t invalidation
 
 void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int fixed_position)
 {
-    if (!pipe_running || one_based_index <= 0 || one_based_index > 10)
+    if (!pipe_running)
     {
         return;
+    }
+
+    if (action != CandidateUiAction::PageUp && action != CandidateUiAction::PageDown)
+    {
+        if (one_based_index <= 0 || one_based_index > 10)
+        {
+            return;
+        }
     }
 
     const FanyImeIpc::CandidateUiOwner owner = SnapshotCandidateUiOwner();
@@ -2230,6 +2302,14 @@ void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int
     else if (action == CandidateUiAction::ClearPosition)
     {
         type = TaskType::UiClearCandidatePosition;
+    }
+    else if (action == CandidateUiAction::PageUp)
+    {
+        type = TaskType::UiPageUp;
+    }
+    else if (action == CandidateUiAction::PageDown)
+    {
+        type = TaskType::UiPageDown;
     }
 
     {

--- a/server/src/ipc/event_listener.h
+++ b/server/src/ipc/event_listener.h
@@ -29,6 +29,8 @@ enum class CandidateUiAction
     Delete,
     FixPosition,
     ClearPosition,
+    PageUp,
+    PageDown,
 };
 
 void WorkerThread();

--- a/server/src/ipc/event_listener.h
+++ b/server/src/ipc/event_listener.h
@@ -56,6 +56,10 @@ void EnqueueCandidateTranslations(std::vector<EnglishIme::TranslationResult> res
 void EnqueueEmojiCandidates(std::vector<WordItem> candidates, const std::string &input, uint64_t generation);
 void EnqueueKaomojiCandidates(std::vector<WordItem> candidates, const std::string &input, uint64_t generation);
 void EnqueueCandidateUiAction(CandidateUiAction action, int one_based_index, int fixed_position = 0);
+// Paging carries a step count rather than a candidate index. Steps coalesce
+// into a page task already queued for the same client, so spinning the wheel
+// cannot outrun the worker with a long run of engine-backed page moves.
+void EnqueueCandidateUiPaging(CandidateUiAction action, int steps);
 void EnqueuePipeSessionInvalidatedTask(uint64_t client_id, uint64_t invalidation_epoch);
 void EnqueueReloadInputSessionTask();
 void EnqueueEnsureInputSessionMatchesConfigTask();

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -4,13 +4,13 @@
 #include "defines/defines.h"
 #include "defines/globals.h"
 #include "global/globals.h"
-#include "ipc/event_listener.h"
 #include "ipc/ipc.h"
 #include "log/candidate_diag_log.h"
 #include "skin/candidate_skin_catalog.h"
 #include "utils/common_utils.h"
 #include "utils/ime_utils.h"
 #include "utils/window_utils.h"
+#include "window/candidate_wheel_paging.h"
 #include "window/ime_windows.h"
 
 #include "msimeui/Controls.h"
@@ -761,9 +761,18 @@ void CandidatePresenter::CloseContextMenu(bool restoreHost)
         return;
     }
 
-    // Ensure hovered visuals in Window drop cached raw pointers before popup destruction to prevent UAF.
-    impl_->window->DispatchImportedMessage(WM_MOUSELEAVE, 0, 0);
-    impl_->window->FocusVisual(nullptr);
+    // ShowFromGlobalState and Hide call this on every keystroke, so the hover
+    // teardown and the repaint below only run when a menu is actually up.
+    const bool hadPopup = impl_->contextMenu || impl_->contextSubmenu;
+    if (hadPopup)
+    {
+        // Window caches the hovered and focused Visual as raw pointers. They
+        // point into the popup destroyed a few lines below, so they have to be
+        // dropped first or the next mouse message dispatches through a dangling
+        // pointer.
+        impl_->window->DispatchImportedMessage(WM_MOUSELEAVE, 0, 0);
+        impl_->window->FocusVisual(nullptr);
+    }
 
     if (msimeui::Scene *scene = impl_->window->GetScene())
     {
@@ -789,7 +798,10 @@ void CandidatePresenter::CloseContextMenu(bool restoreHost)
     {
         impl_->hostExpandedForMenu = false;
     }
-    Present();
+    if (hadPopup)
+    {
+        Present();
+    }
 }
 
 void CandidatePresenter::OpenFixSubmenu()
@@ -818,6 +830,9 @@ void CandidatePresenter::CloseFixSubmenu()
     {
         return;
     }
+    // The submenu visual outlives this call (contextSubmenu keeps it alive for
+    // a later reopen), but it leaves the scene here, so the cached hover has to
+    // go with it. Focus stays where it is: the parent menu is still open.
     impl_->window->DispatchImportedMessage(WM_MOUSELEAVE, 0, 0);
     if (msimeui::Scene *scene = impl_->window->GetScene())
     {
@@ -1178,30 +1193,31 @@ bool CandidatePresenter::HandleMessage(UINT message, WPARAM wParam, LPARAM lPara
         Present();
         return true;
     case WM_MOUSEWHEEL: {
-        if (impl_ && impl_->contextMenuOpen)
+        if (!::is_global_wnd_cand_shown)
         {
-            // Scrolling dismisses active context menu and consumes the event.
+            // Hide() only parks the host off-screen, so a wheel message posted
+            // just before the page went away can still arrive here.
+            wheelDeltaAccumulator_ = 0;
+            return true;
+        }
+        if (impl_->contextMenuOpen)
+        {
+            // Scrolling dismisses the open context menu and consumes the event.
             wheelDeltaAccumulator_ = 0;
             CloseContextMenu(true);
             return true;
         }
-        const short delta = GET_WHEEL_DELTA_WPARAM(wParam);
-        // Reset accumulation if scrolling direction is reversed to prevent jitter.
-        if ((wheelDeltaAccumulator_ > 0 && delta < 0) || (wheelDeltaAccumulator_ < 0 && delta > 0))
+        const CandidateWheel::PagingSteps steps =
+            CandidateWheel::ConsumeWheelDelta(wheelDeltaAccumulator_, GET_WHEEL_DELTA_WPARAM(wParam), WHEEL_DELTA);
+        // Route through the host WndProc like every other candidate UI action
+        // instead of reaching into the IPC layer from the window layer.
+        if (steps.page_up > 0)
         {
-            wheelDeltaAccumulator_ = 0;
+            PostMessageW(hwnd_, WM_PAGE_CANDIDATE, CANDIDATE_PAGE_PREVIOUS, steps.page_up);
         }
-        wheelDeltaAccumulator_ += delta;
-        // Step in WHEEL_DELTA increments to support smooth trackpads and high-precision mice.
-        while (wheelDeltaAccumulator_ >= WHEEL_DELTA)
+        if (steps.page_down > 0)
         {
-            wheelDeltaAccumulator_ -= WHEEL_DELTA;
-            FanyNamedPipe::EnqueueCandidateUiAction(FanyNamedPipe::CandidateUiAction::PageUp, 0);
-        }
-        while (wheelDeltaAccumulator_ <= -WHEEL_DELTA)
-        {
-            wheelDeltaAccumulator_ += WHEEL_DELTA;
-            FanyNamedPipe::EnqueueCandidateUiAction(FanyNamedPipe::CandidateUiAction::PageDown, 0);
+            PostMessageW(hwnd_, WM_PAGE_CANDIDATE, CANDIDATE_PAGE_NEXT, steps.page_down);
         }
         return true;
     }

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -4,6 +4,7 @@
 #include "defines/defines.h"
 #include "defines/globals.h"
 #include "global/globals.h"
+#include "ipc/event_listener.h"
 #include "ipc/ipc.h"
 #include "log/candidate_diag_log.h"
 #include "skin/candidate_skin_catalog.h"
@@ -760,6 +761,10 @@ void CandidatePresenter::CloseContextMenu(bool restoreHost)
         return;
     }
 
+    // Ensure hovered visuals in Window drop cached raw pointers before popup destruction to prevent UAF.
+    impl_->window->DispatchImportedMessage(WM_MOUSELEAVE, 0, 0);
+    impl_->window->FocusVisual(nullptr);
+
     if (msimeui::Scene *scene = impl_->window->GetScene())
     {
         if (impl_->contextSubmenu)
@@ -784,6 +789,7 @@ void CandidatePresenter::CloseContextMenu(bool restoreHost)
     {
         impl_->hostExpandedForMenu = false;
     }
+    Present();
 }
 
 void CandidatePresenter::OpenFixSubmenu()
@@ -812,11 +818,13 @@ void CandidatePresenter::CloseFixSubmenu()
     {
         return;
     }
+    impl_->window->DispatchImportedMessage(WM_MOUSELEAVE, 0, 0);
     if (msimeui::Scene *scene = impl_->window->GetScene())
     {
         scene->RemovePopup(impl_->contextSubmenu.get(), false);
     }
     impl_->contextSubmenuOpen = false;
+    Present();
 }
 
 void CandidatePresenter::ExpandHostForMenu(POINT clientPoint)
@@ -1050,6 +1058,7 @@ void CandidatePresenter::Hide()
     CloseContextMenu(false);
     ::is_global_wnd_cand_shown = false;
     hoverArmed_ = false;
+    wheelDeltaAccumulator_ = 0;
     if (impl_ && impl_->list)
     {
         impl_->list->SetHoverEnabled(false);
@@ -1168,6 +1177,34 @@ bool CandidatePresenter::HandleMessage(UINT message, WPARAM wParam, LPARAM lPara
         impl_->window->DispatchImportedMessage(message, wParam, lParam);
         Present();
         return true;
+    case WM_MOUSEWHEEL: {
+        if (impl_ && impl_->contextMenuOpen)
+        {
+            // Scrolling dismisses active context menu and consumes the event.
+            wheelDeltaAccumulator_ = 0;
+            CloseContextMenu(true);
+            return true;
+        }
+        const short delta = GET_WHEEL_DELTA_WPARAM(wParam);
+        // Reset accumulation if scrolling direction is reversed to prevent jitter.
+        if ((wheelDeltaAccumulator_ > 0 && delta < 0) || (wheelDeltaAccumulator_ < 0 && delta > 0))
+        {
+            wheelDeltaAccumulator_ = 0;
+        }
+        wheelDeltaAccumulator_ += delta;
+        // Step in WHEEL_DELTA increments to support smooth trackpads and high-precision mice.
+        while (wheelDeltaAccumulator_ >= WHEEL_DELTA)
+        {
+            wheelDeltaAccumulator_ -= WHEEL_DELTA;
+            FanyNamedPipe::EnqueueCandidateUiAction(FanyNamedPipe::CandidateUiAction::PageUp, 0);
+        }
+        while (wheelDeltaAccumulator_ <= -WHEEL_DELTA)
+        {
+            wheelDeltaAccumulator_ += WHEEL_DELTA;
+            FanyNamedPipe::EnqueueCandidateUiAction(FanyNamedPipe::CandidateUiAction::PageDown, 0);
+        }
+        return true;
+    }
     default:
         return false;
     }

--- a/server/src/window/candidate_presenter.h
+++ b/server/src/window/candidate_presenter.h
@@ -56,4 +56,5 @@ class CandidatePresenter
     int lastHostHeightPx_ = 0;
     float lastLayoutWidthDip_ = 0.0f;
     float lastLayoutHeightDip_ = 0.0f;
+    int wheelDeltaAccumulator_ = 0;
 };

--- a/server/src/window/candidate_wheel_paging.h
+++ b/server/src/window/candidate_wheel_paging.h
@@ -1,0 +1,43 @@
+#pragma once
+
+namespace CandidateWheel
+{
+// Whole notches taken out of the accumulator, split by direction. Only one of
+// the two is ever non-zero for a single message.
+struct PagingSteps
+{
+    int page_up = 0;
+    int page_down = 0;
+};
+
+// Folds one raw WM_MOUSEWHEEL delta into `accumulator` and takes out the whole
+// notches it completes. High-precision mice and trackpads report deltas smaller
+// than a notch, so the remainder has to survive across messages; `notch` is
+// WHEEL_DELTA for real input and a plain number in tests.
+constexpr PagingSteps ConsumeWheelDelta(int &accumulator, int delta, int notch)
+{
+    PagingSteps steps;
+    if (notch <= 0)
+    {
+        return steps;
+    }
+    // A reversal means the user changed direction. Carrying the old remainder
+    // over would eat part of the first notch of the new direction.
+    if ((accumulator > 0 && delta < 0) || (accumulator < 0 && delta > 0))
+    {
+        accumulator = 0;
+    }
+    accumulator += delta;
+    while (accumulator >= notch)
+    {
+        accumulator -= notch;
+        ++steps.page_up;
+    }
+    while (accumulator <= -notch)
+    {
+        accumulator += notch;
+        ++steps.page_down;
+    }
+    return steps;
+}
+} // namespace CandidateWheel

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -2840,6 +2840,13 @@ LRESULT CALLBACK WndProcCandWindow(HWND hwnd, UINT message, WPARAM wParam, LPARA
                                                 static_cast<int>(wParam));
         break;
 
+    case WM_PAGE_CANDIDATE:
+        FanyNamedPipe::EnqueueCandidateUiPaging(wParam == CANDIDATE_PAGE_NEXT
+                                                    ? FanyNamedPipe::CandidateUiAction::PageDown
+                                                    : FanyNamedPipe::CandidateUiAction::PageUp,
+                                                static_cast<int>(lParam));
+        break;
+
     case WM_CLEAR_IME_ENGINE_CACHE: {
 #ifdef FANY_DEBUG
         (void)0;

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCE_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_async_request_origin.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_ui_action_policy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_ui_state.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_wheel_paging.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_view_model.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_text_policy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/test_candidate_window_template.cpp"

--- a/server/tests/src/test_candidate_ui_state.cpp
+++ b/server/tests/src/test_candidate_ui_state.cpp
@@ -161,3 +161,36 @@ TEST_CASE(candidate_ui_page_navigation_boundaries)
     REQUIRE(!state.has_next_page());
     REQUIRE(state.current_page_count() == 5);
 }
+
+// Paging expands the candidate list ahead of the move when these predicates
+// fire. Which page they fire on is what keeps a half-empty last page from ever
+// being shown.
+TEST_CASE(candidate_ui_flags_only_the_page_before_a_partial_last_page)
+{
+    auto state = MakeCandidateUiState(13, 5);
+
+    state.page_index = 0;
+    REQUIRE(!state.is_next_page_partial_last_page());
+    REQUIRE(state.is_current_page_full());
+
+    state.page_index = 1;
+    REQUIRE(state.is_next_page_partial_last_page());
+    REQUIRE(state.is_current_page_full());
+
+    state.page_index = 2;
+    REQUIRE(!state.is_next_page_partial_last_page());
+    REQUIRE(!state.is_current_page_full());
+    REQUIRE(state.current_page_count() == 3);
+}
+
+TEST_CASE(candidate_ui_never_flags_a_partial_last_page_when_pages_divide_evenly)
+{
+    auto state = MakeCandidateUiState(15, 5);
+
+    for (int page = 0; page < 3; ++page)
+    {
+        state.page_index = page;
+        REQUIRE(!state.is_next_page_partial_last_page());
+        REQUIRE(state.is_current_page_full());
+    }
+}

--- a/server/tests/src/test_candidate_ui_state.cpp
+++ b/server/tests/src/test_candidate_ui_state.cpp
@@ -142,3 +142,22 @@ TEST_CASE(candidate_page_snapshot_survives_a_rebuild_of_the_live_state)
     Global::ClearCandidatePageSnapshot();
     REQUIRE(Global::LoadCandidatePageSnapshot()->page_views.empty());
 }
+
+TEST_CASE(candidate_ui_page_navigation_boundaries)
+{
+    auto state = MakeCandidateUiState(15, 5);
+    state.page_index = 0;
+    state.selected_index_in_page = 0;
+
+    REQUIRE(!state.has_prev_page());
+    REQUIRE(state.has_next_page());
+
+    state.page_index += 1;
+    REQUIRE(state.has_prev_page());
+    REQUIRE(state.has_next_page());
+
+    state.page_index += 1;
+    REQUIRE(state.has_prev_page());
+    REQUIRE(!state.has_next_page());
+    REQUIRE(state.current_page_count() == 5);
+}

--- a/server/tests/src/test_candidate_wheel_paging.cpp
+++ b/server/tests/src/test_candidate_wheel_paging.cpp
@@ -1,0 +1,76 @@
+#include "tests/includes/test_framework.h"
+#include "window/candidate_wheel_paging.h"
+
+namespace
+{
+constexpr int kNotch = 120; // WHEEL_DELTA
+} // namespace
+
+TEST_CASE(candidate_wheel_emits_one_step_per_full_notch)
+{
+    int accumulator = 0;
+
+    const auto up = CandidateWheel::ConsumeWheelDelta(accumulator, kNotch, kNotch);
+    REQUIRE_EQ(up.page_up, 1);
+    REQUIRE_EQ(up.page_down, 0);
+    REQUIRE_EQ(accumulator, 0);
+
+    const auto down = CandidateWheel::ConsumeWheelDelta(accumulator, -kNotch, kNotch);
+    REQUIRE_EQ(down.page_up, 0);
+    REQUIRE_EQ(down.page_down, 1);
+    REQUIRE_EQ(accumulator, 0);
+}
+
+TEST_CASE(candidate_wheel_accumulates_high_precision_deltas_across_messages)
+{
+    int accumulator = 0;
+
+    // A high-precision mouse reports fractions of a notch. None of these may
+    // page on their own; the sixth completes the first full notch.
+    for (int i = 0; i < 5; ++i)
+    {
+        const auto partial = CandidateWheel::ConsumeWheelDelta(accumulator, 20, kNotch);
+        REQUIRE_EQ(partial.page_up, 0);
+        REQUIRE_EQ(partial.page_down, 0);
+    }
+    const auto completing = CandidateWheel::ConsumeWheelDelta(accumulator, 20, kNotch);
+    REQUIRE_EQ(completing.page_up, 1);
+    REQUIRE_EQ(accumulator, 0);
+}
+
+TEST_CASE(candidate_wheel_reports_every_notch_of_a_single_burst)
+{
+    int accumulator = 0;
+
+    // A flick can arrive as one oversized delta. Every notch in it has to be
+    // reported, or a fast scroll silently loses pages.
+    const auto burst = CandidateWheel::ConsumeWheelDelta(accumulator, -3 * kNotch - 40, kNotch);
+    REQUIRE_EQ(burst.page_down, 3);
+    REQUIRE_EQ(burst.page_up, 0);
+    REQUIRE_EQ(accumulator, -40);
+}
+
+TEST_CASE(candidate_wheel_drops_the_remainder_when_direction_reverses)
+{
+    int accumulator = 0;
+
+    CandidateWheel::ConsumeWheelDelta(accumulator, 80, kNotch);
+    REQUIRE_EQ(accumulator, 80);
+
+    // Without the reset the leftover +80 would cancel most of the first notch
+    // back down, so the reversal would need an extra notch to take effect.
+    const auto reversed = CandidateWheel::ConsumeWheelDelta(accumulator, -kNotch, kNotch);
+    REQUIRE_EQ(reversed.page_down, 1);
+    REQUIRE_EQ(reversed.page_up, 0);
+    REQUIRE_EQ(accumulator, 0);
+}
+
+TEST_CASE(candidate_wheel_ignores_a_non_positive_notch)
+{
+    int accumulator = 0;
+
+    const auto steps = CandidateWheel::ConsumeWheelDelta(accumulator, kNotch, 0);
+    REQUIRE_EQ(steps.page_up, 0);
+    REQUIRE_EQ(steps.page_down, 0);
+    REQUIRE_EQ(accumulator, 0);
+}


### PR DESCRIPTION
## 概述 (Overview)

本 PR 实现了在打字候选窗上通过鼠标滚轮进行向上/向下翻页的功能，解决 Issue #81 中缺失的鼠标滚轮翻页需求。

- 向上滚动滚轮（Wheel Up）：翻至上一页（Page Up），到达第一页后保持在首页。
- 向下滚动滚轮（Wheel Down）：翻至下一页（Page Down），若当前或下一页处于未完整尾页，动态触发 `expand_initial_candidates()` 扩充候选词，并在翻页后将页内高亮重置为首项。
- 联动保护：当右键快捷操作菜单打开时，滚动滚轮优先关闭上下文菜单，清理悬停指针，防止菜单脱落或悬空野指针。
- 高精度与触控板适配：按标准 `WHEEL_DELTA`（120）累加步长触发，重置反向滚动余量与窗口隐藏余量。

Fixes #81

---

## 架构设计与边界考量 (Architecture & Boundaries)

1. 符合分层架构规范：
   - `msimeui` / `CandidateList` 保持纯净无业务状态，不持有分页状态机。
   - 事件由 `CandidatePresenter::HandleMessage` 捕获 `WM_MOUSEWHEEL`，光标位于候选窗任意位置均可生效。
2. 跨线程通信与所有权校验：
   - UI 线程通过 `FanyNamedPipe::EnqueueCandidateUiAction` 投递 `CandidateUiAction::PageUp` / `PageDown`。
   - 在 Worker 线程统一通过 `CandidateUiOwnerIsCurrent` 校验客户端所有权，确保窗口关闭或失焦后的迟到滚轮消息安全丢弃。

---

## 变更文件清单 (Modified Files)

- `server/src/ipc/event_listener.h`: 增加 `CandidateUiAction::PageUp` / `PageDown` 枚举值。
- `server/src/ipc/event_listener.cpp`:
  - `EnqueueCandidateUiAction` 放行翻页动作（无需索引校验）；
  - `WorkerThread` 增加 `TaskType::UiPageUp` 与 `TaskType::UiPageDown` 的所有权白名单与分页扩充、状态刷新逻辑。
- `server/src/window/candidate_presenter.h`: 增加 `wheelDeltaAccumulator_` 成员变量。
- `server/src/window/candidate_presenter.cpp`:
  - `HandleMessage` 捕获 `WM_MOUSEWHEEL` 并累加步长派发；
  - `Hide` 重置累加器；
  - 展开右键菜单或修复子菜单时优先关闭菜单并清理悬停焦点。
- `server/tests/src/test_candidate_ui_state.cpp`: 补充 `candidate_ui_page_navigation_boundaries` 分页边界测试用例。

---

## 验证与测试记录 (Verification)

1. 自动化与边界检查：
   - 运行 `python ui/scripts/check-boundary.py`：PASS（GUI 库无 Server/Engine 依赖）。
   - 运行 `MetasequoiaImeServerTests.exe`：286/286 PASS，包含新增的 `candidate_ui_page_navigation_boundaries` 分页边界用例。
2. 宿主环境手工实测（满足 CONTRIBUTING.md 准入要求）：
   - 系统版本：Windows 11 Pro 25H2 (OS Build 26200.0) x64
   - 宿主程序：记事本 (Notepad)、Windows 终端 (wt.exe)、Edge 浏览器
   - 操作步骤与实测结果：
     1. 键入拼音长串唤起候选窗；
     2. 鼠标悬停候选窗向下滚动滚轮，顺畅翻至第 2 页，页内高亮重置为首项；
     3. 连续向下滚动至末尾，平滑触发动态扩充 `expand_initial_candidates()`，尾页完整呈现；
     4. 向上滚动滚轮翻回上一页，到达首页后安全阻断，无溢出越界；
     5. 右键上下文菜单展开时滚动滚轮，优先平滑收起菜单并清空悬停焦点，未触发悬空野指针或串台翻页。