### PR TITLE
feat(server): 模糊音规则接入设置链路——总开关、11 规则勾选与首次启用全选

### DIFF
--- a/installer/default_config/config.default.toml
+++ b/installer/default_config/config.default.toml
@@ -186,6 +186,8 @@ japanese_schema = "romaji"
 # 模糊音，全拼与双拼均生效；默认全部关闭，升级用户零行为变化
 # 总开关：关闭时所有规则不生效，已选规则保留，便于临时停用后恢复
 fuzzy_pinyin = false
+# 播种标记（内部键，勿手改）：首次启用总开关时自动置位；缺失会被升级合并丢弃，导致误重播种
+fuzzy_seeded = false
 # 声母：开启后两个音互相当作同一个读音匹配
 fuzzy_z_zh = false
 fuzzy_c_ch = false

--- a/installer/default_config/config.default.toml
+++ b/installer/default_config/config.default.toml
@@ -183,6 +183,20 @@ shuangpin_schema = "xiaohe"
 wubi_schema = "wubi86"
 # 日语方案，当前支持："romaji"
 japanese_schema = "romaji"
+# 模糊音，全拼与双拼均生效；全部默认关闭，升级用户零行为变化
+# 声母：开启后两个音互相当作同一个读音匹配
+fuzzy_z_zh = false
+fuzzy_c_ch = false
+fuzzy_s_sh = false
+fuzzy_n_l = false
+fuzzy_f_h = false
+fuzzy_r_l = false
+# 韵母：前后鼻音等
+fuzzy_an_ang = false
+fuzzy_en_eng = false
+fuzzy_in_ing = false
+fuzzy_ian_iang = false
+fuzzy_uan_uang = false
 
 #
 # Helpcode

--- a/installer/default_config/config.default.toml
+++ b/installer/default_config/config.default.toml
@@ -183,7 +183,9 @@ shuangpin_schema = "xiaohe"
 wubi_schema = "wubi86"
 # 日语方案，当前支持："romaji"
 japanese_schema = "romaji"
-# 模糊音，全拼与双拼均生效；全部默认关闭，升级用户零行为变化
+# 模糊音，全拼与双拼均生效；默认全部关闭，升级用户零行为变化
+# 总开关：关闭时所有规则不生效，已选规则保留，便于临时停用后恢复
+fuzzy_pinyin = false
 # 声母：开启后两个音互相当作同一个读音匹配
 fuzzy_z_zh = false
 fuzzy_c_ch = false

--- a/server/assets/config/config.toml
+++ b/server/assets/config/config.toml
@@ -186,6 +186,8 @@ japanese_schema = "romaji"
 # 模糊音，全拼与双拼均生效；默认全部关闭，升级用户零行为变化
 # 总开关：关闭时所有规则不生效，已选规则保留，便于临时停用后恢复
 fuzzy_pinyin = false
+# 播种标记（内部键，勿手改）：首次启用总开关时自动置位；缺失会被升级合并丢弃，导致误重播种
+fuzzy_seeded = false
 # 声母：开启后两个音互相当作同一个读音匹配
 fuzzy_z_zh = false
 fuzzy_c_ch = false

--- a/server/assets/config/config.toml
+++ b/server/assets/config/config.toml
@@ -183,6 +183,20 @@ shuangpin_schema = "xiaohe"
 wubi_schema = "wubi86"
 # 日语方案，当前支持："romaji"
 japanese_schema = "romaji"
+# 模糊音，全拼与双拼均生效；全部默认关闭，升级用户零行为变化
+# 声母：开启后两个音互相当作同一个读音匹配
+fuzzy_z_zh = false
+fuzzy_c_ch = false
+fuzzy_s_sh = false
+fuzzy_n_l = false
+fuzzy_f_h = false
+fuzzy_r_l = false
+# 韵母：前后鼻音等
+fuzzy_an_ang = false
+fuzzy_en_eng = false
+fuzzy_in_ing = false
+fuzzy_ian_iang = false
+fuzzy_uan_uang = false
 
 #
 # Helpcode

--- a/server/assets/config/config.toml
+++ b/server/assets/config/config.toml
@@ -183,7 +183,9 @@ shuangpin_schema = "xiaohe"
 wubi_schema = "wubi86"
 # 日语方案，当前支持："romaji"
 japanese_schema = "romaji"
-# 模糊音，全拼与双拼均生效；全部默认关闭，升级用户零行为变化
+# 模糊音，全拼与双拼均生效；默认全部关闭，升级用户零行为变化
+# 总开关：关闭时所有规则不生效，已选规则保留，便于临时停用后恢复
+fuzzy_pinyin = false
 # 声母：开启后两个音互相当作同一个读音匹配
 fuzzy_z_zh = false
 fuzzy_c_ch = false

--- a/server/src/config/ime_config.cpp
+++ b/server/src/config/ime_config.cpp
@@ -81,6 +81,9 @@ bool g_quanpin_autocorrect_transposition = false;
 bool g_quanpin_autocorrect_neighbor = false;
 // Bitmask of FuzzyPinyinRule bits. All off by default so upgrades never change behavior.
 std::uint32_t g_fuzzy_pinyin_rules = 0;
+// Master switch, off by default. It gates GetConfiguredFuzzyPinyinOptions only; the rule
+// bitmask above keeps its value so temporary disable/enable preserves the user's choices.
+bool g_fuzzy_pinyin_enabled = false;
 // Config key ↔ engine rule bit. The key mirrors the enumerator name lowercased, so the
 // only mapping to review is this table; the bit position lives in the enum itself.
 struct FuzzyPinyinRuleKey
@@ -893,6 +896,7 @@ bool LoadImeConfig()
             tbl["helpcode"]["show_qp_helpcode_in_candidate_window"].value_or(true);
         g_quanpin_autocorrect_transposition = tbl["quanpin"]["autocorrect_transposition"].value_or(false);
         g_quanpin_autocorrect_neighbor = tbl["quanpin"]["autocorrect_neighbor"].value_or(false);
+        g_fuzzy_pinyin_enabled = tbl["input"]["fuzzy_pinyin"].value_or(false);
         g_fuzzy_pinyin_rules = 0;
         for (const auto &entry : kFuzzyPinyinRuleKeys)
         {
@@ -2191,7 +2195,30 @@ bool SetConfiguredQuanpinAutocorrectNeighbor(bool enabled)
     return true;
 }
 
+bool GetConfiguredFuzzyPinyinEnabled()
+{
+    return g_fuzzy_pinyin_enabled;
+}
+
+bool SetConfiguredFuzzyPinyinEnabled(bool enabled)
+{
+    if (!WriteConfiguredValue("input", "fuzzy_pinyin", enabled ? "true" : "false"))
+        return false;
+    g_fuzzy_pinyin_enabled = enabled;
+    return true;
+}
+
+// The master switch is gated here and nowhere else: sessions see all-zero rules while it is
+// off, and the cached rule bits survive the toggle so re-enabling restores the prior choice.
 metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinOptions()
+{
+    metasequoia::FuzzyPinyinOptions options;
+    if (g_fuzzy_pinyin_enabled)
+        options.rules = g_fuzzy_pinyin_rules;
+    return options;
+}
+
+metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinRuleStates()
 {
     metasequoia::FuzzyPinyinOptions options;
     options.rules = g_fuzzy_pinyin_rules;

--- a/server/src/config/ime_config.cpp
+++ b/server/src/config/ime_config.cpp
@@ -79,6 +79,28 @@ bool g_show_quanpin_helpcode_in_candidate_window = true;
 // both correction types default to off and users opt in from the settings page.
 bool g_quanpin_autocorrect_transposition = false;
 bool g_quanpin_autocorrect_neighbor = false;
+// Bitmask of FuzzyPinyinRule bits. All off by default so upgrades never change behavior.
+std::uint32_t g_fuzzy_pinyin_rules = 0;
+// Config key ↔ engine rule bit. The key mirrors the enumerator name lowercased, so the
+// only mapping to review is this table; the bit position lives in the enum itself.
+struct FuzzyPinyinRuleKey
+{
+    const char *key;
+    metasequoia::FuzzyPinyinRule rule;
+};
+constexpr FuzzyPinyinRuleKey kFuzzyPinyinRuleKeys[] = {
+    {"fuzzy_z_zh", metasequoia::FuzzyPinyinRule::Z_ZH},
+    {"fuzzy_c_ch", metasequoia::FuzzyPinyinRule::C_CH},
+    {"fuzzy_s_sh", metasequoia::FuzzyPinyinRule::S_SH},
+    {"fuzzy_n_l", metasequoia::FuzzyPinyinRule::N_L},
+    {"fuzzy_f_h", metasequoia::FuzzyPinyinRule::F_H},
+    {"fuzzy_r_l", metasequoia::FuzzyPinyinRule::R_L},
+    {"fuzzy_an_ang", metasequoia::FuzzyPinyinRule::AN_ANG},
+    {"fuzzy_en_eng", metasequoia::FuzzyPinyinRule::EN_ENG},
+    {"fuzzy_in_ing", metasequoia::FuzzyPinyinRule::IN_ING},
+    {"fuzzy_ian_iang", metasequoia::FuzzyPinyinRule::IAN_IANG},
+    {"fuzzy_uan_uang", metasequoia::FuzzyPinyinRule::UAN_UANG},
+};
 bool g_floating_toolbar_enabled = true;
 FloatingToolbarItemsConfig g_floating_toolbar_items;
 double g_floating_toolbar_scale = 1.0;
@@ -871,6 +893,12 @@ bool LoadImeConfig()
             tbl["helpcode"]["show_qp_helpcode_in_candidate_window"].value_or(true);
         g_quanpin_autocorrect_transposition = tbl["quanpin"]["autocorrect_transposition"].value_or(false);
         g_quanpin_autocorrect_neighbor = tbl["quanpin"]["autocorrect_neighbor"].value_or(false);
+        g_fuzzy_pinyin_rules = 0;
+        for (const auto &entry : kFuzzyPinyinRuleKeys)
+        {
+            if (tbl["input"][entry.key].value_or(false))
+                g_fuzzy_pinyin_rules |= static_cast<std::uint32_t>(entry.rule);
+        }
         g_floating_toolbar_enabled = tbl["general"]["floating_toolbar"].value_or(true);
         // Read the old candidate-only key as a migration fallback. New writes
         // use the unified key.
@@ -2160,6 +2188,36 @@ bool SetConfiguredQuanpinAutocorrectNeighbor(bool enabled)
         return false;
     }
     g_quanpin_autocorrect_neighbor = enabled;
