### PR TITLE
fix(server): 避免 WebView2 候选窗阴影被裁切

### DIFF
--- a/server/src/defines/globals.h
+++ b/server/src/defines/globals.h
@@ -6,8 +6,14 @@
 inline float SCALE = 1.0f;
 inline int POP_UP_WND_WIDTH = 43;
 inline int POP_UP_WND_HEIGHT = 55;
-inline int SHADOW_WIDTH = 15;
-inline int SHADOW_HEIGHT = 15;
+// WebView2 candidate shadow reserve in CSS DIPs. Keep these in sync with the
+// two-layer shadows in ui-html/webview2/candwnd/skins. The shadow is biased to
+// the lower right, so symmetric padding either clips its soft tail or reserves
+// too much transparent hit-test area on the upper-left side.
+inline constexpr int CANDIDATE_SHADOW_PAD_LEFT = 16;
+inline constexpr int CANDIDATE_SHADOW_PAD_TOP = 14;
+inline constexpr int CANDIDATE_SHADOW_PAD_RIGHT = 32;
+inline constexpr int CANDIDATE_SHADOW_PAD_BOTTOM = 34;
 
 //
 // 候选窗口

--- a/server/src/webview2/windows_webview2.cpp
+++ b/server/src/webview2/windows_webview2.cpp
@@ -2210,8 +2210,10 @@ void PrepareCandidateWebViewBoundsForMeasure(HWND hwnd)
     {
         scale = 1.0f;
     }
-    const int extraRightDip = ::CANDIDATE_WINDOW_MAX_WIDTH_DIP + (2 * ::SHADOW_WIDTH) + ::POP_UP_WND_WIDTH;
-    const int extraBottomDip = ::CANDIDATE_WINDOW_HEIGHT + (2 * ::SHADOW_HEIGHT) + ::POP_UP_WND_HEIGHT;
+    const int extraRightDip = ::CANDIDATE_WINDOW_MAX_WIDTH_DIP + ::CANDIDATE_SHADOW_PAD_LEFT +
+                              ::CANDIDATE_SHADOW_PAD_RIGHT + ::POP_UP_WND_WIDTH;
+    const int extraBottomDip =
+        ::CANDIDATE_WINDOW_HEIGHT + ::CANDIDATE_SHADOW_PAD_TOP + ::CANDIDATE_SHADOW_PAD_BOTTOM + ::POP_UP_WND_HEIGHT;
     const int extraRightPx = (std::max)(candidateBoundExtraFloorPx, static_cast<int>(std::ceil(extraRightDip * scale)));
     const int extraBottomPx =
         (std::max)(candidateBoundExtraFloorPx, static_cast<int>(std::ceil(extraBottomDip * scale)));

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -203,6 +203,14 @@ double GetCandidateDecorationWidthDip()
     return GetActiveCandidateSkinDecorationWidthDip();
 }
 
+int GetCandidatePackingMarginTopDip()
+{
+    // MarginTop includes the permanent transparent inset that lets Chromium
+    // rasterize the shadow above the card. Only the remainder is placement
+    // slack accumulated while clamping the stable host to a monitor edge.
+    return (std::max)(0, Global::MarginTop - ::CANDIDATE_SHADOW_PAD_TOP);
+}
+
 std::pair<double, double> AddCandidateDecorationToSize(const std::pair<double, double> &cardSize)
 {
     const double decorationTopDip = GetCandidateDecorationTopDip();
@@ -529,10 +537,12 @@ void PlaceCandidateHostNearCaret(HWND hwnd, std::pair<double, double> requestedC
     RememberCandidateFlip(properPos->second, caretPt.y);
 
     MonitorCoordinates coordinates = GetMonitorCoordinatesFromPoint(caretPt);
-    int hostX = properPos->first;
-    const int packingMarginTop = (std::max)(0, Global::MarginTop);
+    int hostX = properPos->first -
+                static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_LEFT * static_cast<double>(layoutScale)));
+    const int packingMarginTop = GetCandidatePackingMarginTopDip();
     int desiredOuterTopPx = GetCandidateOuterTopPx(properPos->second, packingMarginTop, layoutScale);
