### PR TITLE
feat(server): 设置窗口关闭后先隐藏，十分钟后才真正退出

### DIFF
--- a/server/src/settings/settings_app.cpp
+++ b/server/src/settings/settings_app.cpp
@@ -51,7 +51,11 @@ constexpr UINT kActivateExistingWindow = WM_APP + 1;
 constexpr UINT kOpenAboutSection = WM_APP + 2;
 constexpr UINT kScanSkinCatalog = WM_APP + 3;
 constexpr UINT kWorkerCompleted = WM_APP + 4;
+constexpr UINT kQuitSettings = WM_APP + 5;
 constexpr UINT_PTR kConfigReloadTimer = 1;
+constexpr UINT_PTR kLingerTimer = 2;
+// 关闭窗口先只隐藏，进程留着已导航完成的 WebView2；这段时间内重新打开就不用再冷启动一次。
+constexpr UINT kLingerTimeoutMs = 10 * 60 * 1000;
 
 ComPtr<ICoreWebView2Controller> g_controller;
 ComPtr<ICoreWebView2CompositionController> g_composition_controller;
@@ -73,11 +77,13 @@ std::optional<CandidateSkinCatalog::ScanResult> g_candidate_skin_catalog;
 uint64_t g_candidate_skin_catalog_revision = 0;
 std::unique_ptr<SerialTaskQueue> g_worker;
 bool g_closing = false;
+bool g_lingering = false;
 bool g_reload_pending = false;
 bool g_settings_light = false;
 std::wstring g_last_config_message;
 bool g_worker_com_initialized = false; // worker-only
 void CloseSettings(HWND hwnd);
+void HideSettings(HWND hwnd);
 
 nlohmann::json CandidateColorsToJson(const CandidateSkinCatalog::CandidateColors &colors)
 {
@@ -835,7 +841,7 @@ void HandleWebMessage(HWND hwnd, ICoreWebView2WebMessageReceivedEventArgs *args)
             else if (command == "restore")
                 ShowWindow(hwnd, SW_RESTORE);
             else if (command == "close")
-                CloseSettings(hwnd);
+                HideSettings(hwnd);
         }
         else if (type == "maximizeButtonRect")
         {
@@ -1225,10 +1231,31 @@ int TopNonClientInset(HWND hwnd)
            GetSystemMetricsForDpi(SM_CXPADDEDBORDER, dpi);
 }
 
+// 首帧之前隐藏 WebView2 会卡住 raster 初始化，预热阶段不要碰可见性。
+void SetWebViewVisible(bool visible)
+{
+    if (g_controller && g_webview_content_started)
+        g_controller->put_IsVisible(visible ? TRUE : FALSE);
+}
+
+// 重新露面：取消延迟退出，恢复渲染与配置轮询。
+void CancelLinger(HWND hwnd)
+{
+    if (!g_lingering)
+        return;
+    g_lingering = false;
+    KillTimer(hwnd, kLingerTimer);
+    SetWebViewVisible(true);
+    if (g_webview3)
+        g_webview3->Resume();
+    SetTimer(hwnd, kConfigReloadTimer, 300, nullptr);
+}
+
 void ActivateWindow(HWND hwnd)
 {
     if (g_closing)
         return;
+    CancelLinger(hwnd);
     if (IsIconic(hwnd))
         ShowWindow(hwnd, SW_RESTORE);
     else
@@ -1237,11 +1264,44 @@ void ActivateWindow(HWND hwnd)
     SetFocus(hwnd);
 }
 