+    return true;
+}
+
+metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinOptions()
+{
+    metasequoia::FuzzyPinyinOptions options;
+    options.rules = g_fuzzy_pinyin_rules;
+    return options;
+}
+
+bool SetConfiguredFuzzyPinyinRule(const std::string &key, bool enabled)
+{
+    const FuzzyPinyinRuleKey *entry = nullptr;
+    for (const auto &candidate : kFuzzyPinyinRuleKeys)
+    {
+        if (key == candidate.key)
+        {
+            entry = &candidate;
+            break;
+        }
+    }
+    if (!entry)
+        return false;
+    const auto bit = static_cast<std::uint32_t>(entry->rule);
+    if (!WriteConfiguredValue("input", entry->key, enabled ? "true" : "false"))
+        return false;
+    if (enabled)
+        g_fuzzy_pinyin_rules |= bit;
+    else
+        g_fuzzy_pinyin_rules &= ~bit;
     return true;
 }
 

--- a/server/src/config/ime_config.cpp
+++ b/server/src/config/ime_config.cpp
@@ -84,6 +84,10 @@ std::uint32_t g_fuzzy_pinyin_rules = 0;
 // Master switch, off by default. It gates GetConfiguredFuzzyPinyinOptions only; the rule
 // bitmask above keeps its value so temporary disable/enable preserves the user's choices.
 bool g_fuzzy_pinyin_enabled = false;
+// First-enable seed marker: once set, toggling the master switch never rewrites the rule
+// keys. Internal key — never sent to the settings page; if the template loses it, the
+// upgrade merge drops it and every user gets re-seeded on the next master-switch flip.
+bool g_fuzzy_seeded = false;
 // Config key ↔ engine rule bit. The key mirrors the enumerator name lowercased, so the
 // only mapping to review is this table; the bit position lives in the enum itself.
 struct FuzzyPinyinRuleKey
@@ -897,6 +901,7 @@ bool LoadImeConfig()
         g_quanpin_autocorrect_transposition = tbl["quanpin"]["autocorrect_transposition"].value_or(false);
         g_quanpin_autocorrect_neighbor = tbl["quanpin"]["autocorrect_neighbor"].value_or(false);
         g_fuzzy_pinyin_enabled = tbl["input"]["fuzzy_pinyin"].value_or(false);
+        g_fuzzy_seeded = tbl["input"]["fuzzy_seeded"].value_or(false);
         g_fuzzy_pinyin_rules = 0;
         for (const auto &entry : kFuzzyPinyinRuleKeys)
         {
@@ -1226,7 +1231,7 @@ struct ConfigValueUpdate
     std::string value;
 };
 
-bool WriteConfiguredValues(std::initializer_list<ConfigValueUpdate> updates)
+bool WriteConfiguredValues(const std::vector<ConfigValueUpdate> &updates)
 {
     ConfigFileLock lock;
     if (!lock)
@@ -2202,6 +2207,27 @@ bool GetConfiguredFuzzyPinyinEnabled()
 
 bool SetConfiguredFuzzyPinyinEnabled(bool enabled)
 {
+    // 首次启用播种：出厂态第一次开总开关，11 条规则全部置 true 并持久化；之后总开关的
+    // 任何翻动只写总开关一个键，用户修剪过的选择在临时停用/恢复间原样保留。不能拿
+    // 「规则位全零」当首次信号——用户故意全部取消勾选后位图同样是零，无标记会把每次
+    // 开启都误判成首次启用，反复改写用户的空选择。
+    if (enabled && !g_fuzzy_seeded)
+    {
+        std::vector<ConfigValueUpdate> updates;
+        updates.reserve(std::size(kFuzzyPinyinRuleKeys) + 2);
+        updates.push_back({"input", "fuzzy_pinyin", "true"});
+        updates.push_back({"input", "fuzzy_seeded", "true"});
+        for (const auto &entry : kFuzzyPinyinRuleKeys)
+            updates.push_back({"input", entry.key, "true"});
+        // 一次批量写：WriteConfiguredValues 走单文件临时改名，无部分失败态。
+        if (!WriteConfiguredValues(updates))
+            return false;
+        g_fuzzy_pinyin_enabled = true;
+        g_fuzzy_seeded = true;
+        for (const auto &entry : kFuzzyPinyinRuleKeys)
+            g_fuzzy_pinyin_rules |= static_cast<std::uint32_t>(entry.rule);
+        return true;
+    }
     if (!WriteConfiguredValue("input", "fuzzy_pinyin", enabled ? "true" : "false"))
         return false;
     g_fuzzy_pinyin_enabled = enabled;

--- a/server/src/config/ime_config.h
+++ b/server/src/config/ime_config.h
@@ -206,7 +206,15 @@ bool SetConfiguredQuanpinAutocorrectNeighbor(bool enabled);
 // Fuzzy pinyin rules are flat [input] booleans ("fuzzy_z_zh", ...) so the settings page can
 // bind them per key and the upgrade merge keeps user choices per key. Callers get the
 // synthesized engine options and never touch the bitmask themselves.
+// The master switch ("fuzzy_pinyin") gates GetConfiguredFuzzyPinyinOptions only: sessions see
+// all-zero rules while it is off, but the stored rule choices stay intact so flipping it back
+// on restores them.
+bool GetConfiguredFuzzyPinyinEnabled();
+bool SetConfiguredFuzzyPinyinEnabled(bool enabled);
 metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinOptions();
+// Rule bits without the master gate, for the settings snapshot: checkboxes must show the
+// stored choices even while the master switch is off.
+metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinRuleStates();
 // key is the config key without section, e.g. "fuzzy_n_l"; unknown keys return false.
 bool SetConfiguredFuzzyPinyinRule(const std::string &key, bool enabled);
 const std::string &GetConfiguredQuanpinHelpcodeSchema();

--- a/server/src/config/ime_config.h
+++ b/server/src/config/ime_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "engine/core/fuzzy_pinyin_options.h"
 #include "engine/core/scheme_type.h"
 #include <toml++/toml.h>
 #include <filesystem>
@@ -202,6 +203,12 @@ bool GetConfiguredQuanpinAutocorrectTransposition();
 bool SetConfiguredQuanpinAutocorrectTransposition(bool enabled);
 bool GetConfiguredQuanpinAutocorrectNeighbor();
 bool SetConfiguredQuanpinAutocorrectNeighbor(bool enabled);
+// Fuzzy pinyin rules are flat [input] booleans ("fuzzy_z_zh", ...) so the settings page can
+// bind them per key and the upgrade merge keeps user choices per key. Callers get the
+// synthesized engine options and never touch the bitmask themselves.
+metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinOptions();
+// key is the config key without section, e.g. "fuzzy_n_l"; unknown keys return false.
+bool SetConfiguredFuzzyPinyinRule(const std::string &key, bool enabled);
 const std::string &GetConfiguredQuanpinHelpcodeSchema();
 bool SetConfiguredQuanpinHelpcodeSchema(const std::string &schema);
 bool GetConfiguredShowShuangpinHelpcodeInCandidateWindow();

--- a/server/src/config/ime_config.h
+++ b/server/src/config/ime_config.h
@@ -209,6 +209,11 @@ bool SetConfiguredQuanpinAutocorrectNeighbor(bool enabled);
 // The master switch ("fuzzy_pinyin") gates GetConfiguredFuzzyPinyinOptions only: sessions see
 // all-zero rules while it is off, but the stored rule choices stay intact so flipping it back
 // on restores them.
+// First enable seeds: SetConfiguredFuzzyPinyinEnabled(true) while the internal marker key
+// "fuzzy_seeded" is still false batch-writes all 11 rules true plus the marker in one atomic
+// file write. Later toggles only touch the master switch, so a user's pruned selection
+// survives disable/enable cycles; the marker also prevents re-seeding an intentionally empty
+// selection. The marker is never sent to the settings page.
 bool GetConfiguredFuzzyPinyinEnabled();
 bool SetConfiguredFuzzyPinyinEnabled(bool enabled);
 metasequoia::FuzzyPinyinOptions GetConfiguredFuzzyPinyinOptions();

--- a/server/src/session/engine_input_session.cpp
+++ b/server/src/session/engine_input_session.cpp
@@ -34,6 +34,10 @@ void EngineInputSession::ApplyConfiguration()
         (GetConfiguredQuanpinAutocorrectTransposition() ? quanpin::kAutocorrectTransposition : 0u) |
         (GetConfiguredQuanpinAutocorrectNeighbor() ? quanpin::kAutocorrectNeighbor : 0u);
     session_.set_quanpin_autocorrect_types(autocorrect_types);
+    // Fuzzy pinyin applies to both quanpin and shuangpin; the engine fuzzes on the
+    // converted quanpin syllables for shuangpin. Re-read on every key so setting
+    // changes take effect immediately.
+    session_.set_fuzzy_pinyin_options(GetConfiguredFuzzyPinyinOptions());
     session_.set_shuangpin_preedit_uses_raw(GetConfiguredShuangpinPreeditMode() == "shuangpin");
 }
 

--- a/server/src/settings/settings_app.cpp
+++ b/server/src/settings/settings_app.cpp
@@ -309,7 +309,9 @@ std::wstring BuildConfigMessage(bool refresh_skin_catalog)
                                   {"name", std::string(preset.name)},
                                   {"prompt", std::string(preset.prompt)}});
     }
