### PR TITLE
fix(installer): 覆盖安装前退出驻留中的设置进程

### DIFF
--- a/installer/msime_setup.iss
+++ b/installer/msime_setup.iss
@@ -22,6 +22,12 @@
 #define MyAppPublisher "Metasequoia"
 #define MyAppExeName   "MetasequoiaImeServer.exe"
 #define MySettingsExeName "MetasequoiaImeSettings.exe"
+; 与 settings_app.cpp / settings_launcher.cpp 的 kQuitSettings 保持一致：WM_APP + 5。
+#define MySettingsWindowClass "MetasequoiaImeSettingsWindow"
+#define MySettingsQuitMessage 32773
+#define MyEmojiPanelExeName "MetasequoiaImeEmojiPanel.exe"
+#define MyKeyboardPanelExeName "MetasequoiaImeKeyboardPanel.exe"
+#define MyHandwritingPanelExeName "MetasequoiaImeHandwritingPanel.exe"
 #define MyWatchdogName "MetasequoiaImeWatchdog.exe"
 #define MyWatchdogTaskName "Metasequoia IME Watchdog"
 #define MyReplayName   "MetasequoiaImeDictionaryReplay.exe"
@@ -330,7 +336,6 @@ procedure StopProcess(const ImageName: String);
 var
   ResultCode: Integer;
 begin
-  { Watchdog 必须先停，否则它可能在卸载期间重新启动 Server。}
   Exec(
     ExpandConstant('{sys}\taskkill.exe'),
     '/F /T /IM "' + ImageName + '"',
@@ -339,6 +344,42 @@ begin
     ewWaitUntilTerminated,
     ResultCode
   );
+end;
+
+procedure StopSettingsProcess;
+var
+  SettingsWindow: HWND;
+  WaitedMs: Integer;
+begin
+  // 设置窗口关闭后只是隐藏，进程还要驻留十分钟保住已导航完的 WebView2。
+  // 覆盖安装要删掉整个 server 目录，所以这里必须把它请走：先投 kQuitSettings
+  // 让它自己收尾（Server 已被强杀，没人替我们发这条消息了），再强杀兜底。
+  SettingsWindow := FindWindowByClassName('{#MySettingsWindowClass}');
+  if SettingsWindow <> 0 then
+  begin
+    PostMessage(SettingsWindow, {#MySettingsQuitMessage}, 0, 0);
+    WaitedMs := 0;
+    while (WaitedMs < 3000) and
+          (FindWindowByClassName('{#MySettingsWindowClass}') <> 0) do
+    begin
+      Sleep(100);
+      WaitedMs := WaitedMs + 100;
+    end;
+  end;
+  StopProcess('{#MySettingsExeName}');
+end;
+
+procedure StopImeProcesses;
+begin
+  { Watchdog 先停，否则它会在我们删文件期间把 Server 拉起来。}
+  StopProcess('{#MyWatchdogName}');
+  StopProcess('{#MyAppExeName}');
+  StopSettingsProcess;
+  { 面板通常是 Server 的子进程、随 /T 一起走；Server 若已崩溃它们会变成孤儿，
+    同样占着 server 目录里的 exe，所以显式再收一遍。}
+  StopProcess('{#MyEmojiPanelExeName}');
+  StopProcess('{#MyKeyboardPanelExeName}');
+  StopProcess('{#MyHandwritingPanelExeName}');
 end;
 
 procedure DeleteWatchdogLogonTask;
@@ -607,8 +648,7 @@ var
 begin
   { 先锁定本次目录名，再清理能够释放的旧版本 DLL。}
   VersionDirName := GetVersionDir('');
-  StopProcess('{#MyWatchdogName}');
-  StopProcess('{#MyAppExeName}');
+  StopImeProcesses;
 #ifdef LightPackage
   { 轻量包不替换词库：只清 HTML 和 Server/TSF，保留本机 msime.db 等。}
   TryDeleteTree(ExpandConstant('{localappdata}\metasequoiaime\html'));
@@ -669,8 +709,7 @@ begin
       'Software\Microsoft\Windows\CurrentVersion\Run',
       'MetasequoiaImeWatchdog'
     );
-    StopProcess('{#MyWatchdogName}');
-    StopProcess('{#MyAppExeName}');
+    StopImeProcesses;
   end
   else if CurUninstallStep = usPostUninstall then
   begin


### PR DESCRIPTION
## 问题

覆盖安装时安装器杀不干净设置进程，`installer\msime_setup.iss` 的 `PrepareToInstall` 只停 Watchdog 和 Server，从来就没包含过 `MetasequoiaImeSettings.exe`。

设置窗口以前一关进程就退，所以这个遗漏一直没暴露。#353 把关窗改成只 `HideSettings`、进程驻留十分钟（`kLingerTimeoutMs`）之后，它会一直占着 `%ProgramFiles%\metasequoiaime\server\MetasequoiaImeSettings.exe`，安装器删旧 server 目录的 `TryDeleteTree` 失败，用户只能手动去任务管理器结束进程才能装上。

Server 本身有一条优雅退出通道（`CloseSettingsApplication()` 投 `kQuitSettings`），但安装器是 `taskkill /F` 硬杀 Server，它没机会执行收尾逻辑，这条通道在安装场景下形同虚设。

## 改动

只动 `installer/msime_setup.iss`：

- 新增 `StopSettingsProcess`：先 `FindWindowByClassName` 定位设置窗口并 `PostMessage` 投递 `kQuitSettings`（WM_APP+5 = 32773），给它自己收尾落盘的机会，最多轮询等三秒；随后无条件 `taskkill /F /T` 兜底。
- 新增 `StopImeProcesses` 收敛停机顺序（Watchdog → Server → Settings → 三个面板），安装与卸载两条路径共用，避免以后再漏。
- 顺带补杀 Emoji / Keyboard / Handwriting 面板：正常情况下它们是 Server 的子进程、随 `/T` 一起走，但 Server 若已崩溃它们会变成孤儿，同样占住 server 目录。
- 新增 `MySettingsWindowClass` / `MySettingsQuitMessage` 常量，注释标明需与 `settings_app.cpp`、`settings_launcher.cpp` 的 `kQuitSettings` 保持一致。

## 验证

- `installer\Compile-Installer.ps1 -Light` 编译通过（Windows 11 Pro 26200，Inno Setup 7，45.3 秒），新增 Pascal 代码的类型与符号（`HWND`、`FindWindowByClassName`、`PostMessage`、预处理常量展开）均合法。
- 安装器是高完整性、设置进程是中完整性，UIPI 允许高→低方向投递消息，`PostMessage` 不会被拦。
- 驻留期间窗口只是隐藏没销毁，`FindWindow` 不区分可见性仍能定位到；若进程还在 splash 阶段没建主窗口，则直接落到强杀兜底。
- **端到端手工回归尚未做**：还没在真机上跑「打开设置 → 关窗 → 十分钟内覆盖安装」这条完整路径，合入前建议补一次。

## 后续

`kQuitSettings` 的数值现在 C++ 和 `.iss` 各写一份，将来调整 WM_APP 偏移需要同步，已在 `.iss` 注释里标注。