-    int hostY = desiredOuterTopPx;
+    int hostY = desiredOuterTopPx -
+                static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_TOP * static_cast<double>(layoutScale)));
     const int edgePadPx = static_cast<int>(std::lround(2.0 * static_cast<double>(layoutScale)));
     if (hostX + hostWidthPx > coordinates.right)
     {
@@ -946,20 +956,21 @@ void ClipCandidateWindowToContent(HWND hwnd, const std::pair<double, double> &co
     {
         extraTopDip = (std::max)(extraTopDip, 8.0);
     }
-    const int left = (std::max)(
-        static_cast<int>(client.left),
-        static_cast<int>(std::floor((Global::MarginLeft - ::SHADOW_WIDTH) * static_cast<double>(clipScale))));
-    const int top = (std::max)(static_cast<int>(client.top),
-                               static_cast<int>(std::floor((Global::MarginTop - extraTopDip - ::SHADOW_HEIGHT) *
-                                                           static_cast<double>(clipScale))));
-    const int right = (std::min)(
-        static_cast<int>(client.right),
-        static_cast<int>(std::ceil((Global::MarginLeft + containerSize.first + ::SHADOW_WIDTH + kRegionSafetyDip) *
-                                   static_cast<double>(clipScale))));
-    const int bottom = (std::min)(
-        static_cast<int>(client.bottom),
-        static_cast<int>(std::ceil((Global::MarginTop + containerSize.second + ::SHADOW_HEIGHT + kRegionSafetyDip) *
-                                   static_cast<double>(clipScale))));
+    const int left = (std::max)(static_cast<int>(client.left),
+                                static_cast<int>(std::floor((Global::MarginLeft - ::CANDIDATE_SHADOW_PAD_LEFT) *
+                                                            static_cast<double>(clipScale))));
+    const int top =
+        (std::max)(static_cast<int>(client.top),
+                   static_cast<int>(std::floor((Global::MarginTop - extraTopDip - ::CANDIDATE_SHADOW_PAD_TOP) *
+                                               static_cast<double>(clipScale))));
+    const int right = (std::min)(static_cast<int>(client.right),
+                                 static_cast<int>(std::ceil((Global::MarginLeft + containerSize.first +
+                                                             ::CANDIDATE_SHADOW_PAD_RIGHT + kRegionSafetyDip) *
+                                                            static_cast<double>(clipScale))));
+    const int bottom = (std::min)(static_cast<int>(client.bottom),
+                                  static_cast<int>(std::ceil((Global::MarginTop + containerSize.second +
+                                                              ::CANDIDATE_SHADOW_PAD_BOTTOM + kRegionSafetyDip) *
+                                                             static_cast<double>(clipScale))));
 
     if (right <= left || bottom <= top)
     {
@@ -3912,10 +3923,12 @@ int FineTuneWindow(HWND hwnd)
             int hostHeightPx = hostPx.second;
 
             MonitorCoordinates coordinates = GetMonitorCoordinatesFromPoint(pt);
-            int hostX = properPos->first;
-            const int packingMarginTop = (std::max)(0, Global::MarginTop);
+            int hostX = properPos->first -
+                        static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_LEFT * static_cast<double>(layoutScale)));
+            const int packingMarginTop = GetCandidatePackingMarginTopDip();
             int desiredOuterTopPx = GetCandidateOuterTopPx(properPos->second, packingMarginTop, layoutScale);
-            int hostY = desiredOuterTopPx;
+            int hostY = desiredOuterTopPx -
+                        static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_TOP * static_cast<double>(layoutScale)));
             const int edgePadPx =
                 static_cast<int>(std::lround(2.0 * static_cast<double>(layoutScale > 0 ? layoutScale : 1.0f)));
             // Right/bottom first, then re-clamp left/top so a host wider/taller than
@@ -4028,10 +4041,12 @@ int FineTuneWindow(HWND hwnd)
 
                 AdjustCandidateWindowPosition(&pt, containerSize, properPos, layoutScale, containerSize.first);
                 RememberCandidateFlip(properPos->second, caretY);