-    const metasequoia::FuzzyPinyinOptions fuzzy_pinyin = GetConfiguredFuzzyPinyinOptions();
+    // 规则位取不门控视图：总开关关闭时复选框仍要展示用户已存的勾选；
+    // 总开关本身单独下发。
+    const metasequoia::FuzzyPinyinOptions fuzzy_rules = GetConfiguredFuzzyPinyinRuleStates();
     nlohmann::json payload = {
         {"type", "configSnapshot"},
         {"data",
@@ -328,17 +330,18 @@ std::wstring BuildConfigMessage(bool refresh_skin_catalog)
             {"smart_punctuation_repeat_to_chinese", GetConfiguredSmartPunctuationRepeatToChineseEnabled()},
             {"paired_punctuation", GetConfiguredPairedPunctuationEnabled()},
             {"punctuation_lock", GetConfiguredPunctuationLock()},
-            {"fuzzy_z_zh", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::Z_ZH)},
-            {"fuzzy_c_ch", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::C_CH)},
-            {"fuzzy_s_sh", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::S_SH)},
-            {"fuzzy_n_l", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::N_L)},
-            {"fuzzy_f_h", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::F_H)},
-            {"fuzzy_r_l", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::R_L)},
-            {"fuzzy_an_ang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::AN_ANG)},
-            {"fuzzy_en_eng", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::EN_ENG)},
-            {"fuzzy_in_ing", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::IN_ING)},
-            {"fuzzy_ian_iang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::IAN_IANG)},
-            {"fuzzy_uan_uang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::UAN_UANG)}}},
+            {"fuzzy_pinyin", GetConfiguredFuzzyPinyinEnabled()},
+            {"fuzzy_z_zh", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::Z_ZH)},
+            {"fuzzy_c_ch", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::C_CH)},
+            {"fuzzy_s_sh", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::S_SH)},
+            {"fuzzy_n_l", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::N_L)},
+            {"fuzzy_f_h", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::F_H)},
+            {"fuzzy_r_l", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::R_L)},
+            {"fuzzy_an_ang", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::AN_ANG)},
+            {"fuzzy_en_eng", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::EN_ENG)},
+            {"fuzzy_in_ing", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::IN_ING)},
+            {"fuzzy_ian_iang", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::IAN_IANG)},
+            {"fuzzy_uan_uang", fuzzy_rules.enabled(metasequoia::FuzzyPinyinRule::UAN_UANG)}}},
           {"general",
            {{"diagnostic_log", GetConfiguredDiagnosticLogEnabled()},
             {"candidate_window_diagnostic_log", GetConfiguredDiagnosticLogEnabled()},
@@ -577,6 +580,9 @@ bool ApplyConfigUpdate(const json::object &data)
         return SetConfiguredPunctuationLock(json::value_to<std::string>(data.at("value")));
     constexpr std::string_view input_section_prefix = "input.";
     constexpr std::string_view fuzzy_prefix = "input.fuzzy_";
+    // 精确分支必须在前：总开关键同样命中 fuzzy_ 前缀，不能靠 prefix setter 拒绝它。
+    if (path == "input.fuzzy_pinyin")
+        return SetConfiguredFuzzyPinyinEnabled(json::value_to<bool>(data.at("value")));
     if (path.rfind(fuzzy_prefix, 0) == 0)
         return SetConfiguredFuzzyPinyinRule(path.substr(input_section_prefix.size()),
                                             json::value_to<bool>(data.at("value")));

--- a/server/src/settings/settings_app.cpp
+++ b/server/src/settings/settings_app.cpp
@@ -309,6 +309,7 @@ std::wstring BuildConfigMessage(bool refresh_skin_catalog)
                                   {"name", std::string(preset.name)},
                                   {"prompt", std::string(preset.prompt)}});
     }