+// 用户关闭窗口时走这里：只隐藏，进程继续持有导航完成的 WebView2，kLingerTimeoutMs
+// 之后才真正退出。隐藏期间停掉配置轮询并让 controller 不可见，避免白拿 CPU。
+// 首帧还没出来就被关掉，说明用户不想等这次冷启动，直接退出，别留一个半初始化的进程。
+void HideSettings(HWND hwnd)
+{
+    if (g_closing)
+        return;
+    if (!g_webview_content_started)
+    {
+        CloseSettings(hwnd);
+        return;
+    }
+    if (g_lingering)
+    {
+        ShowWindow(hwnd, SW_HIDE);
+        return;
+    }
+    g_lingering = true;
+    // 窗口隐藏时保留的那一帧会在下次打开时先显示出来，带着高亮的标题栏按钮就会闪一下。
+    // 页面自己的关闭按钮已经在点击时清过，这里覆盖 Alt+F4、启动图的关闭按钮等不经过页面的路径。
+    ResetTitlebarHoverAfterVisibilityChange();
+    // 隐藏的窗口收不到 WM_NCMOUSELEAVE，本地这份悬停状态要手动清掉，
+    // 否则下次真的移进去时不会再发 enter。
+    g_maximize_button_hover = false;
+    KillTimer(hwnd, kConfigReloadTimer);
+    SettingsSplash::Dismiss();
+    ShowWindow(hwnd, SW_HIDE);
+    SetWebViewVisible(false);
+    SetTimer(hwnd, kLingerTimer, kLingerTimeoutMs, nullptr);
+}
+
 void CloseSettings(HWND hwnd)
 {
     if (g_closing)
         return;
     g_closing = true;
+    g_lingering = false;
+    KillTimer(hwnd, kLingerTimer);
     KillTimer(hwnd, kConfigReloadTimer);
     SettingsSplash::Dismiss();
     ShowWindow(hwnd, SW_HIDE);
@@ -1400,6 +1460,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM w_param, LPARAM l_pa
         break;
     }
     case WM_TIMER:
+        if (w_param == kLingerTimer)
+        {
+            CloseSettings(hwnd);
+            return 0;
+        }
         if (w_param == kConfigReloadTimer && g_worker && !g_closing && !g_reload_pending)
         {
             g_reload_pending = true;
@@ -1430,12 +1495,17 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM w_param, LPARAM l_pa
         }
         return 0;
     case WM_CLOSE:
+        HideSettings(hwnd);
+        return 0;
+    case kQuitSettings:
         CloseSettings(hwnd);
         return 0;
     case WM_DESTROY:
         g_closing = true;
+        g_lingering = false;
         if (g_worker)
             g_worker->Stop();
+        KillTimer(hwnd, kLingerTimer);
         KillTimer(hwnd, kConfigReloadTimer);
         SettingsSplash::Dismiss();
         g_webview.Reset();

--- a/server/src/settings/settings_launcher.cpp
+++ b/server/src/settings/settings_launcher.cpp
@@ -11,7 +11,9 @@ constexpr wchar_t kSettingsWindowClass[] = L"MetasequoiaImeSettingsWindow";
 constexpr wchar_t kEmojiPanelWindowClass[] = L"msimeui.EmojiPanel";
 constexpr wchar_t kKeyboardPanelWindowClass[] = L"msimeui.KeyboardDemo";
 constexpr wchar_t kHandwritingPanelWindowClass[] = L"msimeui.HandwritingDemo";
+constexpr UINT kActivateSettings = WM_APP + 1;
 constexpr UINT kOpenSettingsAbout = WM_APP + 2;
+constexpr UINT kQuitSettings = WM_APP + 5;
 
 bool OpenSiblingApplication(const wchar_t *executable_name, const wchar_t *window_class)
 {
@@ -43,21 +45,30 @@ bool CloseApplication(const wchar_t *window_class)
     const HWND application_window = FindWindowW(window_class, nullptr);
     return !application_window || PostMessageW(application_window, WM_CLOSE, 0, 0) != FALSE;
 }
