### PR TITLE
fix(settings): 界面渲染下拉框的弹出菜单与按钮同宽

### DIFF
--- a/ui-html/webview2/settings/ime-settings/src/partials/appearance.html
+++ b/ui-html/webview2/settings/ime-settings/src/partials/appearance.html
@@ -27,7 +27,7 @@
           </div>
         </button>
         <div class="dropdown-menu" id="uiBackendMenu">
-          <div class="dropdown-item" data-value="d2d">Direct2D（原生）</div>
+          <div class="dropdown-item" data-value="d2d">Direct2D</div>
           <div class="dropdown-item" data-value="webview2">WebView2</div>
         </div>
       </div>

--- a/ui-html/webview2/settings/ime-settings/src/styles/modules/appearance.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/modules/appearance.css
@@ -102,6 +102,22 @@
 }
 
 /**/
+/* 界面渲染 */
+/**/
+/* 两个选项的文字宽度不同，按钮得有个固定宽度，否则切换渲染方式时按钮会跟着变宽变窄。
+   宽度按最长的 "WebView2" 来定，只比它的自然宽度多留一点余量。 */
+#uiBackendBtn {
+  min-width: 120px;
+}
+
+/* 弹出菜单跟按钮一样宽：.dropdown 由按钮撑开，左右都贴住即可（同 .font-dropdown-menu）。 */
+#uiBackendMenu {
+  left: 0;
+  right: 0;
+  min-width: 0;
+}
+
+/**/
 /* 重启输入法进程 */
 /**/
 .restart-server-button {


### PR DESCRIPTION
## 问题

设置页「外观 → 界面渲染」的下拉框有两个问题：

1. 弹出菜单靠内容撑宽，和上方的切换按钮宽度对不齐
2. 按钮文字右侧的留白偏大

## 改动

`ui-html/webview2/settings/ime-settings/src/styles/modules/appearance.css`：

- `#uiBackendMenu` 用 `left: 0; right: 0; min-width: 0`，让菜单贴住 `.dropdown` 的左右边界。`.dropdown` 是 `position: relative; display: inline-block`，宽度由按钮撑开，所以菜单自然和按钮同宽。这和已有的 `.font-dropdown-menu` 是同一套做法
- `#uiBackendBtn` 给 `min-width: 120px`。`.dropdown-toggle` 是 `justify-content: space-between`，按钮宽度不定住的话，在 “Direct2D” 和 “WebView2” 之间切换时按钮会跟着变宽变窄；固定宽度按最长的 “WebView2” 取，只比它的自然宽度多留一点余量，右侧留白约为原来的一半

`ui-html/webview2/settings/ime-settings/src/partials/appearance.html`：选项文案 `Direct2D（原生）` 改为 `Direct2D`。

## 验证

系统：Windows 11 Pro 26200。

- `pnpm run build` 通过
- `pnpm test`（vitest）通过：5 个测试文件 23 个用例全绿

**尚未做实机目视验证。** 本机没有可用的无头浏览器，这个改动我没有在真实设置窗口里渲染确认过。`min-width: 120px` 是按截图实测像素推算的：1.5 倍缩放下按钮 195 物理像素 ≈ 130 CSS 像素，文字约 73.7px，自然宽度约 112px，原右侧间隙约 18px，取一半后得 120px。合并前建议装包打开设置页 → 外观 → 界面渲染实际看一眼；如果还想再紧或再松，改这一个数值即可。