### PR TITLE
fix(server): 候选窗贴边后不再随内容变化上下左右乱飘

### DIFF
--- a/server/src/utils/window_utils.cpp
+++ b/server/src/utils/window_utils.cpp
@@ -320,7 +320,10 @@ int AdjustCandidateWindowPosition(                  //
         properPos->second = coordinates.top + edgePadPx;
     }
 
-    if (properPos->second + decisionHeightPx > coordinates.bottom)
+    // Decide against the same lower limit every downstream clamp uses. Testing
+    // against the bare work-area bottom declared a card "fits below" that the
+    // edge pad then pushed back up — straight onto the caret's own text line.
+    if (properPos->second + decisionHeightPx > coordinates.bottom - edgePadPx)
     {
         // Point[1] is GetTextExt.bottom (the line's bottom). Sit the opaque card
         // so its bottom meets the line's top — same for short and fully expanded

--- a/server/src/window/candidate_presenter.cpp
+++ b/server/src/window/candidate_presenter.cpp
@@ -940,13 +940,21 @@ void CandidatePresenter::PlaceAndShow(POINT caret, float widthDip, float heightD
     int x = properPos->first - cardLeftPx;
     int y = properPos->second - cardTopPx;
     const MonitorCoordinates monitor = GetMonitorCoordinatesFromPoint(caret);
-    if (x + widthPx > monitor.right)
+    // Clamp the opaque card, not the host window — same rule the vertical branch
+    // below already follows. The host carries transparent shadow padding, is
+    // rounded up to a 64px bucket and only ever grows while typing, so clamping
+    // *its* right edge shoved the card left by all of that slack. AdjustCandidate-
+    // WindowPosition had already parked the card flush against the screen edge;
+    // deleting a character kept the stale (larger) host width, so the card's left
+    // edge froze and its right edge drifted further from the edge on every delete.
+    const int cardWidthPx = (std::max)(1, static_cast<int>(std::ceil(cardWidthDip * scale)));
+    if (x + cardLeftPx + cardWidthPx > monitor.right)
     {
-        x = monitor.right - widthPx - 2;
+        x = monitor.right - cardLeftPx - cardWidthPx - 2;
     }
-    if (x < monitor.left)
+    if (x + cardLeftPx < monitor.left)
     {
-        x = monitor.left + 2;
+        x = monitor.left + 2 - cardLeftPx;
     }
     const int cardBottom = y + cardTopPx + cardHeightPx;
     if (cardBottom > monitor.bottom)

--- a/server/src/window/ime_windows.cpp
+++ b/server/src/window/ime_windows.cpp
@@ -329,6 +329,55 @@ void ClearCandidateClipState()
     g_last_candidate_card_size = {};
 }
 
+// Re-anchor an already-placed card after its painted size changed.
+//
+// A content-only update changes the card's width *and* its height, so the
+// position placement asked for moves with it. Clamping alone cannot follow:
+// MarginLeft only ever shrinks, so a card parked flush against the right screen
+// edge kept its old left edge while narrowing; and a card that grew past the
+// work-area bottom was pushed straight up by KeepCandidateCardInsideHostAndMonitor
+// — onto the very text line it should have flipped above. The old incremental
+// "MarginTop -= height delta" bookkeeping could not fix that either: it kept the
+// bottom glued to wherever the card already was, accumulating every earlier
+// clamp instead of re-deriving the anchor.
+//
+// So ask AdjustCandidateWindowPosition for the whole decision again, using the
+// size that was actually painted — the only height the flip test may trust.
+void ReanchorCandidateHostToPaintedCard(const POINT &layoutCaret, const std::pair<double, double> &cardSize,
+                                        const MonitorCoordinates &coordinates, int hostHeightPx, FLOAT scale,
+                                        int &hostX, int &hostY)
+{
+    if (scale <= 0.0f)
+    {
+        scale = 1.0f;
+    }
+    auto anchorPos = std::make_shared<std::pair<int, int>>();
+    AdjustCandidateWindowPosition(&layoutCaret, cardSize, anchorPos, scale, cardSize.first);
+    RememberCandidateFlip(anchorPos->second, layoutCaret.y);
+
+    const int desiredOuterTopPx = GetCandidateOuterTopPx(anchorPos->second, GetCandidatePackingMarginTopDip(), scale);
+    const int shadowTopPx = static_cast<int>(std::lround(::CANDIDATE_SHADOW_PAD_TOP * static_cast<double>(scale)));
+    const int edgePadPx = static_cast<int>(std::lround(2.0 * static_cast<double>(scale)));
+    // The stable host stays put while its margin can still carry the card to the
+    // anchor. Only a card that wants to sit above the host — a flip, typically —
+    // needs the host itself to move.
+    if (desiredOuterTopPx < hostY + shadowTopPx)
+    {
+        hostY = desiredOuterTopPx - shadowTopPx;
+        if (hostY + hostHeightPx > coordinates.bottom)
+        {
+            hostY = coordinates.bottom - hostHeightPx - edgePadPx;
+        }
+        if (hostY < coordinates.top)
+        {
+            hostY = coordinates.top + edgePadPx;
+        }
+    }
+    Global::MarginLeft =
+        (std::max)(0, static_cast<int>(std::lround((anchorPos->first - hostX) / static_cast<double>(scale))));
+    Global::MarginTop = GetCandidateOuterMarginDip(desiredOuterTopPx, hostY, scale);
+}
+
 void RefreshCandidateClipAfterPaint(HWND hwnd, uint64_t contentGeneration, ULONGLONG updateStartedTick)
 {
     if (!hwnd || !::is_global_wnd_cand_shown || !webviewCandWnd ||
@@ -377,12 +426,9 @@ void RefreshCandidateClipAfterPaint(HWND hwnd, uint64_t contentGeneration, ULONG
 
             // Content-only updates used to only refresh SetWindowRgn. When the
             // painted card grows wider near the right edge, that left the
-            // opaque box hanging past the monitor. Re-clamp margins/host to the
-            // caret monitor without a full FineTune (avoids the show-time jump).
-            //
-            // When the card is above the caret, also keep its bottom glued as
-            // height shrinks/grows — otherwise a short list floats above the
-            // line while a full page sits flush.
+            // opaque box hanging past the monitor. Re-anchor to the painted card
+            // and re-clamp margins/host to the caret monitor, without a full
+            // FineTune (which would reintroduce the show-time jump).
             RECT hostRect{};
             if (GetWindowRect(hwnd, &hostRect))
             {
@@ -395,15 +441,8 @@ void RefreshCandidateClipAfterPaint(HWND hwnd, uint64_t contentGeneration, ULONG
                 const int marginLeftBefore = Global::MarginLeft;
                 const int marginTopBefore = Global::MarginTop;
 
-                if (g_candidate_placed_above_caret && g_last_candidate_card_size.second > 1.0)
-                {
-                    const int deltaDip =
-                        static_cast<int>(std::lround(paintedSize.second - g_last_candidate_card_size.second));
-                    if (deltaDip != 0)
-                    {
-                        Global::MarginTop = (std::max)(0, Global::MarginTop - deltaDip);
-                    }
-                }
+                ReanchorCandidateHostToPaintedCard(layoutCaret, paintedSize, coordinates, hostHeightPx, scale, hostX,
+                                                   hostY);
 
                 KeepCandidateCardInsideHostAndMonitor(hostX, hostY, hostWidthPx, hostHeightPx, decoratedSize.first,
                                                       decoratedSize.second, scale, coordinates, decoratedSize.first);
@@ -640,12 +679,44 @@ void MaybeExpandCandidateClipFromSlotMeasure(HWND hwnd)
         return;
     }
 
-    if (g_candidate_placed_above_caret && g_last_candidate_card_size.second > 1.0)
+    FLOAT slotScale = GetWebViewRasterizationScale(hwnd);
+    if (slotScale <= 0.0f)
     {
-        const int deltaDip = static_cast<int>(std::lround(paintedSize.second - g_last_candidate_card_size.second));
-        if (deltaDip != 0)
+        slotScale = clipLimits.scale > 0.0f ? clipLimits.scale : 1.0f;
+    }
+    // A slot measure reports a new painted height, which can change the flip
+    // decision — re-derive the anchor from it instead of nudging MarginTop by
+    // the height delta. See ReanchorCandidateHostToPaintedCard.
+    RECT slotHostRect{};
+    if (GetWindowRect(hwnd, &slotHostRect))
+    {
+        int hostX = slotHostRect.left;
+        int hostY = slotHostRect.top;
+        const int hostWidthPx = slotHostRect.right - slotHostRect.left;
+        const int hostHeightPx = slotHostRect.bottom - slotHostRect.top;
+        const POINT layoutCaret = GetCandidateLayoutCaret();
+        const MonitorCoordinates coordinates = GetMonitorCoordinatesFromPoint(layoutCaret);
+        const int marginLeftBefore = Global::MarginLeft;
+        const int marginTopBefore = Global::MarginTop;
+        const std::pair<double, double> slotDecoratedSize = AddCandidateDecorationToSize(paintedSize);
+
+        ReanchorCandidateHostToPaintedCard(layoutCaret, paintedSize, coordinates, hostHeightPx, slotScale, hostX,
+                                           hostY);
+        KeepCandidateCardInsideHostAndMonitor(hostX, hostY, hostWidthPx, hostHeightPx, slotDecoratedSize.first,
+                                              slotDecoratedSize.second, slotScale, coordinates,
+                                              slotDecoratedSize.first);
+        if (hostX != slotHostRect.left || hostY != slotHostRect.top)
         {
-            Global::MarginTop = (std::max)(0, Global::MarginTop - deltaDip);
+            SuppressCandidateDpiChange suppressDpi;
+            SetWindowPos(hwnd, nullptr, hostX, hostY, 0, 0,
+                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSIZE | SWP_SHOWWINDOW);
+            if (webviewControllerCandWnd)
+            {
+                webviewControllerCandWnd->NotifyParentWindowPositionChanged();
+            }
+        }
+        if (Global::MarginLeft != marginLeftBefore || Global::MarginTop != marginTopBefore)
+        {
             MoveContainerBottom(webviewCandWnd, Global::MarginTop);
         }
     }
@@ -664,11 +735,7 @@ void MaybeExpandCandidateClipFromSlotMeasure(HWND hwnd)
     {
         return;
     }
-    FLOAT scale = GetWebViewRasterizationScale(hwnd);
-    if (scale <= 0.0f)
-    {
-        scale = clipLimits.scale > 0.0f ? clipLimits.scale : 1.0f;
-    }
+    const FLOAT scale = slotScale;
     double extraTopDip = 0.0;
     if (g_candidate_placed_above_caret)
     {
@@ -1077,7 +1144,21 @@ void KeepCandidateCardInsideHostAndMonitor( //
         const double maxMarginLeft = maxMarginLeftDip();
         if (Global::MarginLeft > maxMarginLeft)
         {
+            // Margin alone cannot carry the card to its anchor. Truncating it here
+            // silently snapped the card back to the host's right end — a sideways
+            // jump with no relation to the caret. Slide the stable host right by the
+            // shortfall instead so the card keeps the position placement asked for.
+            const int shortfallPx = static_cast<int>(std::lround((Global::MarginLeft - maxMarginLeft) * scale));
             Global::MarginLeft = static_cast<int>(std::floor(maxMarginLeft));
+            hostX += shortfallPx;
+            if (hostX + hostWidthPx > coordinates.right - edgePadPx)
+            {
+                hostX = coordinates.right - hostWidthPx - edgePadPx;
+            }
+            if (hostX < coordinates.left + edgePadPx)
+            {
+                hostX = coordinates.left + edgePadPx;
+            }
         }
     }
     else
@@ -1100,7 +1181,21 @@ void KeepCandidateCardInsideHostAndMonitor( //
         const double maxMarginTop = maxMarginTopDip();
         if (Global::MarginTop > maxMarginTop)
         {
+            // Same rule as MarginLeft above: margin alone cannot carry the card
+            // down to its anchor, so slide the stable host instead of truncating
+            // — truncation would snap the card up to the host's lower end, a
+            // vertical jump with no relation to the caret.
+            const int shortfallPx = static_cast<int>(std::lround((Global::MarginTop - maxMarginTop) * scale));
             Global::MarginTop = static_cast<int>(std::floor(maxMarginTop));
+            hostY += shortfallPx;
+            if (hostY + hostHeightPx > coordinates.bottom - edgePadPx)
+            {
+                hostY = coordinates.bottom - hostHeightPx - edgePadPx;
+            }
+            if (hostY < coordinates.top + edgePadPx)
+            {
+                hostY = coordinates.top + edgePadPx;
+            }
         }
     }
     else


### PR DESCRIPTION
## 问题

两个候选窗定位问题，D2D 与 WebView2 两种渲染后端下都会出现：

1. 候选窗右边缘贴住屏幕右边缘后，删除字符时右边缘会离开屏幕边缘，越删越远。
2. 候选窗靠近屏幕下边缘时上下乱飘：有时正常停在当前行文字上方，有时直接盖住当前行的文字。

## 原因

两者是同一个病根——最终定位用的不是候选卡片本身，或者压根没有重新定位。

**D2D。** `PlaceAndShow` 末尾的水平夹取用的是宿主窗口宽度。宿主带透明阴影内边距、向上取整到 64px、而且打字过程中只增不减，于是卡片被这些余量整体推离右边缘。`AdjustCandidateWindowPosition` 本来已经把卡片停在了屏幕边缘上，删字后过大的宿主宽度被保留下来，卡片左边缘就被冻住，右边缘于是每删一个字就离边缘更远一点。

**WebView2。** 内容更新只走「重绘不重排」的两条路径（`RefreshCandidateClipAfterPaint`、`MaybeExpandCandidateClipFromSlotMeasure`），它们从不重做上下翻转判定，只是：

- 用 `MarginTop -= 高度差` 这个累加器去粘住底边，把此前每一次夹取的误差都攒了进去；
- 交给 `KeepCandidateCardInsideHostAndMonitor` 夹取，而它在卡片底边越过工作区下边界时**直接把卡片往上推**。

于是：候选窗本来在光标下方勉强放得下 → 下一个键多出一行释义、卡片变高 → 没有重新判定翻转，只被往上推 → 正好推到当前行文字上面。完整排版路径会正常翻转到行上方，两条路径交替命中，表现就是「偶发乱飘」。

## 改动

- `candidate_presenter.cpp`：水平夹取改成夹取不透明卡片，与紧随其后的垂直夹取用同一条规则；透明宿主允许越过屏幕边缘。
- `ime_windows.cpp`：新增 `ReanchorCandidateHostToPaintedCard()`，用**实际绘制出来的尺寸**重新调用 `AdjustCandidateWindowPosition` 推导锚点（翻转判定只能信这个高度），宿主窗口靠 margin 够得到就不动、够不到才平移。两条内容更新路径都换用它，两个增量累加器删除。
- `ime_windows.cpp`：`MarginLeft` / `MarginTop` 超出宿主可用余量时改为平移宿主而不是截断——截断会让卡片毫无理由地吸到宿主的另一端。
- `window_utils.cpp`：翻转判定的下边界改用 `coordinates.bottom - edgePadPx`，与下游所有夹取共用一条线；否则会判定「下方放得下」，再被 2 DIP 边距顶回来压到文字上。

## 已知未处理

翻转时的行高仍是写死的 24 DIP：IPC 只传了文本范围的 left 和 bottom，行高在 `GetPhysicalTextAnchor` 里就被丢掉了。宿主报出的行比 24 DIP 高时，翻转后的卡片底边仍会压进那一行——但现在是稳定的偏低，不再忽上忽下。要彻底解决得扩 `FanyImeNamedpipeData::point` 把行高一并传过来，DLL 与 Server 需同时改，留作后续。

## 测试

- `cmake --build server\build-release --config Release --target MetasequoiaImeServer`：通过，无新增告警。
- `clang-format --dry-run -Werror`：干净。
- 这几处定位函数目前没有自动化测试覆盖，**运行时效果尚待人工在两种渲染后端下验证**。