+    const metasequoia::FuzzyPinyinOptions fuzzy_pinyin = GetConfiguredFuzzyPinyinOptions();
     nlohmann::json payload = {
         {"type", "configSnapshot"},
         {"data",
@@ -326,7 +327,18 @@ std::wstring BuildConfigMessage(bool refresh_skin_catalog)
             {"smart_punctuation", GetConfiguredSmartPunctuationEnabled()},
             {"smart_punctuation_repeat_to_chinese", GetConfiguredSmartPunctuationRepeatToChineseEnabled()},
             {"paired_punctuation", GetConfiguredPairedPunctuationEnabled()},
-            {"punctuation_lock", GetConfiguredPunctuationLock()}}},
+            {"punctuation_lock", GetConfiguredPunctuationLock()},
+            {"fuzzy_z_zh", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::Z_ZH)},
+            {"fuzzy_c_ch", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::C_CH)},
+            {"fuzzy_s_sh", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::S_SH)},
+            {"fuzzy_n_l", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::N_L)},
+            {"fuzzy_f_h", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::F_H)},
+            {"fuzzy_r_l", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::R_L)},
+            {"fuzzy_an_ang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::AN_ANG)},
+            {"fuzzy_en_eng", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::EN_ENG)},
+            {"fuzzy_in_ing", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::IN_ING)},
+            {"fuzzy_ian_iang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::IAN_IANG)},
+            {"fuzzy_uan_uang", fuzzy_pinyin.enabled(metasequoia::FuzzyPinyinRule::UAN_UANG)}}},
           {"general",
            {{"diagnostic_log", GetConfiguredDiagnosticLogEnabled()},
             {"candidate_window_diagnostic_log", GetConfiguredDiagnosticLogEnabled()},
@@ -563,6 +575,11 @@ bool ApplyConfigUpdate(const json::object &data)
         return SetConfiguredPairedPunctuationEnabled(json::value_to<bool>(data.at("value")));
     if (path == "input.punctuation_lock")
         return SetConfiguredPunctuationLock(json::value_to<std::string>(data.at("value")));
+    constexpr std::string_view input_section_prefix = "input.";
+    constexpr std::string_view fuzzy_prefix = "input.fuzzy_";
+    if (path.rfind(fuzzy_prefix, 0) == 0)
+        return SetConfiguredFuzzyPinyinRule(path.substr(input_section_prefix.size()),
+                                            json::value_to<bool>(data.at("value")));
     if (path == "appearance.tsf_preedit_style")
         return SetConfiguredTsfPreeditStyle(json::value_to<std::string>(data.at("value")));
     if (path == "appearance.ui_backend")

--- a/server/tests/src/test_config_non_ascii_path.cpp
+++ b/server/tests/src/test_config_non_ascii_path.cpp
@@ -280,7 +280,7 @@ constexpr FuzzyRuleKeyFixture kFuzzyRuleKeyFixtures[] = {
 } // namespace
 
 // 模糊音默认值：无配置文件（首次初始化从模板创建）、模板缺键、全显式 false 三种形态下
-// rules 都必须是 0（AC3：全新安装与升级用户零行为变化）。
+// 总开关为 false 且 rules 都必须是 0（AC2b/AC3：全新安装与升级用户零行为变化）。
 TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
 {
     namespace fs = std::filesystem;
@@ -298,17 +298,20 @@ TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
 
         InitImeConfig();
         REQUIRE(fs::exists(data_dir / L"config.toml"));
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
 
-        // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为 0。
+        // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为关。
         WriteText(data_dir / L"config.toml", "[input]\nschema = \"quanpin\"\n");
         InitImeConfig();
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
 
         // 全部显式 false：与默认逐位一致。
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
             REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
         InitImeConfig();
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
     }
 
@@ -316,6 +319,7 @@ TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
 }
 
 // 逐键开：对应位翻转、其余位不动；全开合成 0x7ff；重启后保持；未知键拒绝且不碰位图。
+// 总开关全程开着：聚合 getter 只有在总开关开时才透出规则位。
 TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
 {
     namespace fs = std::filesystem;
@@ -334,6 +338,8 @@ TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
         InitImeConfig();
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
 
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+
         std::uint32_t expected = 0;
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
         {
@@ -345,6 +351,7 @@ TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
 
         InitImeConfig();
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+        REQUIRE(GetConfiguredFuzzyPinyinEnabled()); // 总开关随重启保持
 
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
         {
@@ -357,6 +364,52 @@ TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
         REQUIRE(!SetConfiguredFuzzyPinyinRule("fuzzy_zh_z", true));
         REQUIRE(!SetConfiguredFuzzyPinyinRule("autocorrect_transposition", true));
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+
+        // 收尾归零，不留脏状态给进程内后续用例。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
+    }
+
+    fs::remove_all(unique_root, ec);
+}
+
+// 总开关门控只在聚合 getter：关 → 全零、规则位缓存保留；开 → 位图立即恢复（AC2b）。
+TEST_CASE(fuzzy_pinyin_master_switch_gates_aggregate_only)
+{
+    namespace fs = std::filesystem;
+    const fs::path unique_root =
+        fs::temp_directory_path() / (L"msime-模糊音门控测试-" + std::to_wstring(GetCurrentProcessId()));
+    const fs::path local_app_data = unique_root / L"profile";
+    const fs::path data_dir = local_app_data / L"metasequoiaime";
+
+    std::error_code ec;
+    fs::remove_all(unique_root, ec);
+    SeedTemplate(data_dir);
+
+    {
+        ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
+
+        InitImeConfig();
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+
+        // 关总开关：会话拿到的 options 全零，规则位缓存保留。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+
+        // 重开：既有选择立即生效；翻动不破坏规则位。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+
+        // 收尾归零。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0u);
     }
 
     fs::remove_all(unique_root, ec);

--- a/server/tests/src/test_config_non_ascii_path.cpp
+++ b/server/tests/src/test_config_non_ascii_path.cpp
@@ -255,3 +255,109 @@ TEST_CASE(quanpin_autocorrect_keys_persist_and_legacy_key_stays_ignored)
 
     fs::remove_all(unique_root, ec);
 }
+
+namespace
+{
+// 与 ime_config.cpp 的 kFuzzyPinyinRuleKeys 同一映射；这里是钉住它的测试副本。
+struct FuzzyRuleKeyFixture
+{
+    const char *key;
+    metasequoia::FuzzyPinyinRule rule;
+};
+constexpr FuzzyRuleKeyFixture kFuzzyRuleKeyFixtures[] = {
+    {"fuzzy_z_zh", metasequoia::FuzzyPinyinRule::Z_ZH},
+    {"fuzzy_c_ch", metasequoia::FuzzyPinyinRule::C_CH},
+    {"fuzzy_s_sh", metasequoia::FuzzyPinyinRule::S_SH},
+    {"fuzzy_n_l", metasequoia::FuzzyPinyinRule::N_L},
+    {"fuzzy_f_h", metasequoia::FuzzyPinyinRule::F_H},
+    {"fuzzy_r_l", metasequoia::FuzzyPinyinRule::R_L},
+    {"fuzzy_an_ang", metasequoia::FuzzyPinyinRule::AN_ANG},
+    {"fuzzy_en_eng", metasequoia::FuzzyPinyinRule::EN_ENG},
+    {"fuzzy_in_ing", metasequoia::FuzzyPinyinRule::IN_ING},
+    {"fuzzy_ian_iang", metasequoia::FuzzyPinyinRule::IAN_IANG},
+    {"fuzzy_uan_uang", metasequoia::FuzzyPinyinRule::UAN_UANG},
+};
+} // namespace
+
+// 模糊音默认值：无配置文件（首次初始化从模板创建）、模板缺键、全显式 false 三种形态下
+// rules 都必须是 0（AC3：全新安装与升级用户零行为变化）。
+TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
+{
+    namespace fs = std::filesystem;
+    const fs::path unique_root =
+        fs::temp_directory_path() / (L"msime-模糊音默认测试-" + std::to_wstring(GetCurrentProcessId()));
+    const fs::path local_app_data = unique_root / L"profile";
+    const fs::path data_dir = local_app_data / L"metasequoiaime";
+
+    std::error_code ec;
+    fs::remove_all(unique_root, ec);
+    SeedTemplate(data_dir);
+
+    {
+        ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
+
+        InitImeConfig();
+        REQUIRE(fs::exists(data_dir / L"config.toml"));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+
+        // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为 0。
+        WriteText(data_dir / L"config.toml", "[input]\nschema = \"quanpin\"\n");
+        InitImeConfig();
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+
+        // 全部显式 false：与默认逐位一致。
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
+        InitImeConfig();
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+    }
+
+    fs::remove_all(unique_root, ec);
+}
+
+// 逐键开：对应位翻转、其余位不动；全开合成 0x7ff；重启后保持；未知键拒绝且不碰位图。
+TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
+{
+    namespace fs = std::filesystem;
+    const fs::path unique_root =
+        fs::temp_directory_path() / (L"msime-模糊音往返测试-" + std::to_wstring(GetCurrentProcessId()));
+    const fs::path local_app_data = unique_root / L"profile";
+    const fs::path data_dir = local_app_data / L"metasequoiaime";
+
+    std::error_code ec;
+    fs::remove_all(unique_root, ec);
+    SeedTemplate(data_dir);
+
+    {
+        ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
+
+        InitImeConfig();
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+
+        std::uint32_t expected = 0;
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+        {
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, true));
+            expected |= static_cast<std::uint32_t>(fixture.rule);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, expected);
+        }
+        REQUIRE_EQ(expected, 0x7ffu); // 11 条规则全开
+
+        InitImeConfig();
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+        {
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
+            expected &= ~static_cast<std::uint32_t>(fixture.rule);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, expected);
+        }
+
+        // 未知键（拼写错误、别的段的键）不得落盘，也不得碰位图。
+        REQUIRE(!SetConfiguredFuzzyPinyinRule("fuzzy_zh_z", true));
+        REQUIRE(!SetConfiguredFuzzyPinyinRule("autocorrect_transposition", true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+    }
+
+    fs::remove_all(unique_root, ec);
+}

--- a/server/tests/src/test_config_non_ascii_path.cpp
+++ b/server/tests/src/test_config_non_ascii_path.cpp
@@ -300,16 +300,21 @@ TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
         REQUIRE(fs::exists(data_dir / L"config.toml"));
         REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+        REQUIRE(ReadText(data_dir / L"config.toml").find("fuzzy_seeded = false") != std::string::npos);
 
-        // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为关。
+        // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为关；播种标记同样缺键，
+        // 与总开关一样按 value_or(false) 处理。
         WriteText(data_dir / L"config.toml", "[input]\nschema = \"quanpin\"\n");
         InitImeConfig();
         REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+        REQUIRE(ReadText(data_dir / L"config.toml").find("fuzzy_seeded") == std::string::npos);
 
-        // 全部显式 false：与默认逐位一致。
+        // 全部显式 false（含播种标记共 13 键）：与默认逐位一致。
+        std::string explicit_false = "[input]\nschema = \"quanpin\"\nfuzzy_pinyin = false\nfuzzy_seeded = false\n";
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
-            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
+            explicit_false += std::string(fixture.key) + " = false\n";
+        WriteText(data_dir / L"config.toml", explicit_false);
         InitImeConfig();
         REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
@@ -319,7 +324,8 @@ TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
 }
 
 // 逐键开：对应位翻转、其余位不动；全开合成 0x7ff；重启后保持；未知键拒绝且不碰位图。
-// 总开关全程开着：聚合 getter 只有在总开关开时才透出规则位。
+// 全程断言不门控视图、不碰总开关：首次开总开关会触发播种把位图整个置满，混进来会破坏
+// 「逐键增量」的语义；总开关门控与首次播种各有专门用例。
 TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
 {
     namespace fs = std::filesystem;
@@ -336,44 +342,38 @@ TEST_CASE(fuzzy_pinyin_rule_keys_round_trip)
         ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
 
         InitImeConfig();
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
-
-        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0u);
 
         std::uint32_t expected = 0;
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
         {
             REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, true));
             expected |= static_cast<std::uint32_t>(fixture.rule);
-            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, expected);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, expected);
         }
         REQUIRE_EQ(expected, 0x7ffu); // 11 条规则全开
 
         InitImeConfig();
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
-        REQUIRE(GetConfiguredFuzzyPinyinEnabled()); // 总开关随重启保持
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
 
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
         {
             REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
             expected &= ~static_cast<std::uint32_t>(fixture.rule);
-            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, expected);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, expected);
         }
 
         // 未知键（拼写错误、别的段的键）不得落盘，也不得碰位图。
         REQUIRE(!SetConfiguredFuzzyPinyinRule("fuzzy_zh_z", true));
         REQUIRE(!SetConfiguredFuzzyPinyinRule("autocorrect_transposition", true));
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
-
-        // 收尾归零，不留脏状态给进程内后续用例。
-        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
-        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0u);
     }
 
     fs::remove_all(unique_root, ec);
 }
 
 // 总开关门控只在聚合 getter：关 → 全零、规则位缓存保留；开 → 位图立即恢复（AC2b）。
+// 规则位走真实用户路径建立：出厂首次启用播种全开，再修剪成子集。
 TEST_CASE(fuzzy_pinyin_master_switch_gates_aggregate_only)
 {
     namespace fs = std::filesystem;
@@ -390,26 +390,117 @@ TEST_CASE(fuzzy_pinyin_master_switch_gates_aggregate_only)
         ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
 
         InitImeConfig();
-        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
-        for (const auto &fixture : kFuzzyRuleKeyFixtures)
-            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, true));
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true)); // 首次启用：播种全部规则
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+
+        // 修剪为子集，之后的翻动不得动它。
+        REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_c_ch", false));
+        REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_n_l", false));
+        const std::uint32_t pruned = 0x7ffu & ~static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::C_CH) &
+                                     ~static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::N_L);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, pruned);
 
         // 关总开关：会话拿到的 options 全零，规则位缓存保留。
         REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, pruned);
 