-                const int resyncPackingMarginTop = (std::max)(0, Global::MarginTop);
-                hostX = properPos->first;
+                const int resyncPackingMarginTop = GetCandidatePackingMarginTopDip();
+                hostX = properPos->first -
+                        static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_LEFT * static_cast<double>(layoutScale)));
                 desiredOuterTopPx = GetCandidateOuterTopPx(properPos->second, resyncPackingMarginTop, layoutScale);
-                hostY = desiredOuterTopPx;
+                hostY = desiredOuterTopPx -
+                        static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_TOP * static_cast<double>(layoutScale)));
                 const int resyncEdgePadPx =
                     static_cast<int>(std::lround(2.0 * static_cast<double>(layoutScale > 0 ? layoutScale : 1.0f)));
                 if (hostX + hostWidthPx > coordinates.right)
@@ -4196,7 +4211,7 @@ int FineTuneWindow(HWND hwnd)
                         auto properPos = std::make_shared<std::pair<int, int>>();
                         AdjustCandidateWindowPosition(&pt, paintedSize, properPos, pass2Scale);
                         RememberCandidateFlip(properPos->second, caretY);
-                        const int packingTop = (std::max)(0, Global::MarginTop);
+                        const int packingTop = GetCandidatePackingMarginTopDip();
                         const std::pair<double, double> decoratedPaintedSize =
                             AddCandidateDecorationToSize(paintedSize);
 
@@ -4205,9 +4220,12 @@ int FineTuneWindow(HWND hwnd)
                         const int hostHeightPx = pass2Host.second;
 
                         MonitorCoordinates coordinates = GetMonitorCoordinatesFromPoint(pt);
-                        int hostX = properPos->first;
+                        int hostX = properPos->first - static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_LEFT *
+                                                                                    static_cast<double>(pass2Scale)));
                         const int desiredOuterTopPx = GetCandidateOuterTopPx(properPos->second, packingTop, pass2Scale);
-                        int hostY = desiredOuterTopPx;
+                        int hostY =
+                            desiredOuterTopPx -
+                            static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_TOP * static_cast<double>(pass2Scale)));
                         const int edgePadPx = static_cast<int>(
                             std::lround(2.0 * static_cast<double>(pass2Scale > 0 ? pass2Scale : 1.0f)));
                         if (hostX + hostWidthPx > coordinates.right)

--- a/ui-html/webview2/candwnd/skins/fluent/horizontal_dark.css
+++ b/ui-html/webview2/candwnd/skins/fluent/horizontal_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px 1px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));

--- a/ui-html/webview2/candwnd/skins/fluent/horizontal_light.css
+++ b/ui-html/webview2/candwnd/skins/fluent/horizontal_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px 1px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));

--- a/ui-html/webview2/candwnd/skins/fluent/vertical_dark.css
+++ b/ui-html/webview2/candwnd/skins/fluent/vertical_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -150,7 +150,7 @@
       background: #2d2d2d;
       border: 1px solid #9b9b9b2e;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;

--- a/ui-html/webview2/candwnd/skins/fluent/vertical_light.css
+++ b/ui-html/webview2/candwnd/skins/fluent/vertical_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -150,7 +150,7 @@
       background: #ffffff;
       border: 1px solid rgba(0, 0, 0, 0.12);
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;