+
+// 设置窗口被关闭后只是隐藏，进程会再留一段时间。重新打开必须把消息投给它自己处理，
+// 不能在这边直接 ShowWindow：那样它的延迟退出定时器不会取消，窗口会在用户面前被销毁，
+// 而且 SW_SHOWNORMAL 还会把之前最大化的窗口还原掉。
+bool ActivateSettingsWindow(HWND window, UINT message)
+{
+    PostMessageW(window, message, 0, 0);
+    SetForegroundWindow(window);
+    return true;
+}
 } // namespace
 
 bool OpenSettingsApplication()
 {
-    return OpenSiblingApplication(L"MetasequoiaImeSettings.exe", kSettingsWindowClass);
+    if (const HWND existing_window = FindWindowW(kSettingsWindowClass, nullptr))
+        return ActivateSettingsWindow(existing_window, kActivateSettings);
+
+    return OpenSiblingApplication(L"MetasequoiaImeSettings.exe", nullptr);
 }
 
 bool OpenSettingsAboutApplication()
 {
     if (const HWND existing_window = FindWindowW(kSettingsWindowClass, nullptr))
-    {
-        ShowWindow(existing_window, SW_SHOWNORMAL);
-        PostMessageW(existing_window, kOpenSettingsAbout, 0, 0);
-        return SetForegroundWindow(existing_window) != FALSE;
-    }
+        return ActivateSettingsWindow(existing_window, kOpenSettingsAbout);
 
     std::wstring module_path(32768, L'\0');
     const DWORD length = GetModuleFileNameW(nullptr, module_path.data(), static_cast<DWORD>(module_path.size()));
@@ -72,9 +83,12 @@ bool OpenSettingsAboutApplication()
     return reinterpret_cast<INT_PTR>(result) > 32;
 }
 
+// 这是真正要求退出的通道（Server 自己也要终止），所以发 kQuitSettings 而不是 WM_CLOSE
+// ——后者现在只把窗口隐藏起来，会把设置进程留在 Server 之后。
 bool CloseSettingsApplication()
 {
-    return CloseApplication(kSettingsWindowClass);
+    const HWND application_window = FindWindowW(kSettingsWindowClass, nullptr);
+    return !application_window || PostMessageW(application_window, kQuitSettings, 0, 0) != FALSE;
 }
 
 bool OpenEmojiPanelApplication()