-        // 重开：既有选择立即生效；翻动不破坏规则位。
+        // 重开：既有选择立即生效（标记已置位，不重播种）；翻动不破坏规则位。
         REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
-        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, pruned);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, pruned);
 
         // 收尾归零。
         REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
         for (const auto &fixture : kFuzzyRuleKeyFixtures)
             REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
         REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0u);
+    }
+
+    fs::remove_all(unique_root, ec);
+}
+
+// 首次启用播种（AC2c）：出厂态开总开关 → 11 规则键全 true + 播种标记 true + 位图 0x7ff；
+// 修剪为子集后反复开关总开关，规则键逐键不变、重启保持；用户故意全部取消后位图归零，
+// 再开总开关也不得重播种——这正是需要持久化标记而不是拿「位图全零」当首次信号的原因。
+TEST_CASE(fuzzy_pinyin_first_enable_seeds_rules_once)
+{
+    namespace fs = std::filesystem;
+    const fs::path unique_root =
+        fs::temp_directory_path() / (L"msime-模糊音播种测试-" + std::to_wstring(GetCurrentProcessId()));
+    const fs::path local_app_data = unique_root / L"profile";
+    const fs::path data_dir = local_app_data / L"metasequoiaime";
+
+    std::error_code ec;
+    fs::remove_all(unique_root, ec);
+    SeedTemplate(data_dir);
+
+    {
+        ScopedEnv local_app_data_env(L"LOCALAPPDATA", local_app_data.wstring());
+
+        InitImeConfig();
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
+
+        // 出厂态首次启用：一次批量写 13 键，内存位图置满、标记置位。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+        {
+            const std::string text = ReadText(data_dir / L"config.toml");
+            REQUIRE(text.find("fuzzy_pinyin = true") != std::string::npos);
+            REQUIRE(text.find("fuzzy_seeded = true") != std::string::npos);
+            for (const auto &fixture : kFuzzyRuleKeyFixtures)
+                REQUIRE(text.find(std::string(fixture.key) + " = true") != std::string::npos);
+        }
+
+        // 重启：播种结果与标记都保持。
+        InitImeConfig();
+        REQUIRE(GetConfiguredFuzzyPinyinEnabled());
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0x7ffu);
+
+        // 修剪为子集：只留 z/zh 和 an/ang。
+        constexpr std::uint32_t kPruned = static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::Z_ZH) |
+                                          static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::AN_ANG);
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+        {
+            const bool want = (static_cast<std::uint32_t>(fixture.rule) & kPruned) != 0;
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, want));
+        }
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, kPruned);
+
+        // 反复开关总开关：规则键逐键不变，重开不重播种。
+        for (int round = 0; round < 3; ++round)
+        {
+            REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, kPruned);
+            REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, kPruned);
+            REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, kPruned);
+        }
+
+        // 重启保持：修剪过的选择跨进程存活。
+        InitImeConfig();
+        REQUIRE(GetConfiguredFuzzyPinyinEnabled());
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, kPruned);
+
+        // 用户故意全部取消勾选：位图归零后再开总开关，不得重新播种——标记是唯一的首次信号。
+        for (const auto &fixture : kFuzzyRuleKeyFixtures)
+            REQUIRE(SetConfiguredFuzzyPinyinRule(fixture.key, false));
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules, 0u);
+        {
+            const std::string text = ReadText(data_dir / L"config.toml");
+            REQUIRE(text.find("fuzzy_seeded = true") != std::string::npos);
+            for (const auto &fixture : kFuzzyRuleKeyFixtures)
+                REQUIRE(text.find(std::string(fixture.key) + " = false") != std::string::npos);
+        }
+
+        // 收尾归零，不留脏状态给进程内后续用例。
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+        REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
     }
 
     fs::remove_all(unique_root, ec);

--- a/server/tests/src/test_config_non_ascii_path.cpp
+++ b/server/tests/src/test_config_non_ascii_path.cpp
@@ -303,12 +303,22 @@ TEST_CASE(fuzzy_pinyin_rules_default_to_all_off)
         REQUIRE(ReadText(data_dir / L"config.toml").find("fuzzy_seeded = false") != std::string::npos);
 
         // 模板缺键：手写一份没有任何 fuzzy 键的配置，重读后仍为关；播种标记同样缺键，
-        // 与总开关一样按 value_or(false) 处理。
+        // 与总开关一样按 value_or(false) 处理。标记没有公开 getter，缺省值用行为兜底：
+        // 缺键即出厂态，开总开关必须播种；若有人把缺省改成 true，这次开启会静默跳过
+        // 播种，下面的位图与文件断言立刻红。
         WriteText(data_dir / L"config.toml", "[input]\nschema = \"quanpin\"\n");
         InitImeConfig();
         REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
         REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
         REQUIRE(ReadText(data_dir / L"config.toml").find("fuzzy_seeded") == std::string::npos);
+        REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+        REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0x7ffu);
+        {
+            const std::string text = ReadText(data_dir / L"config.toml");
+            REQUIRE(text.find("fuzzy_seeded = true") != std::string::npos);
+            for (const auto &fixture : kFuzzyRuleKeyFixtures)
+                REQUIRE(text.find(std::string(fixture.key) + " = true") != std::string::npos);
+        }
 
         // 全部显式 false（含播种标记共 13 键）：与默认逐位一致。
         std::string explicit_false = "[input]\nschema = \"quanpin\"\nfuzzy_pinyin = false\nfuzzy_seeded = false\n";

--- a/server/tests/src/test_engine_shuangpin_session.cpp
+++ b/server/tests/src/test_engine_shuangpin_session.cpp
@@ -120,23 +120,34 @@ TEST_CASE(EngineShuangpinSessionContinuesCompositionWithoutHelpcode)
     REQUIRE_EQ(session.get_pinyin_sequence(), std::string("tele"));
 }
 
-// 模糊音是会话级注入：配置键打开后，新键的 ApplyConfiguration 把规则带给引擎，
-// 全拼输入 zhang 也能命中 zang 读音词；双拼（小鹤 vh = zhang）同一注入路径生效（AC1/AC2）。
+// 模糊音是会话级注入：总开关 + 规则位两层。总开关关 → 聚合 getter 全零，候选不出现；
+// 开规则 + 开总开关 → zang 候选出现（全拼 zhang / 双拼 vh，AC1/AC2）；仅关总开关（规则保留）→
+// 候选消失；重开总开关 → 恢复（AC2b）。
 TEST_CASE(EngineSessionAppliesFuzzyPinyinRulesForQuanpinAndShuangpin)
 {
     ScopedConfigRoot config_root;
     InitImeConfig();
+    REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
     REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
 
-    // 默认全关：zhang 只命中 zhang 读音。
+    // A：默认全关，zhang 只命中 zhang 读音。
     {
         EngineInputSession quanpin(SchemeType::Quanpin);
         InputLetters(quanpin, "zhang");
         REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
     }
 
-    // 开 fuzzy_z_zh：zang 候选出现。
+    // 开规则、总开关仍关：getter 全零，行为不变。
     REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_z_zh", true));
+    REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+    {
+        EngineInputSession quanpin(SchemeType::Quanpin);
+        InputLetters(quanpin, "zhang");
+        REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
+    }
+
+    // B：开总开关 —— 既有规则立即生效，全拼与双拼都出 zang 候选。
+    REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
     {
         EngineInputSession quanpin(SchemeType::Quanpin);
         InputLetters(quanpin, "zhang");
@@ -148,14 +159,29 @@ TEST_CASE(EngineSessionAppliesFuzzyPinyinRulesForQuanpinAndShuangpin)
         REQUIRE(HasCandidateWithCanonicalPrefix(shuangpin, "zang"));
     }
 
-    // 关闭后立即恢复精确匹配；并把位图清零，不留脏状态给进程内后续用例。
-    REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_z_zh", false));
+    // A：仅关总开关（规则位保留）—— 候选消失。
+    REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+    REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules,
+               static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::Z_ZH));
     {
         EngineInputSession quanpin(SchemeType::Quanpin);
         InputLetters(quanpin, "zhang");
         REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
     }
+
+    // B：重开总开关 —— 恢复。
+    REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+    {
+        EngineInputSession quanpin(SchemeType::Quanpin);
+        InputLetters(quanpin, "zhang");
+        REQUIRE(HasCandidateWithCanonicalPrefix(quanpin, "zang"));
+    }
+
+    // 收尾：总开关与规则位归零，不留脏状态给进程内后续用例。
+    REQUIRE(SetConfiguredFuzzyPinyinEnabled(false));
+    REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_z_zh", false));
     REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+    REQUIRE(!GetConfiguredFuzzyPinyinEnabled());
 }
 
 TEST_CASE(CloudCandidateNeverEntersCreatingWordMode)

--- a/server/tests/src/test_engine_shuangpin_session.cpp
+++ b/server/tests/src/test_engine_shuangpin_session.cpp
@@ -5,7 +5,10 @@
 #include "engine/quanpin/quanpin_query.h"
 #include "engine/shuangpin/shuangpin_dictionary.h"
 #include "src/ipc/candidate_selection_policy.h"
