### PR TITLE
perf(installer): 本地打包默认不含 PDB，并让 Release 编译真正增量

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -477,6 +477,9 @@ jobs:
           CERTIFICATE_THUMBPRINT: ${{ vars.WINDOWS_SIGNING_CERTIFICATE_THUMBPRINT }}
         run: ./scripts/ci/detect-release-signing.ps1
 
+      # -IncludeSymbols is what makes the published installer carry the PDBs matching its binaries.
+      # Staging symbols is opt-in because they are ~140 MB against ~20 MB of binaries and Inno Setup
+      # compresses them with solid LZMA2, which is why the local test scripts leave them out.
       - name: Collect the installer payload
         shell: pwsh
         working-directory: installer
@@ -486,7 +489,7 @@ jobs:
           pwsh -File ./Prepare-PackageFiles.ps1 -TargetVersion $env:TARGET_VERSION
           -RepoRoot (Resolve-Path '..').Path
           -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
-          -HelpCodeDirectory engine/helpcode
+          -HelpCodeDirectory engine/helpcode -IncludeSymbols
 
       - name: Embed the exact product dependency manifest
         env:

--- a/installer/Invoke-LocalTest.ps1
+++ b/installer/Invoke-LocalTest.ps1
@@ -1,0 +1,68 @@
+# 本地测试安装流程的共用实现：编译本仓组件 → 收集安装文件 → 本机自签名 →
+# Inno Setup 打包 → 签安装包 → 启动安装程序。
+#
+# 三个入口都是这个脚本的薄包装：
+#   test.ps1          完整包（含词库），不含 PDB
+#   test-light.ps1    轻量包（不含词库），不含 PDB
+#   test-symbols.ps1  带 PDB，默认轻量，加 -Full 走完整包
+#
+# 编译是增量的：build-release / build{32,64}-release 已有 CMake 缓存时不再重跑 configure
+# （Visual Studio 生成器的 ZERO_CHECK 会在 CMakeLists.txt 变化时自己重新生成），并且只构建
+# 打包用的目标，不构建那些打完包又被删掉的测试可执行文件。-Reconfigure 可强制重跑 configure。
+
+[CmdletBinding()]
+param(
+    # 轻量包：跳过词库、辅助码、拼音表和出厂配置，只刷新 TSF、Server、HTML。
+    # 适用：只改了 TSF、Server 或 HTML，本机已有完整安装（词库已在
+    # %LOCALAPPDATA%\metasequoiaime）。不要用轻量包做首次安装。
+    [switch]$Light,
+    # 把 PDB 打进安装包。PDB 有 ~140 MB，而真正的二进制只有 ~20 MB，Inno Setup 还要对它们做
+    # 固实 LZMA2 压缩，所以默认不打包；只有需要在装好的机器上直接做崩溃分析时才加这个开关。
+    [switch]$IncludeSymbols,
+    # 强制重跑 CMake configure（改了 preset、换了工具链或怀疑缓存不对时用）。
+    [switch]$Reconfigure
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Every build step below uses its own Push-Location and absolute paths ($repoRoot / $PSScriptRoot),
+# so the script never relies on the process cwd. Push/pop it here too, inside try/finally, so the
+# caller's shell is left where it started instead of stranded in installer\ when the script exits.
+Push-Location $PSScriptRoot
+try {
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
+    $serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
+    $settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
+
+    # All three are directories of this repository now, so a missing one is a broken checkout rather
+    # than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
+    # lying around would produce an installer you then run on your own machine.
+    foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
+        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+            throw "缺少组件构建入口：$required"
+        }
+    }
+
+    Push-Location (Join-Path $repoRoot 'windows')
+    try { & $tsfCompile -Reconfigure:$Reconfigure } finally { Pop-Location }
+
+    Push-Location (Join-Path $repoRoot 'server')
+    try { & $serverCompile -Reconfigure:$Reconfigure } finally { Pop-Location }
+
+    Push-Location $settingsDir
+    try {
+        pnpm run build
+        if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+
+    & (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -Light:$Light -IncludeSymbols:$IncludeSymbols `
+        -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
+    & (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
+    & (Join-Path $PSScriptRoot 'Compile-Installer.ps1') -Light:$Light
+    & (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1') -Light:$Light
+    & (Join-Path $PSScriptRoot 'Install.ps1') -Light:$Light
+} finally {
+    Pop-Location
+}

--- a/installer/Prepare-PackageFiles.ps1
+++ b/installer/Prepare-PackageFiles.ps1
@@ -13,7 +13,12 @@ param(
     # the notice covers the whole product and lives at the root, one level above windows/, so where
     # to read it is no longer answered by where the tip is.
     [string]$NoticesDirectory = '.',
-    [switch]$Light
+    [switch]$Light,
+    # PDBs are ~140 MB against ~20 MB of actual binaries, and Inno Setup compresses them with solid
+    # LZMA2, so staging them is what makes a local packaging run take minutes. Symbols are therefore
+    # opt-in: the release job and test-symbols.ps1 pass this, everyday local runs do not. The
+    # assertions above still require the build to have produced matching PDBs either way.
+    [switch]$IncludeSymbols
 )
 
 $ErrorActionPreference = 'Stop'
@@ -179,26 +184,34 @@ Copy-DirectoryContents -Source (Join-Path $webviewRoot 'settings\ime-settings\di
     -Destination (Join-Path $targetWebview 'settings\ime-settings\dist')
 
 # Server Release 输出整体复制，但测试程序及其 PDB 绝不能进入安装包。
-# 其他 PDB 保留在对应 EXE 旁边，方便安装后直接进行崩溃分析。
+# 带 -IncludeSymbols 时其他 PDB 保留在对应 EXE 旁边，方便安装后直接进行崩溃分析。
 Reset-Directory -LiteralPath $targetServer
 Copy-DirectoryContents -Source $serverRelease -Destination $targetServer
 Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter '*Tests.exe' |
     Remove-Item -Force
-Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter '*Tests.pdb' |
-    Remove-Item -Force
 Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter 'test_*.exe' |
     Remove-Item -Force
-Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter 'test_*.pdb' |
-    Remove-Item -Force
+if ($IncludeSymbols) {
+    Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter '*Tests.pdb' |
+        Remove-Item -Force
+    Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter 'test_*.pdb' |
+        Remove-Item -Force
+}
+else {
+    Get-ChildItem -LiteralPath $targetServer -Recurse -File -Filter '*.pdb' |
+        Remove-Item -Force
+}
 
 Reset-Directory -LiteralPath $targetTsf
 $targetTsf32 = Join-Path $targetTsf '32'
 $targetTsf64 = Join-Path $targetTsf '64'
 New-Item -ItemType Directory -Path $targetTsf32, $targetTsf64 -Force | Out-Null
 Copy-Item -LiteralPath $tsf32Release -Destination $targetTsf32 -Force
-Copy-Item -LiteralPath $tsf32Pdb -Destination $targetTsf32 -Force
 Copy-Item -LiteralPath $tsf64Release -Destination $targetTsf64 -Force
-Copy-Item -LiteralPath $tsf64Pdb -Destination $targetTsf64 -Force
+if ($IncludeSymbols) {
+    Copy-Item -LiteralPath $tsf32Pdb -Destination $targetTsf32 -Force
+    Copy-Item -LiteralPath $tsf64Pdb -Destination $targetTsf64 -Force
+}
 Copy-Item -LiteralPath $appIcon -Destination (Join-Path $PSScriptRoot 'MetasequoiaIME.ico') -Force
 # rime-ice is GPL-3.0 and requires attribution, and its content forms the bulk of msime.db, so the
 # notice has to reach the user's disk rather than only exist in the source repository.
@@ -246,5 +259,6 @@ $symbolCount = @(
     Get-ChildItem -LiteralPath $targetServer, $targetTsf -Recurse -File -Filter '*.pdb'
 ).Count
 $modeLabel = if ($Light) { '轻量' } else { '完整' }
+if (-not $IncludeSymbols) { $modeLabel += '，不含符号' }
 Write-Host "安装文件准备完成（$modeLabel）：$PSScriptRoot"
 Write-Host "版本：$TargetVersion；Server EXE/DLL：$serverBinaryCount 个；TSF EXE/DLL：$tsfBinaryCount 个；PDB：$symbolCount 个。"

--- a/installer/README.md
+++ b/installer/README.md
@@ -36,7 +36,7 @@ pwsh -File ./Prepare-PackageFiles.ps1 -TargetVersion 1.2.3 -RepoRoot .. `
 - Windows 10/11，PowerShell 7（`pwsh`）
 - [Inno Setup](https://jrsoftware.org/isinfo.php) 6.6 或更高版本
 - Windows SDK（提供 `signtool.exe`）
-- 先初始化本仓 submodule，并完成 `windows/`、`server/` 的 Release 编译以及 `ui-html/` 设置页构建。Release 构建必须生成同目录 PDB；打包脚本会拒绝缺少匹配符号的产物。
+- 先初始化本仓 submodule，并完成 `windows/`、`server/` 的 Release 编译以及 `ui-html/` 设置页构建。Release 构建必须生成同目录 PDB；打包脚本会拒绝缺少匹配符号的产物（符号是否随包安装是另一回事，由 `-IncludeSymbols` 决定）。
 - 在仓库根目录运行 `python scripts/product_lock.py fetch-dictionaries --staging-root .`，下载并验证产品锁中的词库。
 - `engine/helpcode/helpcodes/` 是本仓的目录，普通检出即有，无需旧 HelpCode 仓库，也无需初始化 submodule。
 
@@ -56,13 +56,35 @@ pwsh -File .\test.ps1
 `test.ps1` 会按顺序做这些事：
 
 1. 编译本仓 TSF、Server，并构建设置页；缺少组件入口则失败
-2. `Prepare-PackageFiles.ps1` — 收集 `server_exe\`、`tsf_dll\`、`app_data\` 及匹配的 PDB，并把 `msime_setup.iss` 的版本写成 `0.0.1`
+2. `Prepare-PackageFiles.ps1` — 收集 `server_exe\`、`tsf_dll\`、`app_data\`，并把 `msime_setup.iss` 的版本写成 `0.0.1`
 3. `Sign-PackageBinaries-Local.ps1` — 本机自签名包内 EXE/DLL
 4. `Compile-Installer.ps1` — 编译出 `Output\MetasequoiaIME_Setup_v0.0.1.exe`
 5. `Sign-Installer-Local.ps1` — 本机自签名安装包
 6. `Install.ps1` — 启动安装程序
 
 也可以按上面的顺序逐步运行。
+
+### 三个入口的区别
+
+三个入口都是 `Invoke-LocalTest.ps1` 的薄包装，只是开关不同：
+
+| 脚本 | 词库 | PDB |
+| --- | --- | --- |
+| `test.ps1` | 含 | 不含 |
+| `test-light.ps1` | 不含 | 不含 |
+| `test-symbols.ps1`（加 `-Full` 则含词库） | 默认不含 | 含 |
+
+**PDB 默认不进本地安装包。** 它们有 ~140 MB，而真正的 EXE/DLL 只有 ~20 MB，Inno Setup 还要对它们做固实 LZMA2 压缩，是本地打包耗时的大头。只有需要在装好的机器上直接做崩溃分析时才用 `test-symbols.ps1`。正式发布仍然带符号：`release.yml` 显式传 `-IncludeSymbols`。
+
+### 增量编译
+
+`Invoke-LocalTest.ps1` 调用的 `lcompile-release*.ps1` 是增量的：
+
+- `build-release` / `build{32,64}-release` 已有 CMake 缓存时不再重跑 configure。Visual Studio 生成器把 ZERO_CHECK 接进了每个目标，`CMakeLists.txt` 变化时构建会自己重新生成。改了 preset 或换了工具链，用 `-Reconfigure` 强制重跑
+- 只构建打包用的目标（`MetasequoiaImeServer` / `MetasequoiaImeTsf`），不构建那些打完包又被删掉的测试可执行文件。要连测试一起构建（比如为了跑 ctest）传 `-Target ALL_BUILD`
+- `cmake --build` 带 `--parallel`
+
+没有改动时整轮编译约 15 秒；如果比这慢很多，慢的多半是打包而不是编译。
 
 ## 本机测试证书
 

--- a/installer/msime_setup.iss
+++ b/installer/msime_setup.iss
@@ -15,6 +15,7 @@
 ; 也可以直接运行 .\test.ps1 走完整测试流程。
 ; 只改 TSF / Server / HTML 时用 .\test-light.ps1：ISCC /DLightPackage=1，
 ; 打出不含词库的轻量包，安装时也不会删本机已有词库。
+; 上面两条都不把 PDB 打进包；要带符号用 .\test-symbols.ps1。
 ; 本仓库不包含任何预置代码签名证书。
 
 #define MyAppName      "Metasequoia IME 水杉输入法"
@@ -99,6 +100,8 @@ Source: "{#MySourceRoot}\LICENSE.txt"; \
 
 ; TSF DLL 使用版本独立目录，避免升级时覆盖仍被进程加载的 DLL。
 ; PDB 与对应 DLL 放在同一目录，调试器可按二进制的内嵌路径自动找到符号。
+; 只有 Prepare-PackageFiles.ps1 -IncludeSymbols 才会把 PDB 放进 tsf_dll\；默认本地打包不含符号，
+; 所以这两条必须带 skipifsourcedoesntexist，否则通配符匹配不到文件时 ISCC 会直接报错。
 Source: "{#MySourceRoot}\tsf_dll\32\*.dll"; \
     DestDir: "{commonpf32}\metasequoiaime\{code:GetVersionDir}"; \
     Flags: ignoreversion regserver 32bit
@@ -109,11 +112,11 @@ Source: "{#MySourceRoot}\tsf_dll\64\*.dll"; \
 
 Source: "{#MySourceRoot}\tsf_dll\32\*.pdb"; \
     DestDir: "{commonpf32}\metasequoiaime\{code:GetVersionDir}"; \
-    Flags: ignoreversion
+    Flags: ignoreversion skipifsourcedoesntexist
 
 Source: "{#MySourceRoot}\tsf_dll\64\*.pdb"; \
     DestDir: "{commonpf64}\metasequoiaime\{code:GetVersionDir}"; \
-    Flags: ignoreversion
+    Flags: ignoreversion skipifsourcedoesntexist
 
 Source: "{#MySourceRoot}\server_exe\*"; \
     DestDir: "{commonpf64}\metasequoiaime\server"; \

--- a/installer/test-light.ps1
+++ b/installer/test-light.ps1
@@ -3,47 +3,11 @@
 # 适用：只改了 TSF、Server 或 HTML，本机已有完整安装（词库已在
 # %LOCALAPPDATA%\metasequoiaime）。不要用这个脚本做首次安装。
 #
-# 完整流程（含词库）仍用 .\test.ps1。
+# 完整流程（含词库）仍用 .\test.ps1；需要包内带 PDB 时用 .\test-symbols.ps1。
+#
+# 编译是增量的，实现见 Invoke-LocalTest.ps1。
 
+[CmdletBinding()]
+param([switch]$Reconfigure)
 $ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
-
-# Every build step below uses its own Push-Location and absolute paths ($repoRoot / $PSScriptRoot),
-# so the script never relies on the process cwd. Push/pop it here too, inside try/finally, so the
-# caller's shell is left where it started instead of stranded in installer\ when the script exits.
-Push-Location $PSScriptRoot
-try {
-    $repoRoot = Split-Path -Parent $PSScriptRoot
-    $tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
-    $serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
-    $settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
-
-    # All three are directories of this repository now, so a missing one is a broken checkout rather
-    # than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
-    # lying around would produce an installer you then run on your own machine.
-    foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
-        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
-            throw "缺少组件构建入口：$required"
-        }
-    }
-
-    Push-Location (Join-Path $repoRoot 'windows')
-    try { & $tsfCompile } finally { Pop-Location }
-
-    Push-Location (Join-Path $repoRoot 'server')
-    try { & $serverCompile } finally { Pop-Location }
-
-    Push-Location $settingsDir
-    try {
-        pnpm run build
-        if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
-    } finally { Pop-Location }
-
-    & (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -Light -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
-    & (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
-    & (Join-Path $PSScriptRoot 'Compile-Installer.ps1') -Light
-    & (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1') -Light
-    & (Join-Path $PSScriptRoot 'Install.ps1') -Light
-} finally {
-    Pop-Location
-}
+& (Join-Path $PSScriptRoot 'Invoke-LocalTest.ps1') -Light -Reconfigure:$Reconfigure

--- a/installer/test-symbols.ps1
+++ b/installer/test-symbols.ps1
@@ -1,0 +1,19 @@
+# 带符号的本地测试安装：和 test-light.ps1 / test.ps1 走同一条流水线，但把 PDB 一起打进安装包，
+# 安装后 PDB 就躺在对应 EXE / DLL 旁边，调试器能按二进制里内嵌的路径直接找到符号。
+#
+#   .\test-symbols.ps1          轻量包（不含词库）+ PDB
+#   .\test-symbols.ps1 -Full    完整包（含词库）+ PDB
+#
+# 只在需要对装好的那一份做崩溃分析时才用这个脚本：PDB 有 ~140 MB，而真正的二进制只有 ~20 MB，
+# Inno Setup 还要对它们做固实 LZMA2 压缩，打包会明显比 test.ps1 / test-light.ps1 慢。
+#
+# 编译是增量的，实现见 Invoke-LocalTest.ps1。
+
+[CmdletBinding()]
+param(
+    # 默认走轻量包，和日常改 TSF / Server / HTML 的节奏一致；要连词库一起装就加 -Full。
+    [switch]$Full,
+    [switch]$Reconfigure
+)
+$ErrorActionPreference = 'Stop'
+& (Join-Path $PSScriptRoot 'Invoke-LocalTest.ps1') -Light:(-not $Full) -IncludeSymbols -Reconfigure:$Reconfigure

--- a/installer/test.ps1
+++ b/installer/test.ps1
@@ -3,46 +3,11 @@
 #
 # 不使用任何预置证书。签名脚本会在本机生成并复用自签名测试证书。
 # 只改 TSF / Server / HTML、且本机已有词库时，用 .\test-light.ps1。
+# 需要包内带 PDB 时用 .\test-symbols.ps1 -Full。
+#
+# 编译是增量的，实现见 Invoke-LocalTest.ps1。
 
+[CmdletBinding()]
+param([switch]$Reconfigure)
 $ErrorActionPreference = 'Stop'
-Set-StrictMode -Version Latest
-
-# Every build step below uses its own Push-Location and absolute paths ($repoRoot / $PSScriptRoot),
-# so the script never relies on the process cwd. Push/pop it here too, inside try/finally, so the
-# caller's shell is left where it started instead of stranded in installer\ when the script exits.
-Push-Location $PSScriptRoot
-try {
-    $repoRoot = Split-Path -Parent $PSScriptRoot
-    $tsfCompile = Join-Path $repoRoot 'windows\scripts\lcompile-release-both.ps1'
-    $serverCompile = Join-Path $repoRoot 'server\scripts\lcompile-release.ps1'
-    $settingsDir = Join-Path $repoRoot 'ui-html\webview2\settings\ime-settings'
-
-    # All three are directories of this repository now, so a missing one is a broken checkout rather
-    # than a neighbour nobody cloned. Skipping the build and packaging whatever binaries happen to be
-    # lying around would produce an installer you then run on your own machine.
-    foreach ($required in @($tsfCompile, $serverCompile, (Join-Path $settingsDir 'package.json'))) {
-        if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
-            throw "缺少组件构建入口：$required"
-        }
-    }
-
-    Push-Location (Join-Path $repoRoot 'windows')
-    try { & $tsfCompile } finally { Pop-Location }
-
-    Push-Location (Join-Path $repoRoot 'server')
-    try { & $serverCompile } finally { Pop-Location }
-
-    Push-Location $settingsDir
-    try {
-        pnpm run build
-        if ($LASTEXITCODE -ne 0) { throw "Settings page build failed ($LASTEXITCODE)" }
-    } finally { Pop-Location }
-
-    & (Join-Path $PSScriptRoot 'Prepare-PackageFiles.ps1') -RepoRoot $repoRoot -TsfDirectory windows -ServerDirectory server -UiHtmlDirectory ui-html -NoticesDirectory .
-    & (Join-Path $PSScriptRoot 'Sign-PackageBinaries-Local.ps1')
-    & (Join-Path $PSScriptRoot 'Compile-Installer.ps1')
-    & (Join-Path $PSScriptRoot 'Sign-Installer-Local.ps1')
-    & (Join-Path $PSScriptRoot 'Install.ps1')
-} finally {
-    Pop-Location
-}
+& (Join-Path $PSScriptRoot 'Invoke-LocalTest.ps1') -Reconfigure:$Reconfigure

--- a/installer/tests/build-failures.ps1
+++ b/installer/tests/build-failures.ps1
@@ -81,7 +81,8 @@ try {
     New-Item -ItemType Directory -Force $installer | Out-Null
     [IO.File]::WriteAllText((Join-Path $installer 'Prepare-PackageFiles.ps1'), "throw 'Reached package staging after failure'")
     function global:pnpm { $global:LASTEXITCODE = 23 }
-    foreach ($entry in @('test.ps1', 'test-light.ps1')) {
+    Copy-Item (Join-Path $source 'installer/Invoke-LocalTest.ps1') $installer
+    foreach ($entry in @('test.ps1', 'test-light.ps1', 'test-symbols.ps1')) {
         Copy-Item (Join-Path $source "installer/$entry") $installer
         $rejected = $false
         try { & (Join-Path $installer $entry) }

--- a/installer/tests/package-files.ps1
+++ b/installer/tests/package-files.ps1
@@ -45,7 +45,7 @@ try {
     $english = Join-Path $fixture 'MetasequoiaImeDict/out/english.db'
     python -c "import sqlite3,sys; sqlite3.connect(sys.argv[1]).execute('CREATE TABLE english_words(word TEXT,display TEXT,weight INTEGER,PRIMARY KEY(word,display))')" $english
     if ($LASTEXITCODE -ne 0) { throw 'Failed to create packaging fixture' }
-    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TargetVersion '2026.9.1'
+    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TargetVersion '2026.9.1' -IncludeSymbols
     foreach ($file in @('app_data/html/webview2/shared/runtime.js', 'app_data/dictionary-manifest.json',
                          'tsf_dll/32/MetasequoiaImeTsf.dll', 'tsf_dll/32/MetasequoiaImeTsf.pdb',
                          'tsf_dll/64/MetasequoiaImeTsf.dll', 'tsf_dll/64/MetasequoiaImeTsf.pdb',
@@ -61,6 +61,20 @@ try {
         'server_exe/test_webview_contract.pdb'
     )) {
         if (Test-Path (Join-Path $installer $testFile)) { throw "Packaged a test file: $testFile" }
+    }
+    # 默认不带符号：PDB 是安装包体积和打包耗时的大头，只有显式 -IncludeSymbols 才进包。
+    & (Join-Path $installer 'Prepare-PackageFiles.ps1') -RepoRoot $fixture -TargetVersion '2026.9.1'
+    foreach ($file in @('app_data/html/webview2/shared/runtime.js',
+                         'tsf_dll/32/MetasequoiaImeTsf.dll', 'tsf_dll/64/MetasequoiaImeTsf.dll',
+                         'server_exe/MetasequoiaImeServer.exe')) {
+        if (-not (Test-Path (Join-Path $installer $file))) { throw "Missing packaged file: $file" }
+    }
+    $stagedSymbols = @(
+        Get-ChildItem -LiteralPath (Join-Path $installer 'server_exe'), (Join-Path $installer 'tsf_dll') `
+            -Recurse -File -Filter '*.pdb'
+    )
+    if ($stagedSymbols.Count -gt 0) {
+        throw "Packaged symbols without -IncludeSymbols: $($stagedSymbols.Name -join ', ')"
     }
     $serverPdbFixture = Join-Path $fixture 'server/build-release/bin/Release/MetasequoiaImeServer.pdb'
     Remove-Item $serverPdbFixture -Force

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -31,6 +31,9 @@ IPC 线格式、opcode 和语音分帧的唯一实现位于 `../engine/contracts
 改了协议或候选逻辑，正常构建并备好数据之后自己跑一次：
 
 ```powershell
+# scripts/lcompile-release.ps1 默认只构建 MetasequoiaImeServer 目标（打包用的那一套），
+# 不含测试可执行文件。要跑 ctest 就得显式构建全部：
+.\scripts\lcompile-release.ps1 -Target ALL_BUILD
 ctest --test-dir build-release -C Release --output-on-failure
 ```
 

--- a/server/scripts/lcompile-release.ps1
+++ b/server/scripts/lcompile-release.ps1
@@ -1,14 +1,27 @@
 # Configure and build the Server; do not reuse old binaries after a failed build.
 [CmdletBinding()]
-param([string]$ManifestTool = 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\mt.exe')
+param(
+    [string]$ManifestTool = 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\mt.exe',
+    # ALL_BUILD also builds MetasequoiaImeServerTests and test_webview_contract, which the packaging
+    # step deletes again. The server target already depends on the watchdog, the three panels,
+    # Settings, DictionaryReplay and the OpenCC dictionaries, so it produces exactly the packaged
+    # set. The test jobs still build everything by passing -Target ALL_BUILD.
+    [string]$Target = 'MetasequoiaImeServer',
+    # The Visual Studio generator wires ZERO_CHECK into every target, so a build regenerates itself
+    # whenever CMakeLists.txt changes. Re-running configure up front only costs ~10s without
+    # changing the result, so do it once and let ZERO_CHECK handle the rest.
+    [switch]$Reconfigure
+)
 $ErrorActionPreference = 'Stop'
 $projectRoot = Split-Path -Parent $PSScriptRoot
 $buildDirectory = Join-Path $projectRoot 'build-release'
 Push-Location $projectRoot
 try {
-    cmake --preset=vcpkg-release
-    if ($LASTEXITCODE -ne 0) { throw "Server configure failed ($LASTEXITCODE)" }
-    cmake --build $buildDirectory --config Release
+    if ($Reconfigure -or -not (Test-Path -LiteralPath (Join-Path $buildDirectory 'CMakeCache.txt'))) {
+        cmake --preset=vcpkg-release
+        if ($LASTEXITCODE -ne 0) { throw "Server configure failed ($LASTEXITCODE)" }
+    }
+    cmake --build $buildDirectory --config Release --target $Target --parallel
     if ($LASTEXITCODE -ne 0) { throw "Server build failed ($LASTEXITCODE)" }
     # Keep the local SDK selection; the complete resource argument must reach mt.exe as one value.
     $binary = Join-Path $buildDirectory 'bin/Release/MetasequoiaImeServer.exe'

--- a/windows/scripts/lcompile-release-both.ps1
+++ b/windows/scripts/lcompile-release-both.ps1
@@ -1,3 +1,5 @@
+[CmdletBinding()]
+param([string]$Target = 'MetasequoiaImeTsf', [switch]$Reconfigure)
 $ErrorActionPreference = 'Stop'
-& (Join-Path $PSScriptRoot 'lcompile-release.ps1') 32
-& (Join-Path $PSScriptRoot 'lcompile-release.ps1') 64
+& (Join-Path $PSScriptRoot 'lcompile-release.ps1') 32 -Target $Target -Reconfigure:$Reconfigure
+& (Join-Path $PSScriptRoot 'lcompile-release.ps1') 64 -Target $Target -Reconfigure:$Reconfigure

--- a/windows/scripts/lcompile-release.ps1
+++ b/windows/scripts/lcompile-release.ps1
@@ -1,13 +1,25 @@
 # Build the TSF DLL without depending on the caller's working directory.
 [CmdletBinding()]
-param([ValidateSet('32', '64')][string]$Architecture = '64')
+param(
+    [ValidateSet('32', '64')][string]$Architecture = '64',
+    # ALL_BUILD also builds test_windows_ipc_contract and the tests/ subdirectory, neither of which
+    # is packaged. Naming the DLL target keeps a local packaging run from paying for them; the test
+    # jobs still build ALL_BUILD by passing -Target ALL_BUILD.
+    [string]$Target = 'MetasequoiaImeTsf',
+    # The Visual Studio generator wires ZERO_CHECK into every target, so a build regenerates itself
+    # whenever CMakeLists.txt changes. Re-running configure up front only costs ~10s per build
+    # directory without changing the result, so do it once and let ZERO_CHECK handle the rest.
+    [switch]$Reconfigure
+)
 $ErrorActionPreference = 'Stop'
 $projectRoot = Split-Path -Parent $PSScriptRoot
 $buildDirectory = Join-Path $projectRoot "build$Architecture-release"
 Push-Location $projectRoot
 try {
-    cmake "--preset=for$Architecture-release"
-    if ($LASTEXITCODE -ne 0) { throw "TSF $Architecture configure failed ($LASTEXITCODE)" }
-    cmake --build $buildDirectory --config Release
+    if ($Reconfigure -or -not (Test-Path -LiteralPath (Join-Path $buildDirectory 'CMakeCache.txt'))) {
+        cmake "--preset=for$Architecture-release"
+        if ($LASTEXITCODE -ne 0) { throw "TSF $Architecture configure failed ($LASTEXITCODE)" }
+    }
+    cmake --build $buildDirectory --config Release --target $Target --parallel
     if ($LASTEXITCODE -ne 0) { throw "TSF $Architecture build failed ($LASTEXITCODE)" }
 } finally { Pop-Location }


### PR DESCRIPTION
## 背景

`installer\test-light.ps1` 每次跑都要等很久，实测后发现瓶颈不在编译器：

| 阶段 | 改前 | 说明 |
| --- | --- | --- |
| cmake configure | 9.7s | 每次都重跑，即使 cache 已存在 |
| Server 构建 | 12.2s | 构建的是 ALL_BUILD，含测试目标 |
| TSF 构建（32+64） | 18.0s | 同上 |
| pnpm build | 2.0s | |
| **ISCC 打包** | **58.7s** | 真正的大头 |

`installer\` 里暂存的产物 184.4 MB 里有约 164 MB 是 PDB，实际二进制只有 20 MB，而 `msime_setup.iss` 用的是 `Compression=lzma2` + `SolidCompression=yes`，所以大部分时间花在压缩本地测试根本用不到的符号上。

## 改动

**1. 本地打包默认不含 PDB，另开带符号入口**

- 新增 `installer\test-symbols.ps1`：需要包内带 PDB 时用它（默认轻量包，`-Full` 走完整包）
- `test.ps1` / `test-light.ps1` 改为不打包 PDB
- `Prepare-PackageFiles.ps1` 新增 `-IncludeSymbols`。**注意：PDB 的存在性断言没有放松**——构建仍然必须产出同名 PDB，否则打包照样失败；这个开关只决定要不要把它们拷进包
- `msime_setup.iss` 的两条 `tsf_dll\*\*.pdb` 加 `skipifsourcedoesntexist`，一份 .iss 同时服务两种模式
- `.github\workflows\release.yml` 显式传 `-IncludeSymbols`，**正式发布的安装包仍然携带与二进制匹配的符号，行为不变**
- `test.ps1` / `test-light.ps1` 原本是两份几乎重复的脚本，抽成共享的 `installer\Invoke-LocalTest.ps1`，三个入口都是薄壳

**2. Release 编译跳过重复 configure，只构建打包用的目标**

- `server/scripts/lcompile-release.ps1`、`windows/scripts/lcompile-release.ps1`、`lcompile-release-both.ps1`：仅在 `CMakeCache.txt` 不存在或显式 `-Reconfigure` 时才跑 `cmake --preset`。VS 生成器的 ZERO_CHECK 本来就会在 CMakeLists 变化时自动重新生成，前置的 configure 是纯浪费
- 构建目标从 ALL_BUILD 收窄为打包实际需要的目标（`-Target` 可覆盖），并加 `--parallel`
- 已核对依赖闭包：`MetasequoiaImeServer` 通过 `add_dependencies` 仍会带出 Watchdog、Emoji/Keyboard/Handwriting 面板、Settings、DictionaryReplay 和 OpenCC `Dictionaries` 共 7 个产品 EXE；被排除的只有 `MetasequoiaImeServerTests` 和 `test_webview_contract`
- 因此本地 `ctest` 之前需要先 `.\scripts\lcompile-release.ps1 -Target ALL_BUILD`，已写进 `server/AGENTS.md`

## 效果

| | 改前 | 改后 |
| --- | --- | --- |
| TSF 增量构建 | 18.0s | 3.7s |
| Server 增量构建 | 21.9s | 10.9s |
| ISCC 打包 | 58.7s | 9.2s |
| 安装包体积 | 33.4 MB | 7.7 MB |

## 验证

系统：Windows 11 Pro 26200，PowerShell 7，Visual Studio 18 2026 生成器。

- 完整跑通 `.\installer\test-light.ps1`，安装包生成并成功安装；上表的耗时即此次实测
- 跑 `.\installer\test-symbols.ps1`，确认包内 `tsf_dll\32\`、`tsf_dll\64\`、`server_exe\` 都带 PDB，ISCC 编译成功
- 手工执行 `cmake --build build-release --config Release --target MetasequoiaImeServer --parallel`，逐个确认 7 个产品 EXE 都产出，两个测试 EXE 未构建
- `pwsh -File installer\tests\package-files.ps1` 通过（已补充：默认运行断言暂存目录内零个 PDB；带符号运行走 `-IncludeSymbols`）
- `pwsh -File installer\tests\build-failures.ps1` 通过（fixture 增加 `Invoke-LocalTest.ps1`，并把 `test-symbols.ps1` 纳入循环）
- `bash scripts/ci/check-developer-paths.sh` 通过

两个与本 PR 无关的本机环境问题，如实记录：

- `python -m unittest discover -s tests` → 19 个用例 1 个失败：`test_passing_pr_ci_merges_only_tested_head` 报 `scripts/ci/land-release-pr.sh: line 33: jq: command not found`。本机没装 `jq`，该脚本本 PR 未改动
- `bash scripts/format.sh --check` → exit 127，`/tmp/metasequoia-clang-format-18.1.8/bin/pip: No such file or directory`，本机 clang-format bootstrap 坏了。本 PR 未改动任何 C++