--- a/ui-html/webview2/settings/ime-settings/src/main.ts
+++ b/ui-html/webview2/settings/ime-settings/src/main.ts
@@ -124,6 +124,7 @@ function setupTitlebarButtons(): void {
   const closeBtn = document.getElementById('btn-close');
   const windowControls = document.querySelector<HTMLElement>('.window-controls');
   let minimizeMessageTimer: number | null = null;
+  let closeMessageTimer: number | null = null;
 
   const postWindowMessage = (value: 'minimize' | 'maximize' | 'restore' | 'close') => {
     if (window.chrome?.webview) {
@@ -215,7 +216,25 @@ function setupTitlebarButtons(): void {
   restoreBtn?.addEventListener('click', () => {
     postWindowMessage('restore');
   });
-  closeBtn?.addEventListener('click', () => postWindowMessage('close'));
+  // 关闭窗口只是隐藏，进程和这份文档都会留一段时间，所以关闭按钮的悬停/按下高亮必须先
+  // 清掉再隐藏——否则隐藏时保留的那一帧带着红色背景，下次打开会先闪一下它。
+  // 和 minimize 一样延迟发消息，给页面一次重绘的机会。
+  closeBtn?.addEventListener('click', () => {
+    windowControls?.classList.add('window-controls-click-reset');
+
+    if (closeBtn instanceof HTMLElement) {
+      closeBtn.blur();
+    }
+
+    if (closeMessageTimer !== null) {
+      window.clearTimeout(closeMessageTimer);
+    }
+
+    closeMessageTimer = window.setTimeout(() => {
+      postWindowMessage('close');
+      closeMessageTimer = null;
+    }, 100);
+  });
 
   postMaximizeButtonRect();
 


### PR DESCRIPTION
## 为什么

设置窗口是独立进程（`MetasequoiaImeSettings.exe`），每次关闭都销毁窗口、退出进程，于是每次打开都要重新创建 WebView2 环境并等首屏导航完成——冷启动的等待完整地落在用户那一侧，而设置窗口恰好是个会被反复开关的东西。

## 改了什么

**关闭只隐藏，十分钟后才真正退出**（`server/src/settings/settings_app.cpp`）

用户关闭窗口（标题栏 X 与 `WM_CLOSE`）进入新的 `HideSettings`：隐藏 HWND、停掉 300ms 的配置轮询、把 controller 置为不可见让页面被浏览器降频，然后起一个十分钟的 `kLingerTimer`。定时器到点时走原来的 `CloseSettings`，退出路径一字未改。

重新打开走既有的 `kActivateExistingWindow` / `kOpenAboutSection`，`ActivateWindow` 里新增 `CancelLinger` 对称恢复：撤掉定时器、恢复可见性、调用 `WM_ACTIVATE` 早就接好但此前一直是空操作的 `Resume()`、重启配置轮询。WebView2 仍然停在导航完成的状态，所以没有冷启动，也不再出启动图。

**关闭按钮的红色高亮不再在下次打开时闪一下**（`ui-html/.../src/main.ts`）

红色来自 CSS `:hover`。点击时按钮先渲染成红色，窗口才隐藏，于是 WebView2 保留的那一帧是红的。以前窗口被销毁，这一帧再也不会回来；现在进程留着，下次打开会先把它显示出来，等页面按真实指针位置（在托盘上）重算 `:hover` 才消失。

最小化按钮早就解决过同一个问题（加 `window-controls-click-reset` 再延迟 100ms 发消息，让页面重绘一次之后窗口才消失），关闭按钮照着同一套做。原生侧在 `HideSettings` 里复用 `WM_SIZE` 已经在用的 `ResetTitlebarHoverAfterVisibilityChange()`，覆盖 Alt+F4、启动图关闭按钮等不经过页面的路径。

## 边界情况

- **首帧之前被关掉直接真退出**，不留半初始化的进程——那种进程重新打开时启动图已经 dismiss 过，用户会对着一个空窗口等。这条同时覆盖启动图自己的关闭按钮（`settings_splash.cpp:314` 发的也是 `WM_CLOSE`）。
- **`CloseSettingsApplication()` 改发新的 `kQuitSettings`**。它是 `Ctrl+Shift+Alt+T` 的终止通道，紧接着 Server 自己也要 `ExitProcess`；原来发 `WM_CLOSE`，而 `WM_CLOSE` 现在只隐藏，会把设置进程留在 Server 之后。
- **`OpenSettingsApplication()` 不再自己 `ShowWindow`**，改为投 `kActivateSettings` 让设置进程自己处理。在 Server 这边直接显示不会取消延迟退出定时器（窗口会在用户面前被销毁），而且 `SW_SHOWNORMAL` 还会把之前最大化的窗口还原掉。
- **清掉 `g_maximize_button_hover`**：隐藏的窗口收不到 `WM_NCMOUSELEAVE`，那个标志会一直是脏的，下次真的移进去时不再发 enter。

## 验证

- `MetasequoiaImeSettings` 与 `MetasequoiaImeServer` 两个 target 均编译通过（`settings_launcher.cpp` 两边都编）。
- 设置页前端 `tsc --noEmit` 干净，`vite build` 通过，`vitest run` 23 个用例全过。
- `clang-format 18.1.8 --dry-run --Werror` 对改动的两个 C++ 文件干净。

**尚未在运行时验证。** 作者机器上当时开着一个已安装版本的设置窗口，占着 single-instance 互斥量，跑新构建要先关掉它。合之前值得手动过一遍：关闭后窗口消失而进程存活、重新打开是即时的且不闪红、十分钟后进程自行退出、`Ctrl+Shift+Alt+T` 仍能连同 Server 一起收掉。

## 留给后续

隐藏期间只是停掉渲染，进程仍持有 WebView2，实测常驻约 37MB。`ICoreWebView2_3::TrySuspend` 能进一步压下去，但向挂起的页面投脚本/消息需要在若干调用点加 resume 守卫，这次没做。