+#include <windows.h>
 #include <algorithm>
+#include <filesystem>
+#include <system_error>
 
 namespace
 {
@@ -32,6 +35,56 @@ void InputSequence(EngineInputSession &session, const std::string &keys)
         const char upper = is_upper ? ch : static_cast<char>(ch - ('a' - 'A'));
         session.handle_key(static_cast<UINT>(upper), 0, static_cast<WCHAR>(ch));
     }
+}
+
+// 把 ime 配置重定向到一次性目录：SetConfiguredFuzzyPinyinRule 会真实落盘，
+// 不能写进开发机的用户配置。引擎词库仍走 METASEQUOIA_IME_DATA_DIR，不受影响。
+class ScopedConfigRoot
+{
+  public:
+    ScopedConfigRoot()
+    {
+        wchar_t buffer[32768];
+        const DWORD length = GetEnvironmentVariableW(L"LOCALAPPDATA", buffer, 32768);
+        had_previous_ = length != 0 || GetLastError() != ERROR_ENVVAR_NOT_FOUND;
+        previous_.assign(buffer, length);
+        root_ = std::filesystem::temp_directory_path() /
+                (L"msime-模糊音注入测试-" + std::to_wstring(GetCurrentProcessId()));
+        const auto data_dir = root_ / L"metasequoiaime";
+        std::error_code ec;
+        std::filesystem::remove_all(root_, ec);
+        std::filesystem::create_directories(data_dir, ec);
+        std::filesystem::copy_file(MSIME_DEFAULT_CONFIG_PATH, data_dir / L"config.default.toml",
+                                   std::filesystem::copy_options::overwrite_existing, ec);
+        // 拷贝失败（如仓库路径含非 ASCII 字符被 ACP 转换破坏）必须在源头报出来，
+        // 否则后面的 SetConfiguredFuzzyPinyinRule 会以无关断言的形式失败。
+        REQUIRE(!ec);
+        SetEnvironmentVariableW(L"LOCALAPPDATA", root_.c_str());
+    }
+    ~ScopedConfigRoot()
+    {
+        SetEnvironmentVariableW(L"LOCALAPPDATA", had_previous_ ? previous_.c_str() : nullptr);
+        std::error_code ec;
+        std::filesystem::remove_all(root_, ec);
+    }
+
+    ScopedConfigRoot(const ScopedConfigRoot &) = delete;
+    ScopedConfigRoot &operator=(const ScopedConfigRoot &) = delete;
+
+  private:
+    std::wstring previous_;
+    bool had_previous_ = false;
+    std::filesystem::path root_;
+};
+
+bool HasCandidateWithCanonicalPrefix(const EngineInputSession &session, const char *prefix)
+{
+    for (const auto &item : session.get_candidates())
+    {
+        if (item.canonical_pinyin.rfind(prefix, 0) == 0)
+            return true;
+    }
+    return false;
 }
 } // namespace
 
@@ -65,6 +118,44 @@ TEST_CASE(EngineShuangpinSessionContinuesCompositionWithoutHelpcode)
     const auto transition = session.advance_composition_after_selection("xi", "西", "xi");
     REQUIRE(transition.continues_composition);
     REQUIRE_EQ(session.get_pinyin_sequence(), std::string("tele"));
+}
+
+// 模糊音是会话级注入：配置键打开后，新键的 ApplyConfiguration 把规则带给引擎，
+// 全拼输入 zhang 也能命中 zang 读音词；双拼（小鹤 vh = zhang）同一注入路径生效（AC1/AC2）。
+TEST_CASE(EngineSessionAppliesFuzzyPinyinRulesForQuanpinAndShuangpin)
+{
+    ScopedConfigRoot config_root;
+    InitImeConfig();
+    REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
+
+    // 默认全关：zhang 只命中 zhang 读音。
+    {
+        EngineInputSession quanpin(SchemeType::Quanpin);
+        InputLetters(quanpin, "zhang");
+        REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
+    }
+
+    // 开 fuzzy_z_zh：zang 候选出现。
+    REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_z_zh", true));
+    {
+        EngineInputSession quanpin(SchemeType::Quanpin);
+        InputLetters(quanpin, "zhang");
+        REQUIRE(HasCandidateWithCanonicalPrefix(quanpin, "zang"));
+    }
+    {
+        EngineInputSession shuangpin(SchemeType::Shuangpin);
+        InputLetters(shuangpin, "vh");
+        REQUIRE(HasCandidateWithCanonicalPrefix(shuangpin, "zang"));
+    }
+
+    // 关闭后立即恢复精确匹配；并把位图清零，不留脏状态给进程内后续用例。
+    REQUIRE(SetConfiguredFuzzyPinyinRule("fuzzy_z_zh", false));
+    {
+        EngineInputSession quanpin(SchemeType::Quanpin);
+        InputLetters(quanpin, "zhang");
+        REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
+    }
+    REQUIRE_EQ(GetConfiguredFuzzyPinyinOptions().rules, 0u);
 }
 
 TEST_CASE(CloudCandidateNeverEntersCreatingWordMode)

--- a/server/tests/src/test_engine_shuangpin_session.cpp
+++ b/server/tests/src/test_engine_shuangpin_session.cpp
@@ -146,8 +146,14 @@ TEST_CASE(EngineSessionAppliesFuzzyPinyinRulesForQuanpinAndShuangpin)
         REQUIRE(!HasCandidateWithCanonicalPrefix(quanpin, "zang"));
     }
 
-    // B：开总开关 —— 既有规则立即生效，全拼与双拼都出 zang 候选。
+    // B：开总开关 —— 首次启用会播种全部规则（产品语义）；本用例要的是「只有 z/zh 一条
+    // 规则」的纯净场景，播种后把其余规则关回去，此后总开关翻动不再碰规则位。
     REQUIRE(SetConfiguredFuzzyPinyinEnabled(true));
+    for (const char *key : {"fuzzy_c_ch", "fuzzy_s_sh", "fuzzy_n_l", "fuzzy_f_h", "fuzzy_r_l", "fuzzy_an_ang",
+                            "fuzzy_en_eng", "fuzzy_in_ing", "fuzzy_ian_iang", "fuzzy_uan_uang"})
+        REQUIRE(SetConfiguredFuzzyPinyinRule(key, false));
+    REQUIRE_EQ(GetConfiguredFuzzyPinyinRuleStates().rules,
+               static_cast<std::uint32_t>(metasequoia::FuzzyPinyinRule::Z_ZH));
     {
         EngineInputSession quanpin(SchemeType::Quanpin);
         InputLetters(quanpin, "zhang");

--- a/ui-html/webview2/settings/ime-settings/src/modules/config-sync.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/config-sync.ts
@@ -126,6 +126,26 @@ function applyConfigData(data: Record<string, any>, target?: string): void {
   if (typeof data?.quanpin?.autocorrect_neighbor === 'boolean') {
     applyToggleState('autocorrectNeighborToggleBtn', data.quanpin.autocorrect_neighbor);
   }
+  // 模糊音 11 键逐键回填；单键缺失/类型不符不影响其余键（AC4）。
+  const fuzzyRuleCheckboxes: [string, string][] = [
+    ['fuzzyZZhCheckbox', 'fuzzy_z_zh'],
+    ['fuzzyCChCheckbox', 'fuzzy_c_ch'],
+    ['fuzzySShCheckbox', 'fuzzy_s_sh'],
+    ['fuzzyNlCheckbox', 'fuzzy_n_l'],
+    ['fuzzyFhCheckbox', 'fuzzy_f_h'],
+    ['fuzzyRlCheckbox', 'fuzzy_r_l'],
+    ['fuzzyAnAngCheckbox', 'fuzzy_an_ang'],
+    ['fuzzyEnEngCheckbox', 'fuzzy_en_eng'],
+    ['fuzzyInIngCheckbox', 'fuzzy_in_ing'],
+    ['fuzzyIanIangCheckbox', 'fuzzy_ian_iang'],
+    ['fuzzyUanUangCheckbox', 'fuzzy_uan_uang']
+  ];
+  for (const [id, key] of fuzzyRuleCheckboxes) {
+    const value = data?.input?.[key];
+    if (typeof value !== 'boolean') continue;
+    const checkbox = findElement(id) as HTMLInputElement | null;
+    if (checkbox) checkbox.checked = value;
+  }
   if (data?.input?.punctuation_lock === 'chinese' || data?.input?.punctuation_lock === 'english' ||
       data?.input?.punctuation_lock === 'follow') {
     applyToggleState('alwaysEnglishPunctuationToggleBtn', data.input.punctuation_lock === 'english');

--- a/ui-html/webview2/settings/ime-settings/src/modules/config-sync.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/config-sync.ts
@@ -1,6 +1,6 @@
 import { onHostMessage } from '../utils/host-messages';
 import { serializeHostMessage } from '../../../../shared/messages';
-import { applyCandidateArrange, applyDropdownValue as applyDropdown, applyToggleState as applyToggle } from './shared';
+import { applyCandidateArrange, applyDropdownValue as applyDropdown, applyToggleState as applyToggle, setFuzzyRuleOptionsDisabled } from './shared';
 
 let lastSnapshot: Record<string, any> | null = null;
 const readyModules = new Set<string>();
@@ -125,6 +125,11 @@ function applyConfigData(data: Record<string, any>, target?: string): void {
   }
   if (typeof data?.quanpin?.autocorrect_neighbor === 'boolean') {
     applyToggleState('autocorrectNeighborToggleBtn', data.quanpin.autocorrect_neighbor);
+  }
+  // 先回填总开关再回填规则：总开关关闭时规则复选禁用并提示，但勾选状态仍按已存值展示。
+  if (typeof data?.input?.fuzzy_pinyin === 'boolean') {
+    applyToggleState('fuzzyPinyinToggleBtn', data.input.fuzzy_pinyin);
+    setFuzzyRuleOptionsDisabled(!data.input.fuzzy_pinyin);
   }
   // 模糊音 11 键逐键回填；单键缺失/类型不符不影响其余键（AC4）。
   const fuzzyRuleCheckboxes: [string, string][] = [

--- a/ui-html/webview2/settings/ime-settings/src/modules/input.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/input.ts
@@ -220,6 +220,7 @@ export function setupInput(): void {
   setupToggleButton('autocorrectNeighborToggleBtn', (active) => {
     updateConfig('quanpin.autocorrect_neighbor', active);
   });
+  setupFuzzyRuleOptions();
   setupToggleButton('smartPunctuationRepeatToChineseToggleBtn', (active) => {
     updateConfig('input.smart_punctuation_repeat_to_chinese', active);
   });
@@ -306,6 +307,15 @@ function setupPageOptions(): void {
       };
       const path = configPaths[checkbox.value];
       if (path) updateConfig(path, checkbox.checked);
+    });
+  });
+}
+
+// 模糊音 11 键同名同前缀：checkbox value 直接是 [input] 段的配置键。
+function setupFuzzyRuleOptions(): void {
+  document.querySelectorAll<HTMLInputElement>('input[name="fuzzy-rule"]').forEach((checkbox) => {
+    checkbox.addEventListener('change', () => {
+      if (checkbox.value.startsWith('fuzzy_')) updateConfig(`input.${checkbox.value}`, checkbox.checked);
     });
   });
 }

