### PR TITLE
fix(engine): 消除 /W4 下的编译警告

### DIFF
--- a/engine/core/data_path.h
+++ b/engine/core/data_path.h
@@ -2,6 +2,9 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -10,6 +13,24 @@
 
 namespace metasequoia
 {
+#ifdef _WIN32
+namespace detail
+{
+inline std::optional<std::wstring> wide_environment_variable(const wchar_t *name)
+{
+    wchar_t *buffer = nullptr;
+    size_t size = 0;
+    if (_wdupenv_s(&buffer, &size, name) != 0 || buffer == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    const std::unique_ptr<wchar_t, decltype(&std::free)> owned_buffer(buffer, &std::free);
+    return std::wstring(owned_buffer.get());
+}
+} // namespace detail
+#endif
+
 inline std::filesystem::path path_from_utf8(const char *path)
 {
 #if defined(__cpp_lib_char8_t)
@@ -22,9 +43,9 @@ inline std::filesystem::path path_from_utf8(const char *path)
 inline std::filesystem::path data_directory()
 {
 #ifdef _WIN32
-    if (const wchar_t *override_path = _wgetenv(L"METASEQUOIA_IME_DATA_DIR"))
+    if (const auto override_path = detail::wide_environment_variable(L"METASEQUOIA_IME_DATA_DIR"))
     {
-        const std::filesystem::path path(override_path);
+        const std::filesystem::path path(*override_path);
         if (path.is_absolute())
         {
             return path;
@@ -42,9 +63,9 @@ inline std::filesystem::path data_directory()
 #endif
 
 #ifdef _WIN32
-    if (const wchar_t *local_app_data = _wgetenv(L"LOCALAPPDATA"))
+    if (const auto local_app_data = detail::wide_environment_variable(L"LOCALAPPDATA"))
     {
-        const std::filesystem::path root(local_app_data);
+        const std::filesystem::path root(*local_app_data);
         if (root.is_absolute())
         {
             return root / L"metasequoiaime";

--- a/engine/core/pinyin_file_io.h
+++ b/engine/core/pinyin_file_io.h
@@ -5,17 +5,28 @@
 #include <cstdio>
 #include <filesystem>
 #include <io.h>
+#include <share.h>
 #include <string>
 namespace ime_pinyin
 {
+// _wfsopen / _wsopen_s instead of the deprecated _wfopen / _wopen: the secure
+// _wfopen_s opens without sharing, while the decoder's dictionary files are read
+// concurrently by the Server, the TSF DLL and the settings process. _SH_DENYNO is
+// exactly the sharing mode the deprecated calls used, so this only silences C4996.
 inline FILE *fopen(const char *path, const char *mode)
 {
     const std::wstring wide_mode(mode, mode + std::char_traits<char>::length(mode));
-    return _wfopen(std::filesystem::u8path(path).c_str(), wide_mode.c_str());
+    return _wfsopen(std::filesystem::u8path(path).c_str(), wide_mode.c_str(), _SH_DENYNO);
 }
 inline int open(const char *path, int flags)
 {
-    return _wopen(std::filesystem::u8path(path).c_str(), flags);
+    int fd = -1;
+    // pmode is only consulted for _O_CREAT, which no caller passes.
+    if (_wsopen_s(&fd, std::filesystem::u8path(path).c_str(), flags, _SH_DENYNO, 0) != 0)
+    {
+        return -1;
+    }
+    return fd;
 }
 } // namespace ime_pinyin
 #endif

--- a/engine/quanpin/quanpin_dictionary.cpp
+++ b/engine/quanpin/quanpin_dictionary.cpp
@@ -169,10 +169,10 @@ std::vector<WordItem> QuanpinDictionary::query_exact(const std::string &raw_inpu
 
     // Autocorrected results get their own cache slot so they never leak the
     // fallback tail into plain (correct) spellings sharing the same key.
-    if (auto cached = series_cache_.get(resolution.cache_key))
+    if (series_cache_.get(resolution.cache_key))
     {
         reset_cache_if_database_changed();
-        if (cached = series_cache_.get(resolution.cache_key))
+        if (const auto cached = series_cache_.get(resolution.cache_key))
         {
             current_candidate_list_ = cached.value();
             return current_candidate_list_;
@@ -487,7 +487,7 @@ std::vector<WordItem> QuanpinDictionary::query_database(const quanpin::Segments 
         }
         return result;
     }
-    catch (const std::exception &ex)
+    catch (const std::exception &)
     {
         (void)0;
         return {};
@@ -666,7 +666,7 @@ int QuanpinDictionary::create_word(std::string pinyin, std::string word)
         return ERROR_CODE;
     }
 
-    if (check_data(build_sql_for_checking_word(pinyin, jp, word)))
+    if (check_data(build_sql_for_checking_word(pinyin, word)))
     {
         return OK;
     }
@@ -699,7 +699,7 @@ int QuanpinDictionary::create_word_from_canonical_pinyin(std::string pinyin, std
     {
         return ERROR_CODE;
     }
-    if (check_data(build_sql_for_checking_word(pinyin, jp, word)))
+    if (check_data(build_sql_for_checking_word(pinyin, word)))
     {
         return OK;
     }
@@ -1012,8 +1012,7 @@ std::string QuanpinDictionary::build_sql_for_creating_word(const std::string &pi
     return sql;
 }
 
-std::string QuanpinDictionary::build_sql_for_checking_word(const std::string &key, const std::string &jp,
-                                                           const std::string &value)
+std::string QuanpinDictionary::build_sql_for_checking_word(const std::string &key, const std::string &value)
 {
     const auto cuts = quanpin::cut_pinyin_by_mode(key, "correction");
     if (cuts.empty())

--- a/engine/quanpin/quanpin_dictionary.h
+++ b/engine/quanpin/quanpin_dictionary.h
@@ -92,7 +92,7 @@ class QuanpinDictionary
     int delete_data(const std::string &sql_str);
 
     std::string build_sql_for_creating_word(const std::string &pinyin);
-    std::string build_sql_for_checking_word(const std::string &key, const std::string &jp, const std::string &value);
+    std::string build_sql_for_checking_word(const std::string &key, const std::string &value);
     std::string build_sql_for_inserting_word(const std::string &key, const std::string &jp, const std::string &value);
     std::string build_sql_for_updating_word(const std::string &word);
     std::string build_sql_for_updating_word(std::string pinyin, const std::string &word);

--- a/engine/shuangpin/shuangpin_dictionary.cpp
+++ b/engine/shuangpin/shuangpin_dictionary.cpp
@@ -676,7 +676,7 @@ int ShuangpinDictionary::create_word_from_quanpin(string pinyin, string word)
     {
         return ERROR_CODE;
     }
-    if (check_data(quanpin_db_, build_quanpin_sql_for_checking_word(pinyin, jp, word)))
+    if (check_data(quanpin_db_, build_quanpin_sql_for_checking_word(pinyin, word)))
     {
         return OK;
     }
@@ -826,7 +826,7 @@ vector<ShuangpinDictionary::WordItem> ShuangpinDictionary::query_from_quanpin_da
             candidate_list.emplace_back(pinyin_sequence, item.value, item.weight, CandidateSource::Database, item.key);
         }
     }
-    catch (const std::exception &ex)
+    catch (const std::exception &)
     {
         (void)0;
     }
@@ -973,7 +973,7 @@ std::string ShuangpinDictionary::build_quanpin_sql_for_creating_word(const std::
     return sql;
 }
 
-std::string ShuangpinDictionary::build_quanpin_sql_for_checking_word(const std::string &key, const std::string &jp,
+std::string ShuangpinDictionary::build_quanpin_sql_for_checking_word(const std::string &key,
                                                                      const std::string &value) const
 {
     const auto cuts = quanpin::cut_pinyin_by_mode(key, "correction");

--- a/engine/shuangpin/shuangpin_dictionary.h
+++ b/engine/shuangpin/shuangpin_dictionary.h
@@ -108,8 +108,7 @@ class ShuangpinDictionary
     std::string normalize_shuangpin_to_quanpin_segmentation(const std::string &pinyin) const;
     std::string normalize_shuangpin_to_quanpin_input(const std::string &pinyin) const;
     std::string build_quanpin_sql_for_creating_word(const std::string &pinyin) const;
-    std::string build_quanpin_sql_for_checking_word(const std::string &key, const std::string &jp,
-                                                    const std::string &value) const;
+    std::string build_quanpin_sql_for_checking_word(const std::string &key, const std::string &value) const;
     std::string build_quanpin_sql_for_inserting_word(const std::string &key, const std::string &jp,
                                                      const std::string &value) const;
     std::string build_quanpin_sql_for_updating_word(const std::string &word) const;
@@ -129,10 +128,10 @@ class ShuangpinDictionary
     // Whether in full help mode
     bool _is_full_help_mode = false;
     // Localtion of starting position
-    int _help_mode_raw_pos = 0;                 // Start from pos, e.g. 妮: ninv: 2
-    std::string _pinyin_helpcodes = "";         // Help codes
-    std::vector<ImeKeyCode> _kb_input_sequence; // Keyboard input sequence
-    std::string _pinyin_sequence = "";          // Pinyin extracted from from keyboard sequence
+    std::string::size_type _help_mode_raw_pos = 0; // Start from pos, e.g. 妮: ninv: 2
+    std::string _pinyin_helpcodes = "";            // Help codes
+    std::vector<ImeKeyCode> _kb_input_sequence;    // Keyboard input sequence
+    std::string _pinyin_sequence = "";             // Pinyin extracted from from keyboard sequence
     std::string _pinyin_sequence_with_cases =
         ""; // Pinyin extracted from from keyboard sequence, but with letters' original cases
     std::string _pure_pinyin_sequence = "";        // Pinyin without help code
@@ -160,11 +159,11 @@ class ShuangpinDictionary
         this->_is_full_help_mode = is_full_help_mode;
     }
 
-    int get_help_mode_raw_pos()
+    std::string::size_type get_help_mode_raw_pos()
     {
         return this->_help_mode_raw_pos;
     }
-    void set_help_mode_raw_pos(int raw_pos)
+    void set_help_mode_raw_pos(std::string::size_type raw_pos)
     {
         this->_help_mode_raw_pos = raw_pos;
     }

--- a/engine/tests/src/test_pinyin.cpp
+++ b/engine/tests/src/test_pinyin.cpp
@@ -44,8 +44,8 @@ class ScopedLocalAppDataOverride
         {
             throw std::runtime_error("A data directory should be available for regression tests.");
         }
-        const wchar_t *current = _wgetenv(kDataDirectoryVariable);
-        original_ = current == nullptr ? L"" : current;
+        const auto current = metasequoia::detail::wide_environment_variable(kDataDirectoryVariable);
+        original_ = current.value_or(L"");
 
         root_ = fs::temp_directory_path() / "msime-regression" / suffix;
         app_dir_ = root_ / "metasequoiaime";

--- a/engine/voice/include/msime/voice/wav_writer.h
+++ b/engine/voice/include/msime/voice/wav_writer.h
@@ -14,9 +14,9 @@ class WavWriter
   public:
     // The PCM recognizer uses the default 60-second budget. Hosts encoding longer
     // bounded uploads can specify their own limit without copying this encoder.
-    static std::vector<uint8_t> create_wav(const std::vector<float> &pcm_data, int sample_rate = 16000, std::size_t sample_limit = maximum_samples)
+    static std::vector<uint8_t> create_wav(const std::vector<float> &pcm_data, int requested_sample_rate = metasequoia::voice::sample_rate, std::size_t sample_limit = maximum_samples)
     {
-        if (sample_rate != metasequoia::voice::sample_rate || pcm_data.size() > sample_limit || pcm_data.size() > ((std::numeric_limits<uint32_t>::max)() - 36u) / 2u)
+        if (requested_sample_rate != metasequoia::voice::sample_rate || pcm_data.size() > sample_limit || pcm_data.size() > ((std::numeric_limits<uint32_t>::max)() - 36u) / 2u)
             throw VoiceError("Expected mono 16 kHz audio within the selected WAV sample limit");
         std::vector<uint8_t> wav_data;
 
@@ -45,13 +45,13 @@ class WavWriter
 
         // fmt chunk
         write_cw(wav_data, "fmt ");
-        write_u32(wav_data, 16);              // Chunk size
-        write_u16(wav_data, 1);               // PCM format
-        write_u16(wav_data, 1);               // Channels (Mono)
-        write_u32(wav_data, sample_rate);     // Sample rate
-        write_u32(wav_data, sample_rate * 2); // Byte rate (SampleRate * BlockAlign)
-        write_u16(wav_data, 2);               // Block align (Channels * BitsPerSample / 8)
-        write_u16(wav_data, 16);              // Bits per sample
+        write_u32(wav_data, 16);                        // Chunk size
+        write_u16(wav_data, 1);                         // PCM format
+        write_u16(wav_data, 1);                         // Channels (Mono)
+        write_u32(wav_data, requested_sample_rate);     // Sample rate
+        write_u32(wav_data, requested_sample_rate * 2); // Byte rate (SampleRate * BlockAlign)
+        write_u16(wav_data, 2);                         // Block align (Channels * BitsPerSample / 8)
+        write_u16(wav_data, 16);                        // Bits per sample
 
         // data chunk
         write_cw(wav_data, "data");


### PR DESCRIPTION
## 背景

`engine/` 在 `/W4` 下积了一批编译警告。本 PR 把**一方代码的警告清到零**。

剩余的 107 条警告全部位于上游副本 —— `engine/googlepinyinime-rev/`、`vendor/opencc/` 及其捆绑的 marisa。按 [AGENTS.md](../blob/develop/engine/AGENTS.md) 的约定这三处保留上游原格式，本 PR 有意不动。

## 改动

| 文件 | 警告 | 处理 |
|---|---|---|
| `core/data_path.h`、`tests/src/test_pinyin.cpp` | C4996 `_wgetenv` | 改 `_wdupenv_s`，返回值用 `std::optional` 包一层，缓冲区交给 `unique_ptr` 释放 |
| `quanpin/quanpin_dictionary.cpp` | C4706 条件表达式内赋值 | 去掉未使用的外层绑定；`reset_cache_if_database_changed()` 可能使缓存失效，重取保留 |
| `quanpin/`、`shuangpin/` | C4100 未使用形参 | 删掉 `build_sql_for_checking_word` 中从未使用的 `jp` 形参；未使用的 `catch` 形参去名 |
| `shuangpin/shuangpin_dictionary.h` | C4267 符号不匹配 | `_help_mode_raw_pos` 及其 getter/setter 由 `int` 改 `std::string::size_type` |
| `voice/include/msime/voice/wav_writer.h` | C4459 遮蔽全局声明 | 形参 `sample_rate` 遮蔽了同名命名空间常量，改名 `requested_sample_rate`；默认值由字面量 `16000` 改为直接引用该常量 |
| `core/pinyin_file_io.h` | C4996 `_wfopen` / `_wopen` | 改用 `_wfsopen` / `_wsopen_s`，共享模式显式传 `_SH_DENYNO` |

### 关于最后一项的取舍

**没有**采用微软推荐的 `_wfopen_s`。`_wfopen_s` 打开的文件**不可共享**，而这里是拼音解码器的词库文件，Server、TSF DLL 和设置进程会并发读取同一份 —— 换过去等于引入一个只在运行期暴露的文件占用缺陷。

`_wfsopen` / `_wsopen_s` 配 `_SH_DENYNO` 正是被弃用调用原本的共享语义，因此这次改动只消除警告，不改变行为。`_wsopen_s` 的 pmode 传 0，因为唯一调用方 `userdict.cpp` 用的是 `O_WRONLY`，不带 `_O_CREAT`。

## 验证

- Server 构建（Release）exit 0；一方代码 `/W4` 警告数 **3 → 0**
- Server 测试 ctest **2/2** 通过
- 引擎独立构建 + 测试 ctest **22/22** 通过
- clang-format 18.1.8 `--dry-run --Werror` 对全部改动文件通过

已确认 `dicttrie.cpp` 等依赖 `pinyin_file_io.h` 的翻译单元确实重新编译过，垫片的 C4996 不是被增量构建跳过的。

## 附带发现（本 PR 未处理）

`scripts/format.sh` 在 Windows 上跑不起来：脚本按 POSIX 布局取 `$venv/bin/pip`，而 Windows 的 venv 生成的是 `Scripts/`，直接 exit 127。本次是另建 venv 绕过的。若希望本地能自检格式，这个脚本值得单独加一段平台分支。