--- a/ui-html/webview2/candwnd/skins/graphite/horizontal_dark.css
+++ b/ui-html/webview2/candwnd/skins/graphite/horizontal_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -177,7 +177,7 @@
       padding: 3px 5px;
       border: 1px solid #30353b;
       border-radius: 3px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, .28);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .cand { border-radius: 2px; }
     .cursor { background: #8993a0; }

--- a/ui-html/webview2/candwnd/skins/graphite/horizontal_light.css
+++ b/ui-html/webview2/candwnd/skins/graphite/horizontal_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -177,7 +177,7 @@
       padding: 3px 5px;
       border: 1px solid #e2e5e9;
       border-radius: 3px;
-      box-shadow: 0 2px 8px rgba(17, 24, 39, .10);
+      box-shadow: 8px 10px 24px rgba(17, 24, 39, .18), 2px 3px 8px rgba(17, 24, 39, .10);
     }
     .cand { border-radius: 2px; }
     .cursor { background: #5f6b7a; }

--- a/ui-html/webview2/candwnd/skins/graphite/vertical_dark.css
+++ b/ui-html/webview2/candwnd/skins/graphite/vertical_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #2d2d2d;
       border: 1px solid #9b9b9b2e;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -185,7 +185,7 @@
       padding: 3px 5px;
       border: 1px solid #30353b;
       border-radius: 3px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, .28);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .cand { border-radius: 2px; }
     .cursor { background: #8993a0; }

--- a/ui-html/webview2/candwnd/skins/graphite/vertical_light.css
+++ b/ui-html/webview2/candwnd/skins/graphite/vertical_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #ffffff;
       border: 1px solid rgba(0, 0, 0, 0.12);
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -185,7 +185,7 @@
       padding: 3px 5px;
       border: 1px solid #e2e5e9;
       border-radius: 3px;
-      box-shadow: 0 2px 8px rgba(17, 24, 39, .10);
+      box-shadow: 8px 10px 24px rgba(17, 24, 39, .18), 2px 3px 8px rgba(17, 24, 39, .10);
     }
     .cand { border-radius: 2px; }
     .cursor { background: #5f6b7a; }

--- a/ui-html/webview2/candwnd/skins/wechat/horizontal_dark.css
+++ b/ui-html/webview2/candwnd/skins/wechat/horizontal_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -177,7 +177,7 @@
       padding: 2px;
       border: 1px solid #292929;
       border-radius: 5px;
-      box-shadow: 0 6px 18px rgba(0, 0, 0, .42);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .cand { border-radius: 4px; }
     .cursor { background: #07c160; }

--- a/ui-html/webview2/candwnd/skins/wechat/horizontal_light.css
+++ b/ui-html/webview2/candwnd/skins/wechat/horizontal_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -175,7 +175,7 @@
       padding: 2px;
       border: 1px solid #dedede;
       border-radius: 5px;
-      box-shadow: 0 5px 15px rgba(0, 0, 0, .14);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .18), 2px 3px 8px rgba(0, 0, 0, .10);
     }
     .cand { border-radius: 4px; }
     .cursor { background: #07c160; }

--- a/ui-html/webview2/candwnd/skins/wechat/vertical_dark.css
+++ b/ui-html/webview2/candwnd/skins/wechat/vertical_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #2d2d2d;
       border: 1px solid #9b9b9b2e;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -185,7 +185,7 @@
       padding: 2px;
       border: 1px solid #292929;
       border-radius: 5px;
-      box-shadow: 0 6px 18px rgba(0, 0, 0, .42);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .cand {
       border-radius: 4px;

--- a/ui-html/webview2/candwnd/skins/wechat/vertical_light.css
+++ b/ui-html/webview2/candwnd/skins/wechat/vertical_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #ffffff;
       border: 1px solid rgba(0, 0, 0, 0.12);
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -183,7 +183,7 @@
       padding: 2px;
       border: 1px solid #dedede;
       border-radius: 5px;
-      box-shadow: 0 5px 15px rgba(0, 0, 0, .14);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .18), 2px 3px 8px rgba(0, 0, 0, .10);
     }
     .cand {
       border-radius: 4px;

--- a/ui-html/webview2/candwnd/skins/willow_green/horizontal_dark.css
+++ b/ui-html/webview2/candwnd/skins/willow_green/horizontal_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -174,7 +174,7 @@
     body { border-radius: 9px; }
     .containerParent {
       border-radius: 9px;
-      box-shadow: 0 7px 18px rgba(0, 0, 0, .34);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .container {
       --wg-surface: #2d2f2e;

--- a/ui-html/webview2/candwnd/skins/willow_green/horizontal_light.css
+++ b/ui-html/webview2/candwnd/skins/willow_green/horizontal_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       /* Wrap only when content reaches the host (injected) max width. */
       width: min(max-content, var(--msime-max-width-dip));
@@ -173,7 +173,7 @@
     body { border-radius: 9px; }
     .containerParent {
       border-radius: 9px;
-      box-shadow: 0 7px 18px rgba(42, 55, 47, .16);
+      box-shadow: 8px 10px 24px rgba(42, 55, 47, .18), 2px 3px 8px rgba(42, 55, 47, .10);
     }
     .container {
       --wg-surface: #f4f5f3;

--- a/ui-html/webview2/candwnd/skins/willow_green/vertical_dark.css
+++ b/ui-html/webview2/candwnd/skins/willow_green/vertical_dark.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #2d2d2d;
       border: 1px solid #9b9b9b2e;
       border-radius: 6px;
-      box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -182,7 +182,7 @@
     body { border-radius: 9px; }
     .containerParent {
       border-radius: 9px;
-      box-shadow: 0 7px 18px rgba(0, 0, 0, .34);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
     }
     .container {
       --wg-surface: #2d2f2e;

--- a/ui-html/webview2/candwnd/skins/willow_green/vertical_light.css
+++ b/ui-html/webview2/candwnd/skins/willow_green/vertical_light.css
@@ -31,7 +31,7 @@
       /* background: url("https://appassets/background.jpg"); */
       padding: 2px;
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       min-width: 7em;
       width: min(fit-content, var(--msime-max-width-dip));
       max-width: var(--msime-max-width-dip);
@@ -148,7 +148,7 @@
       background: #ffffff;
       border: 1px solid rgba(0, 0, 0, 0.12);
       border-radius: 6px;
-      box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+      box-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
       padding: 1px 0;
       /* min-width: 80px; */
       z-index: 1000;
@@ -181,7 +181,7 @@
     body { border-radius: 9px; }
     .containerParent {
       border-radius: 9px;
-      box-shadow: 0 7px 18px rgba(42, 55, 47, .16);
+      box-shadow: 8px 10px 24px rgba(42, 55, 47, .18), 2px 3px 8px rgba(42, 55, 47, .10);
     }
     .container {
       --wg-surface: #f4f5f3;

--- a/ui-html/webview2/settings/ime-settings/src/styles/modules/candidate/style-v.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/modules/candidate/style-v.css
@@ -102,7 +102,7 @@
 .candidate.theme-light {
   --cand-bg: #ffffff;
   --cand-border: rgba(0, 0, 0, 0.12);
-  --cand-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
   --cand-text: #1a1a1a;
   --cand-num: rgba(26, 26, 26, 0.55);
   --cand-hover: #ececec;
@@ -112,7 +112,7 @@
 .candidate.theme-dark {
   --cand-bg: #202020;
   --cand-border: #9b9b9b2e;
-  --cand-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
   --cand-text: #e9e8e8;
   --cand-num: #e9e8e89d;
   --cand-hover: #414141;

--- a/ui-html/webview2/settings/ime-settings/src/styles/modules/skin.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/modules/skin.css
@@ -29,6 +29,7 @@
 .skin-preview-list { padding: 9px 0; background: var(--skin-preview-stage-bg); }
 .skin-preview-row { min-width: 0; }
 .skin-preview-stage { display: flex; align-items: flex-start; justify-content: flex-start; min-width: 0; padding: 9px 24px; overflow: hidden; }
+.skin-preview-stage:has(> .candidate) { padding: 14px 36px 38px 24px; }
 .skin-preview-row .candidate { flex: 0 0 auto; align-items: flex-start; margin-top: 0; transform-origin: left center; }
 .skin-preview-horizontal .container {
   width: fit-content;
@@ -45,7 +46,7 @@
   --accent-strong: #07c160;
   --cand-bg: #151515;
   --cand-border: #292929;
-  --cand-shadow: 0 6px 18px rgba(0, 0, 0, .42);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
   --cand-text: #b7b7b7;
   --cand-num: #858585;
   --cand-hover: rgba(7, 193, 96, .32);
@@ -55,7 +56,7 @@
   --accent-strong: #07c160;
   --cand-bg: #f7f7f7;
   --cand-border: #dedede;
-  --cand-shadow: 0 5px 15px rgba(0, 0, 0, .14);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, .18), 2px 3px 8px rgba(0, 0, 0, .10);
   --cand-text: #333333;
   --cand-num: #757575;
   --cand-hover: rgba(7, 193, 96, .14);
@@ -92,7 +93,7 @@
 .candidate.skin-graphite.theme-dark {
   --cand-bg: #1c1f23;
   --cand-border: #30353b;
-  --cand-shadow: 0 2px 8px rgba(0, 0, 0, .28);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
   --cand-text: #aeb6c2;
   --cand-num: #707987;
   --cand-hover: rgba(255, 255, 255, .055);
@@ -102,7 +103,7 @@
 .candidate.skin-graphite.theme-light {
   --cand-bg: #fbfbfc;
   --cand-border: #e2e5e9;
-  --cand-shadow: 0 2px 8px rgba(17, 24, 39, .10);
+  --cand-shadow: 8px 10px 24px rgba(17, 24, 39, .18), 2px 3px 8px rgba(17, 24, 39, .10);
   --cand-text: #586476;
   --cand-num: #8993a1;
   --cand-hover: rgba(31, 41, 55, .055);
@@ -141,7 +142,7 @@
   --accent-strong: #65c98d;
   --cand-bg: #2d2f2e;
   --cand-border: transparent;
-  --cand-shadow: 0 7px 18px rgba(0, 0, 0, .34);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, .34), 2px 3px 8px rgba(0, 0, 0, .22);
   --cand-text: #d8dbd8;
   --cand-num: #a6aba7;
   --cand-hover: rgba(101, 201, 141, .22);
@@ -151,7 +152,7 @@
   --accent-strong: #58b980;
   --cand-bg: #f4f5f3;
   --cand-border: transparent;
-  --cand-shadow: 0 7px 18px rgba(42, 55, 47, .16);
+  --cand-shadow: 8px 10px 24px rgba(42, 55, 47, .18), 2px 3px 8px rgba(42, 55, 47, .10);
   --cand-text: #343936;
   --cand-num: #686f6a;
   --cand-hover: rgba(88, 185, 128, .16);

--- a/ui-html/webview2/settings/ime-settings/src/styles/variables.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/variables.css
@@ -57,7 +57,7 @@ html[data-theme="dark"] {
   --toast-text: #f3f3f3;
   --cand-bg: #202020;
   --cand-border: #9b9b9b2e;
-  --cand-shadow: 5px 5px 10px rgba(0, 0, 0, 0.5);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, 0.34), 2px 3px 8px rgba(0, 0, 0, 0.22);
   --cand-text: #e9e8e8;
   --cand-num: #e9e8e89d;
   --cand-hover: #414141;
@@ -126,7 +126,7 @@ html[data-theme="light"] {
   --toast-text: #242424;
   --cand-bg: #ffffff;
   --cand-border: rgba(0, 0, 0, 0.12);
-  --cand-shadow: 4px 4px 12px rgba(0, 0, 0, 0.12);
+  --cand-shadow: 8px 10px 24px rgba(0, 0, 0, 0.18), 2px 3px 8px rgba(0, 0, 0, 0.10);
   --cand-text: #1a1a1a;
   --cand-num: rgba(26, 26, 26, 0.55);
   --cand-hover: #ececec;


### PR DESCRIPTION
## 变更内容

- 将四套内置 WebView2 候选窗皮肤统一为向右下偏移的双层雾状阴影
- 为候选窗宿主裁剪区域配置与阴影外延匹配的非对称留白
- 将宿主窗口向左上偏移，并通过 HTML margin 保持实体候选框原有锚点，避免 Chromium viewport 裁掉左侧和顶部阴影
- 同步设置页中的皮肤预览效果与预览留白

## 验证

- `pnpm build`
- `pnpm test`（23 项通过）
- `cmake --build server/build-release --config Release --target MetasequoiaImeServer --parallel 4`
- `clang-format --dry-run --Werror`（本次修改的 C++ 文件）
- `git diff --check`