--- a/ui-html/webview2/settings/ime-settings/src/modules/input.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/input.ts
@@ -1,5 +1,5 @@
 import { serializeHostMessage } from '../../../../shared/messages';
-import { applyDropdownValue, applyToggleState, setupDropdownMenu, setupToggleButton } from './shared';
+import { applyDropdownValue, applyToggleState, setFuzzyRuleOptionsDisabled, setupDropdownMenu, setupToggleButton } from './shared';
 import { updateConfig } from './config-sync';
 import { updateCandidatePreviewHelpcode } from './appearance';
 
@@ -220,7 +220,7 @@ export function setupInput(): void {
   setupToggleButton('autocorrectNeighborToggleBtn', (active) => {
     updateConfig('quanpin.autocorrect_neighbor', active);
   });
-  setupFuzzyRuleOptions();
+  setupFuzzySection();
   setupToggleButton('smartPunctuationRepeatToChineseToggleBtn', (active) => {
     updateConfig('input.smart_punctuation_repeat_to_chinese', active);
   });
@@ -309,6 +309,23 @@ function setupPageOptions(): void {
       if (path) updateConfig(path, checkbox.checked);
     });
   });
+}
+
+// 模糊音分区：折叠头 + 总开关 + 11 规则复选。折叠交互仿 appearance.ts 的主题模式：
+// aria-expanded 驱动 chevron 与容器显隐，默认收起且不跨会话持久化。
+function setupFuzzySection(): void {
+  setupToggleButton('fuzzyPinyinToggleBtn', (active) => {
+    updateConfig('input.fuzzy_pinyin', active);
+    setFuzzyRuleOptionsDisabled(!active);
+  });
+  const fuzzyExpand = document.getElementById('fuzzyExpand');
+  const fuzzyDetails = document.getElementById('fuzzyDetails');
+  fuzzyExpand?.addEventListener('click', () => {
+    const expanded = fuzzyExpand.getAttribute('aria-expanded') !== 'true';
+    fuzzyExpand.setAttribute('aria-expanded', String(expanded));
+    fuzzyDetails?.classList.toggle('open', expanded);
+  });
+  setupFuzzyRuleOptions();
 }
 
 // 模糊音 11 键同名同前缀：checkbox value 直接是 [input] 段的配置键。

--- a/ui-html/webview2/settings/ime-settings/src/modules/shared.ts
+++ b/ui-html/webview2/settings/ime-settings/src/modules/shared.ts
@@ -322,6 +322,16 @@ export function applyToggleState(btnId: string, active: boolean): void {
   toggle?.setAttribute('aria-checked', String(active));
 }
 
+// 模糊音规则复选随总开关联动：禁用 + 置灰 + 提示。input.ts（点击总开关）与
+// config-sync.ts（快照回填）共用这一份 DOM 名单，不要在两侧各写一遍。
+export function setFuzzyRuleOptionsDisabled(disabled: boolean): void {
+  document.querySelectorAll<HTMLInputElement>('input[name="fuzzy-rule"]').forEach((checkbox) => {
+    checkbox.disabled = disabled;
+  });
+  document.getElementById('fuzzyDetails')?.classList.toggle('is-disabled', disabled);
+  document.getElementById('fuzzyDisabledHint')?.classList.toggle('is-hidden', !disabled);
+}
+
 export function applyCandidateArrange(value: string | undefined): void {
   if (value !== 'horizontal' && value !== 'vertical') {
     return;

--- a/ui-html/webview2/settings/ime-settings/src/partials/input.html
+++ b/ui-html/webview2/settings/ime-settings/src/partials/input.html
@@ -148,41 +148,48 @@
   </div>
 
   <div class="section">
-    <div class="section-header">
-      <div>
-        <div class="section-title">模糊音</div>
-        <div class="input-setting-description">开启后两个读音互相匹配，如输入 zhang 也可命中 zang 开头的词；全拼与双拼均生效，默认关闭</div>
+    <div class="section-header fuzzy-toggle-header">
+      <button class="fuzzy-expand" id="fuzzyExpand" type="button" aria-expanded="false" aria-controls="fuzzyDetails">
+        <span class="section-title">模糊音</span><span class="fuzzy-chevron" aria-hidden="true"></span>
+      </button>
+      <div class="ftb-toggle-btn" id="fuzzyPinyinToggleBtn" role="switch" aria-checked="false" tabindex="0">
+        <div class="ftb-toggle-knob"></div>
       </div>
     </div>
-    <div class="section-header">
-      <div class="section-title">声母</div>
-    </div>
-    <div class="content-page-option">
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyZZhCheckbox" value="fuzzy_z_zh"><span>z ⇄ zh</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyCChCheckbox" value="fuzzy_c_ch"><span>c ⇄ ch</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzySShCheckbox" value="fuzzy_s_sh"><span>s ⇄ sh</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyNlCheckbox" value="fuzzy_n_l"><span>n ⇄ l</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyFhCheckbox" value="fuzzy_f_h"><span>f ⇄ h</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyRlCheckbox" value="fuzzy_r_l"><span>r ⇄ l</span></label>
-    </div>
-    <div class="section-header">
-      <div class="section-title">韵母</div>
-    </div>
-    <div class="content-page-option">
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyAnAngCheckbox" value="fuzzy_an_ang"><span>an ⇄ ang</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyEnEngCheckbox" value="fuzzy_en_eng"><span>en ⇄ eng</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyInIngCheckbox" value="fuzzy_in_ing"><span>in ⇄ ing</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyIanIangCheckbox" value="fuzzy_ian_iang"><span>ian ⇄ iang</span></label>
-      <div class="input-option-divider"></div>
-      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyUanUangCheckbox" value="fuzzy_uan_uang"><span>uan ⇄ uang</span></label>
+    <!-- 折叠容器默认收起（仿 appearance 主题模式分区）；总开关关时规则复选置灰禁用 -->
+    <div class="fuzzy-details" id="fuzzyDetails">
+      <div class="input-setting-description">开启后两个读音互相匹配，如输入 zhang 也可命中 zang 开头的词；全拼与双拼均生效</div>
+      <div class="section-header">
+        <div class="section-title">声母</div>
+      </div>
+      <div class="content-page-option">
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyZZhCheckbox" value="fuzzy_z_zh"><span>z ⇄ zh</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyCChCheckbox" value="fuzzy_c_ch"><span>c ⇄ ch</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzySShCheckbox" value="fuzzy_s_sh"><span>s ⇄ sh</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyNlCheckbox" value="fuzzy_n_l"><span>n ⇄ l</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyFhCheckbox" value="fuzzy_f_h"><span>f ⇄ h</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyRlCheckbox" value="fuzzy_r_l"><span>r ⇄ l</span></label>
+      </div>
+      <div class="section-header">
+        <div class="section-title">韵母</div>
+      </div>
+      <div class="content-page-option">
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyAnAngCheckbox" value="fuzzy_an_ang"><span>an ⇄ ang</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyEnEngCheckbox" value="fuzzy_en_eng"><span>en ⇄ eng</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyInIngCheckbox" value="fuzzy_in_ing"><span>in ⇄ ing</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyIanIangCheckbox" value="fuzzy_ian_iang"><span>ian ⇄ iang</span></label>
+        <div class="input-option-divider"></div>
+        <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyUanUangCheckbox" value="fuzzy_uan_uang"><span>uan ⇄ uang</span></label>
+      </div>
+      <div class="fuzzy-disabled-hint is-hidden" id="fuzzyDisabledHint">开启总开关后生效</div>
     </div>
   </div>
 

--- a/ui-html/webview2/settings/ime-settings/src/partials/input.html
+++ b/ui-html/webview2/settings/ime-settings/src/partials/input.html
@@ -150,6 +150,45 @@
   <div class="section">
     <div class="section-header">
       <div>
+        <div class="section-title">模糊音</div>
+        <div class="input-setting-description">开启后两个读音互相匹配，如输入 zhang 也可命中 zang 开头的词；全拼与双拼均生效，默认关闭</div>
+      </div>
+    </div>
+    <div class="section-header">
+      <div class="section-title">声母</div>
+    </div>
+    <div class="content-page-option">
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyZZhCheckbox" value="fuzzy_z_zh"><span>z ⇄ zh</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyCChCheckbox" value="fuzzy_c_ch"><span>c ⇄ ch</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzySShCheckbox" value="fuzzy_s_sh"><span>s ⇄ sh</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyNlCheckbox" value="fuzzy_n_l"><span>n ⇄ l</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyFhCheckbox" value="fuzzy_f_h"><span>f ⇄ h</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyRlCheckbox" value="fuzzy_r_l"><span>r ⇄ l</span></label>
+    </div>
+    <div class="section-header">
+      <div class="section-title">韵母</div>
+    </div>
+    <div class="content-page-option">
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyAnAngCheckbox" value="fuzzy_an_ang"><span>an ⇄ ang</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyEnEngCheckbox" value="fuzzy_en_eng"><span>en ⇄ eng</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyInIngCheckbox" value="fuzzy_in_ing"><span>in ⇄ ing</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyIanIangCheckbox" value="fuzzy_ian_iang"><span>ian ⇄ iang</span></label>
+      <div class="input-option-divider"></div>
+      <label class="check-option"><input type="checkbox" name="fuzzy-rule" id="fuzzyUanUangCheckbox" value="fuzzy_uan_uang"><span>uan ⇄ uang</span></label>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-header">
+      <div>
         <div class="section-title">候选词翻译</div>
         <div class="input-setting-description">仅在竖排候选窗口中显示中文与所选语种的互译，每项最多两个简短释义</div>
       </div>

--- a/ui-html/webview2/settings/ime-settings/src/styles/modules/input.css
+++ b/ui-html/webview2/settings/ime-settings/src/styles/modules/input.css
@@ -289,3 +289,74 @@
   background: #d1d1d128;
   border-color: #555;
 }
+
+/* 输入 -> 模糊音（可折叠分区：结构与 appearance 主题模式一致，类名用 fuzzy 专名，
+   不跨模块借用 theme-surface-* 类） */
+.fuzzy-toggle-header {
+  margin-bottom: 0;
+}
+
+.fuzzy-expand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.fuzzy-chevron {
+  width: 7px;
+  height: 7px;
+  margin-top: -3px;
+  border-right: 2px solid var(--text-muted);
+  border-bottom: 2px solid var(--text-muted);
+  transform: rotate(45deg);
+  transition: transform 0.16s ease, margin 0.16s ease;
+}
+
+.fuzzy-expand[aria-expanded="true"] .fuzzy-chevron {
+  margin-top: 3px;
+  transform: rotate(225deg);
+}
+
+.fuzzy-details {
+  display: none;
+  margin: 4px 0 0 18px;
+}
+
+.fuzzy-details.open {
+  display: block;
+}
+
+.fuzzy-details .section-header {
+  padding: 2px 0;
+}
+
+.fuzzy-details .section-title {
+  font-size: 15px;
+  font-weight: 400;
+}
+
+.fuzzy-details .input-setting-description {
+  margin-top: 0;
+}
+
+/* 总开关关闭：规则复选随 checkbox disabled 置灰，提示何时生效 */
+.fuzzy-details.is-disabled .content-page-option {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.fuzzy-disabled-hint {
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.fuzzy-disabled-hint.is-hidden {
+  display: none;
+}


### PR DESCRIPTION
Closes #78（#340 为其重复项，已关）

## 背景

引擎的模糊音层（`engine/quanpin/fuzzy_pinyin.h` + `engine/core/fuzzy_pinyin_options.h`）实现完整：11 条规则（声母 z/zh、c/ch、s/sh、n/l、f/h、r/l，韵母 an/ang、en/eng、in/ing、ian/iang、uan/uang），全拼与双拼两条查询路径都已消费 `request.fuzzy_pinyin`。但 server 从未把配置注入会话，`rules` 恒 0，整个功能处于死态——#78 里 09-05 的核查（grep 零命中）即此状态。

本 PR 把模糊音接通 `config.toml` → `ime_config` 缓存 → `EngineInputSession::ApplyConfiguration()` 注入 → 设置页的完整链路，并落地四个产品决策（#78 当初遗留的方案问题逐条有了答案）：

| #78 的方案问题 | 本 PR 的落点 |
|---|---|
| 规则表放哪层 | 引擎已有，server 只做配置注入，每键热生效 |
| 哪些组合默认开启 | 全默认关（升级零回归）；首次打开总开关自动全选并持久化 |
| 是否按方案分别配置 | 不分：`[input]` 段，全拼与双拼同样生效（双拼在转换出的全拼音节上模糊） |
| 对候选排序的影响 | 不做权重干预，读音扩展后仍交词典词频竞争，与精确输入零回归 |

## 改动

**1. 11 规则配置接线** — feb7db6d / 575b2362 / 58df42f5

- `ime_config` 新增 `g_fuzzy_pinyin_rules` 位掩码缓存，键名↔`FuzzyPinyinRule` 枚举用固定表驱动（键名 = 枚举名小写加 `fuzzy_` 前缀），reload 块 `value_or(false)`；单键 setter 先落盘成功再翻内存位，写失败不污染位图
- `EngineInputSession::ApplyConfiguration()` 注入聚合 getter 结果——唯一注入点，不按方案门控
- settings_app configSnapshot 补 11 字段；`ApplyConfigUpdate` 用 `input.fuzzy_` 前缀分发一次吃掉 11 个键
- 设置页「输入」分区新增模糊音规则复选；两份 toml 模板补 11 键

**2. 总开关 + 折叠分区** — b807f50d / 9dbb020a / e60c3224

- 新增总开关 `fuzzy_pinyin`（默认关），门控在聚合 getter 内（关 → 全零 options，规则位缓存保留）——会话注入代码不感知总开关；临时停用/恢复只翻一个开关
- settings_app 分发加精确分支 `input.fuzzy_pinyin`，**排在 `input.fuzzy_` 前缀分支之前**（前缀否则吞掉总键）
- 设置页分区改为「主题模式」同款折叠风格（`aria-expanded` + `.open` 容器），分区头 = 折叠标题 + 总开关 toggle；总开关关时规则复选置灰并提示；CSS 在 input.css 用 fuzzy 专名类，不跨模块借用 appearance 类名

**3. 首次启用播种** — a3b1e438 / cadbe85b

- 用户**第一次**打开总开关时，用一次 `WriteConfiguredValues` 批量写 13 键（总开关 true + 11 规则全 true + 标记 `fuzzy_seeded` true），单文件原子操作无部分失败态；此后总开关任何翻动零规则键改动，修剪过的选择在停用/恢复间原样保留
- 「首次」用持久化标记判定而非「位图全零」——用户故意清空选择后位图也是零，无标记会误重播种
- 播种逻辑只存在 server 侧；前端勾选态由 configSnapshot 驱动，无第二套真值

**4. 测试兜底** — 1ea42a31

- `fuzzy_seeded` 缺键默认值补行为断言（缺键形态开总开关必须播种到 `0x7ff` 且标记落盘），并做变异验证：把 `value_or(false)` 临时改成 `value_or(true)` 重建，恰好只有该断言红——只断言「文件里没有这个键」挡不住默认值被改

## 行为速查

| 场景 | 行为 |
|---|---|
| 全新安装 / 升级 | 总开关 false → 零模糊，与历史版本逐位一致 |
| 第一次打开总开关 | 11 条规则全部勾选（持久化），输入 zhang 出现 zang 读音候选 |
| 临时关闭总开关 | 候选恢复精确匹配，勾选保留；重开立即恢复 |
| 修剪为子集后反复开关 | 规则键逐键不变，重启保持 |

## 验证

- `server/build-release` 构建零新告警；ctest **2/2 全绿**（`MetasequoiaImeServerTests` 303 项，含 5 个模糊音用例：默认值三形态、逐键往返 + 全开 `0x7ff`、总开关门控、首次播种全生命周期、全拼+双拼注入 A-B-A）
- `scripts/format.sh --check` 通过（CI 同款钉版 clang-format）
- ime-settings `pnpm build` 通过（prebuild 契约 `--check` 自然过，`engine/contracts/` 零改动）+ vitest 23/23
- 两份模板 13 个 fuzzy 键逐键 diff 一致；跨层键名（ime_config 表、configSnapshot、input.html/ts/config-sync.ts、两模板）程序化比对零漂移
- `windows_webview2.cpp` 的设置窗宿主未接线：`InitWebviewSettingsWnd` 全仓零调用者，死代码（先例 f8f13e70 同此处理）
